### PR TITLE
feat: add reset method to reset userId and deviceId

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -81,4 +81,7 @@ tasks.dokkaHtmlPartial.configure {
 
 tasks.withType(Test) {
     useJUnitPlatform()
+    testLogging {
+        showStandardStreams = true
+    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
     testImplementation 'io.mockk:mockk:1.10.6'
+    testImplementation project(':core')
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
@@ -76,4 +77,8 @@ dependencies {
 
 tasks.dokkaHtmlPartial.configure {
     failOnWarning.set(true)
+}
+
+tasks.withType(Test) {
+    useJUnitPlatform()
 }

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -30,7 +30,7 @@ class AndroidContextPlugin : Plugin {
         return event
     }
 
-    private fun initializeDeviceId(configuration: Configuration) {
+    fun initializeDeviceId(configuration: Configuration) {
         val deviceId = amplitude.store.deviceId
         if (deviceId != null && validDeviceId(deviceId) && !deviceId.endsWith("S")) {
             return

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -40,10 +40,15 @@ class AmplitudeTest {
     fun amplitude_reset_wipesUserIdDeviceId() {
         amplitude?.setUserId("test user")
         amplitude?.setDeviceId("test device")
-        Assertions.assertEquals("test user", amplitude?.store?.userId)
-        Assertions.assertEquals("test device", amplitude?.store?.deviceId)
+        println("=======================")
+        println(amplitude?.store?.userId)
+        println(amplitude?.store?.deviceId)
+//        Assertions.assertEquals("test user", amplitude?.store?.userId)
+//        Assertions.assertEquals("test device", amplitude?.store?.deviceId)
 
         amplitude?.reset()
+        println(amplitude?.store?.userId)
+        println(amplitude?.store?.deviceId)
         Assertions.assertNull(amplitude?.store?.userId)
         Assertions.assertNotEquals("test device", amplitude?.store?.deviceId)
     }

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -40,15 +40,12 @@ class AmplitudeTest {
     fun amplitude_reset_wipesUserIdDeviceId() {
         amplitude?.setUserId("test user")
         amplitude?.setDeviceId("test device")
-        println("=======================")
-        println(amplitude?.store?.userId)
-        println(amplitude?.store?.deviceId)
-//        Assertions.assertEquals("test user", amplitude?.store?.userId)
-//        Assertions.assertEquals("test device", amplitude?.store?.deviceId)
+        Thread.sleep(1_000)
+        Assertions.assertEquals("test user", amplitude?.store?.userId)
+        Assertions.assertEquals("test device", amplitude?.store?.deviceId)
 
         amplitude?.reset()
-        println(amplitude?.store?.userId)
-        println(amplitude?.store?.deviceId)
+        Thread.sleep(1_000)
         Assertions.assertNull(amplitude?.store?.userId)
         Assertions.assertNotEquals("test device", amplitude?.store?.deviceId)
     }

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -1,0 +1,50 @@
+package com.amplitude.android
+
+import android.app.Application
+import android.content.Context
+import com.amplitude.android.plugins.AndroidLifecyclePlugin
+import com.amplitude.core.utilities.InMemoryStorageProvider
+import com.amplitude.id.IMIdentityStorageProvider
+import com.amplitude.id.IdentityConfiguration
+import com.amplitude.id.IdentityContainer
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class AmplitudeTest {
+    private var context: Context? = null
+    private var amplitude: Amplitude? = null
+
+    @BeforeEach
+    fun setUp() {
+        context = mockk<Application>(relaxed = true)
+        mockkStatic(AndroidLifecyclePlugin::class)
+        val configuration = IdentityConfiguration(
+            "testInstance",
+            identityStorageProvider = IMIdentityStorageProvider()
+        )
+        IdentityContainer.getInstance(configuration)
+        amplitude = Amplitude(
+            Configuration(
+                apiKey = "api-key",
+                context = context!!,
+                instanceName = "testInstance",
+                storageProvider = InMemoryStorageProvider()
+            )
+        )
+    }
+
+    @Test
+    fun amplitude_reset_wipesUserIdDeviceId() {
+        amplitude?.setUserId("test user")
+        amplitude?.setDeviceId("test device")
+        Assertions.assertEquals("test user", amplitude?.store?.userId)
+        Assertions.assertEquals("test device", amplitude?.store?.deviceId)
+
+        amplitude?.reset()
+        Assertions.assertNull(amplitude?.store?.userId)
+        Assertions.assertNotEquals("test device", amplitude?.store?.deviceId)
+    }
+}

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -9,6 +9,9 @@ import com.amplitude.id.IdentityConfiguration
 import com.amplitude.id.IdentityContainer
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -37,18 +40,23 @@ class AmplitudeTest {
 
     @Test
     fun amplitude_reset_wipesUserIdDeviceId() {
-        amplitude?.setUserId("test user")
-        amplitude?.setDeviceId("test device")
-        println("=======================")
-        println(amplitude?.store?.userId)
-        println(amplitude?.store?.deviceId)
-//        Assertions.assertEquals("test user", amplitude?.store?.userId)
-//        Assertions.assertEquals("test device", amplitude?.store?.deviceId)
+        runBlocking {
+            val job = launch {
+                amplitude?.setUserId("test user")
+                amplitude?.setDeviceId("test device")
+            }
+            job.join()
+        }
+        Assertions.assertEquals("test user", amplitude?.store?.userId)
+        Assertions.assertEquals("test device", amplitude?.store?.deviceId)
 
-        amplitude?.reset()
-        println(amplitude?.store?.userId)
-        println(amplitude?.store?.deviceId)
-//        Assertions.assertNull(amplitude?.store?.userId)
-//        Assertions.assertNotEquals("test device", amplitude?.store?.deviceId)
+        runBlocking {
+            val job = launch {
+                amplitude?.reset()
+            }
+            job.join()
+        }
+        Assertions.assertNull(amplitude?.store?.userId)
+        Assertions.assertNotEquals("test device", amplitude?.store?.deviceId)
     }
 }

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -9,7 +9,6 @@ import com.amplitude.id.IdentityConfiguration
 import com.amplitude.id.IdentityContainer
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -40,13 +39,16 @@ class AmplitudeTest {
     fun amplitude_reset_wipesUserIdDeviceId() {
         amplitude?.setUserId("test user")
         amplitude?.setDeviceId("test device")
-        Thread.sleep(1_000)
-        Assertions.assertEquals("test user", amplitude?.store?.userId)
-        Assertions.assertEquals("test device", amplitude?.store?.deviceId)
+        println("=======================")
+        println(amplitude?.store?.userId)
+        println(amplitude?.store?.deviceId)
+//        Assertions.assertEquals("test user", amplitude?.store?.userId)
+//        Assertions.assertEquals("test device", amplitude?.store?.deviceId)
 
         amplitude?.reset()
-        Thread.sleep(1_000)
-        Assertions.assertNull(amplitude?.store?.userId)
-        Assertions.assertNotEquals("test device", amplitude?.store?.deviceId)
+        println(amplitude?.store?.userId)
+        println(amplitude?.store?.deviceId)
+//        Assertions.assertNull(amplitude?.store?.userId)
+//        Assertions.assertNotEquals("test device", amplitude?.store?.deviceId)
     }
 }

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
+import java.util.UUID
 import java.util.concurrent.Executors
 
 /**
@@ -180,6 +181,18 @@ open class Amplitude internal constructor(
         amplitudeScope.launch(amplitudeDispatcher) {
             idContainer.identityManager.editIdentity().setDeviceId(deviceId).commit()
         }
+        return this
+    }
+
+    /**
+     * Reset identity:
+     *  - reset userId to "null"
+     *  - reset deviceId to random UUID
+     * @return the Amplitude instance
+     */
+    open fun reset(): Amplitude {
+        this.setUserId(null)
+        this.setDeviceId(UUID.randomUUID().toString() + "R")
         return this
     }
 

--- a/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
@@ -20,6 +20,7 @@ import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
@@ -327,6 +328,29 @@ internal class AmplitudeTest {
             }
             amplitude.flush()
             assertTrue(callbackCalled)
+        }
+    }
+
+    @Nested
+    inner class TestReset {
+        @Test
+        fun `test reset`() {
+            val mockPlugin = spyk(StubPlugin())
+            amplitude.add(mockPlugin)
+
+            amplitude.setUserId("user_id")
+            amplitude.setDeviceId("device_id")
+            amplitude.reset()
+            amplitude.track("test event")
+
+            val track = slot<BaseEvent>()
+            verify { mockPlugin.track(capture(track)) }
+
+            track.captured.let {
+                assertEquals(null, it.userId)
+                assertNotEquals("device_id", it.deviceId)
+                assertEquals("test event", it.eventType)
+            }
         }
     }
 }


### PR DESCRIPTION
### Summary
This PR adds the `#reset` method, which does the following things:
- `setUserId` to null
- `setDeviceId` to new generated one

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
No