### PR TITLE
test: fix unstable coroutine test

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
     testImplementation 'io.mockk:mockk:1.10.6'
     testImplementation project(':core')
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.2'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'


### PR DESCRIPTION
### Summary
This PR fixes the unstable coroutine test, which was commented out to unblock last release.

Refer to: https://developer.android.com/kotlin/coroutines/test#injecting-test-dispatchers

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No