### PR TITLE
fix: Unterminated arrays caused by multi client instances with same name and api key

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -142,7 +142,7 @@ open class Amplitude(
         // start new session
         setSessionId(timestamp)
         refreshSessionTime(timestamp)
-        if ((configuration as Configuration).trackingSessionEvents) {
+        if (configuration.trackingSessionEvents) {
             sendSessionEvent(START_SESSION_EVENT)
         }
     }

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -68,6 +68,7 @@ open class Amplitude(
     override fun reset(): Amplitude {
         this.setUserId(null)
         amplitudeScope.launch(amplitudeDispatcher) {
+            isBuilt.await()
             idContainer.identityManager.editIdentity().setDeviceId(null).commit()
             androidContextPlugin.initializeDeviceId(configuration as Configuration)
         }
@@ -76,13 +77,15 @@ open class Amplitude(
 
     fun onEnterForeground(timestamp: Long) {
         amplitudeScope.launch(amplitudeDispatcher) {
+            isBuilt.await()
             startNewSessionIfNeeded(timestamp)
             inForeground = true
         }
     }
 
-    fun onExitForeground(timestamp: Long) {
+    fun onExitForeground() {
         amplitudeScope.launch(amplitudeDispatcher) {
+            isBuilt.await()
             inForeground = false
             if ((configuration as Configuration).flushEventsOnClose) {
                 flush()
@@ -125,6 +128,7 @@ open class Amplitude(
         sessionId = timestamp
         previousSessionId = timestamp
         amplitudeScope.launch(amplitudeDispatcher) {
+            isBuilt.await()
             storage.write(Storage.Constants.PREVIOUS_SESSION_ID, timestamp.toString())
         }
     }
@@ -156,6 +160,7 @@ open class Amplitude(
         }
         lastEventTime = timestamp
         amplitudeScope.launch(amplitudeDispatcher) {
+            isBuilt.await()
             storage.write(Storage.Constants.LAST_EVENT_TIME, timestamp.toString())
         }
     }

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -27,7 +27,7 @@ class AndroidLifecyclePlugin : Application.ActivityLifecycleCallbacks, Plugin {
     }
 
     override fun onActivityPaused(activity: Activity) {
-        (amplitude as com.amplitude.android.Amplitude).onExitForeground(getCurrentTimeMillis())
+        (amplitude as com.amplitude.android.Amplitude).onExitForeground()
     }
 
     override fun onActivityStopped(activity: Activity) {

--- a/android/src/main/java/com/amplitude/android/utilities/AndroidStorage.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidStorage.kt
@@ -17,7 +17,6 @@ import com.amplitude.core.utilities.ResponseHandler
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import org.json.JSONArray
-import java.io.BufferedReader
 import java.io.File
 
 class AndroidStorage(
@@ -61,11 +60,8 @@ class AndroidStorage(
         return eventsFile.read()
     }
 
-    override fun getEventsString(content: Any): String {
-        val bufferedReader: BufferedReader = File(content as String).bufferedReader()
-        bufferedReader.use {
-            return it.readText()
-        }
+    override suspend fun getEventsString(content: Any): String {
+        return eventsFile.getEventString(content as String)
     }
 
     override fun getResponseHandler(
@@ -93,7 +89,7 @@ class AndroidStorage(
 
     override fun getEventCallback(insertId: String): EventCallBack? {
         if (eventCallbacksMap.contains(insertId)) {
-            return eventCallbacksMap.get(insertId)
+            return eventCallbacksMap[insertId]
         }
         return null
     }

--- a/android/src/main/java/com/amplitude/android/utilities/AndroidStorage.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidStorage.kt
@@ -88,10 +88,7 @@ class AndroidStorage(
     }
 
     override fun getEventCallback(insertId: String): EventCallBack? {
-        if (eventCallbacksMap.contains(insertId)) {
-            return eventCallbacksMap[insertId]
-        }
-        return null
+        return eventCallbacksMap[insertId]
     }
 
     override fun removeEventCallback(insertId: String) {

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -185,6 +185,7 @@ open class Amplitude internal constructor(
      */
     fun setDeviceId(deviceId: String): Amplitude {
         amplitudeScope.launch(amplitudeDispatcher) {
+            isBuilt.await()
             idContainer.identityManager.editIdentity().setDeviceId(deviceId).commit()
         }
         return this
@@ -317,6 +318,7 @@ open class Amplitude internal constructor(
             logger.info("Skip event for opt out config.")
         }
         amplitudeScope.launch(amplitudeDispatcher) {
+            isBuilt.await()
             timeline.process(event)
         }
     }

--- a/core/src/main/java/com/amplitude/core/Storage.kt
+++ b/core/src/main/java/com/amplitude/core/Storage.kt
@@ -26,7 +26,7 @@ interface Storage {
 
     fun readEventsContent(): List<Any>
 
-    fun getEventsString(content: Any): String
+    suspend fun getEventsString(content: Any): String
 
     fun getResponseHandler(eventPipeline: EventPipeline, configuration: Configuration, scope: CoroutineScope, dispatcher: CoroutineDispatcher, events: Any, eventsString: String): ResponseHandler
 }

--- a/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
@@ -59,7 +59,7 @@ class FileStorage(
         return eventsFile.read()
     }
 
-    override fun getEventsString(content: Any): String {
+    override suspend fun getEventsString(content: Any): String {
         // content is filePath String
         val bufferedReader: BufferedReader = File(content as String).bufferedReader()
         bufferedReader.use {

--- a/core/src/main/java/com/amplitude/core/utilities/InMemoryStorage.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/InMemoryStorage.kt
@@ -48,7 +48,7 @@ class InMemoryStorage(
         return listOf(eventsToSend)
     }
 
-    override fun getEventsString(content: Any): String {
+    override suspend fun getEventsString(content: Any): String {
         // content is list of BaseEvent
         return JSONUtil.eventsToString(content as List<BaseEvent>)
     }


### PR DESCRIPTION
### Summary

* Put mutex to class companion to lock for possible multi instance access
* Reduce duplicate events requests from same event file
* Put curFile reference to companion and managed by apiKey
* Handle invalid events json string: delete file and clean up callback map

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no