### PR TITLE
fix: enable the remote ip

### DIFF
--- a/core/src/main/java/com/amplitude/core/platform/plugins/ContextPlugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/plugins/ContextPlugin.kt
@@ -35,6 +35,10 @@ class ContextPlugin : Plugin {
                 event.partnerId = it
             }
         }
+        event.ip ?: let {
+            // get the ip in server side if there is no event level ip
+            event.ip = "\$remote"
+        }
         event.plan ?: let {
             amplitude.configuration.plan ?. let {
                 event.plan = it.clone()


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
In android SDK the IP address can be get on the server side. 
The old android SDK is using the HTTP API v1. We don't need to set anything in order to use the remote IP. https://github.com/amplitude/amplitude/blob/master/event/converters/sdk.py#L164
But the Kotlin SDK is using the HTTP API V2, which required to pass `ip="$remote"` https://github.com/amplitude/amplitude/blob/master/event/converters/http_event.py#L528.

In order to fix the IP is null in kotlin SDK we need to pass the `ip="$remote"`.


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->