### PR TITLE
feat: add ampli extra plugin for attaching ingestion metadata information

### DIFF
--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -14,6 +14,7 @@ import com.amplitude.core.platform.Plugin
 import com.amplitude.core.platform.Timeline
 import com.amplitude.core.platform.plugins.AmplitudeDestination
 import com.amplitude.core.platform.plugins.ContextPlugin
+import com.amplitude.core.platform.plugins.GetAmpliExtrasPlugin
 import com.amplitude.core.utilities.AnalyticsEventReceiver
 import com.amplitude.core.utilities.AnalyticsIdentityListener
 import com.amplitude.eventbridge.EventBridgeContainer
@@ -74,6 +75,7 @@ open class Amplitude internal constructor(
         }
         EventBridgeContainer.getInstance(configuration.instanceName).eventBridge.setEventReceiver(EventChannel.EVENT, AnalyticsEventReceiver(this))
         add(ContextPlugin())
+        add(GetAmpliExtrasPlugin())
         add(AmplitudeDestination())
 
         isBuilt = amplitudeScope.async(amplitudeDispatcher) {

--- a/core/src/main/java/com/amplitude/core/platform/plugins/GetAmpliExtrasPlugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/plugins/GetAmpliExtrasPlugin.kt
@@ -1,0 +1,32 @@
+package com.amplitude.core.platform.plugins
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.events.IngestionMetadata
+import com.amplitude.core.platform.Plugin
+
+class GetAmpliExtrasPlugin : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Enrichment
+    override lateinit var amplitude: Amplitude
+    companion object {
+        const val AMP_AMPLI = "ampli"
+    }
+
+    override fun setup(amplitude: Amplitude) {
+        super.setup(amplitude)
+    }
+
+    override fun execute(event: BaseEvent): BaseEvent {
+        val ampliExtra = event.extra?.get(AMP_AMPLI) ?: return event
+        try {
+            val ingestionMetadataMap = (ampliExtra as Map<String, Any>).get("ingestionMetadata") as Map<String, String>
+            val ingestionMetadata = IngestionMetadata(
+                ingestionMetadataMap?.get("sourceName"),
+                ingestionMetadataMap?.get("sourceVersion")
+            )
+            event.ingestionMetadata = ingestionMetadata
+        } finally {
+            return event
+        }
+    }
+}

--- a/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
@@ -279,7 +279,7 @@ internal class AmplitudeTest {
             amplitude.add(middleware)
             amplitude.timeline.plugins[Plugin.Type.Enrichment]?.plugins?.let {
                 assertEquals(
-                    1,
+                    2,
                     it.size
                 )
             } ?: fail()
@@ -295,7 +295,7 @@ internal class AmplitudeTest {
             amplitude.remove(middleware)
             amplitude.timeline.plugins[Plugin.Type.Enrichment]?.plugins?.let {
                 assertEquals(
-                    0, // SegmentLog is the other added at startup
+                    1, // SegmentLog is the other added at startup
                     it.size
                 )
             } ?: fail()

--- a/core/src/test/kotlin/com/amplitude/core/platform/plugins/GetAmpliExtrasPluginTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/plugins/GetAmpliExtrasPluginTest.kt
@@ -1,0 +1,96 @@
+package com.amplitude.core.platform.plugins
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.Configuration
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.utils.testAmplitude
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GetAmpliExtrasPluginTest {
+    private lateinit var amplitude: Amplitude
+
+    @ExperimentalCoroutinesApi
+    @BeforeEach
+    fun setup() {
+        val testApiKey = "test-123"
+        amplitude = testAmplitude(Configuration(testApiKey))
+    }
+
+    @Test
+    fun `test missing ampli extra in event`() {
+        val getAmpliExtrasPlugin = GetAmpliExtrasPlugin()
+        getAmpliExtrasPlugin.setup(amplitude)
+        val event = BaseEvent()
+        getAmpliExtrasPlugin.execute(event)
+        Assertions.assertEquals(event.ingestionMetadata, null)
+    }
+
+    @Test
+    fun `test ingestion metadata in event`() {
+        val getAmpliExtrasPlugin = GetAmpliExtrasPlugin()
+        getAmpliExtrasPlugin.setup(amplitude)
+        val event = BaseEvent()
+        val sourceName = "test-source-name"
+        val sourceVersion = "test-source-version"
+        event.extra = mapOf(
+            "ampli" to mapOf(
+                "ingestionMetadata" to mapOf(
+                    "sourceName" to sourceName,
+                    "sourceVersion" to sourceVersion
+                )
+            )
+        )
+        getAmpliExtrasPlugin.execute(event)
+        Assertions.assertEquals(event.ingestionMetadata?.sourceName, sourceName)
+        Assertions.assertEquals(event.ingestionMetadata?.sourceVersion, sourceVersion)
+    }
+
+    @Test
+    fun `test ingeston metadata in event with null value`() {
+        val getAmpliExtrasPlugin = GetAmpliExtrasPlugin()
+        getAmpliExtrasPlugin.setup(amplitude)
+        val event = BaseEvent()
+        val sourceName = "test-source-name"
+        val sourceVersion = null
+        event.extra = mapOf(
+            "ampli" to mapOf(
+                "ingestionMetadata" to mapOf(
+                    "sourceName" to sourceName,
+                    "sourceVersion" to sourceVersion
+                )
+            )
+        )
+        getAmpliExtrasPlugin.execute(event)
+        Assertions.assertEquals(event.ingestionMetadata?.sourceName, sourceName)
+        Assertions.assertEquals(event.ingestionMetadata?.sourceVersion, sourceVersion)
+    }
+
+    @Test
+    fun `test empty ampli extra in event`() {
+        val getAmpliExtrasPlugin = GetAmpliExtrasPlugin()
+        getAmpliExtrasPlugin.setup(amplitude)
+        val event = BaseEvent()
+        event.extra = mapOf(
+            "ampli" to mapOf(
+                "ingestionMetadata" to null
+            )
+        )
+        getAmpliExtrasPlugin.execute(event)
+        Assertions.assertEquals(event.ingestionMetadata, null)
+    }
+
+    @Test
+    fun `test wrong ampli extra in event`() {
+        val getAmpliExtrasPlugin = GetAmpliExtrasPlugin()
+        getAmpliExtrasPlugin.setup(amplitude)
+        val event = BaseEvent()
+        event.extra = mapOf("ampli" to "string")
+        getAmpliExtrasPlugin.execute(event)
+        Assertions.assertEquals(event.ingestionMetadata, null)
+    }
+}


### PR DESCRIPTION
### Summary
This PR adds a `GetAmpliExtrasPlugin` as enrichment plugin for retrieving the ampli information from extra field, currently will be used for the ingestion metadata injection.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No