### PR TITLE
fix: fix the ip address not catch issue

### DIFF
--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -145,6 +145,10 @@ class AndroidContextPlugin : Plugin {
                 event.partnerId = it
             }
         }
+        event.ip ?: let {
+            // get the ip in server side if there is no event level ip
+            event.ip = "\$remote"
+        }
         event.plan ?: let {
             amplitude.configuration.plan ?. let {
                 event.plan = it.clone()

--- a/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
@@ -65,6 +65,7 @@ internal class AmplitudeTest {
                 assertEquals(mapOf(Pair("foo", "bar")), it.eventProperties)
                 assertEquals("CA", it.region)
                 assertEquals("test", it.plan?.source)
+                assertEquals("\$remote", it.ip)
                 assertEquals("ampli", it.ingestionMetadata?.sourceName)
             }
         }
@@ -80,6 +81,7 @@ internal class AmplitudeTest {
             val event = BaseEvent()
             event.eventType = "test event"
             event.region = "CA"
+            event.ip = "127.0.0.1"
             amplitude.track(event, eventOptions)
             val track = slot<BaseEvent>()
             verify { mockPlugin.track(capture(track)) }
@@ -91,6 +93,7 @@ internal class AmplitudeTest {
                 assertEquals("SF", it.city)
                 assertEquals("test", it.plan?.source)
                 assertEquals("ampli", it.ingestionMetadata?.sourceName)
+                assertEquals("127.0.0.1", it.ip)
             }
         }
     }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
Added the IP = "\$remote" in AndroidContextPlugin. 
Added IP test.
### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->