### PR TITLE
fix: move session-specific logic from ContextPlugin to avoid race conditions

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -84,9 +84,6 @@ open class Amplitude(
     override fun processEvent(event: BaseEvent) {
         val eventTimestamp = event.timestamp ?: System.currentTimeMillis()
         event.timestamp = eventTimestamp
-        if (lastEventTime < eventTimestamp) {
-            lastEventTime = eventTimestamp
-        }
 
         if (!(event.eventType == START_SESSION_EVENT || event.eventType == END_SESSION_EVENT)) {
             if (!inForeground) {
@@ -100,11 +97,13 @@ open class Amplitude(
             event.sessionId = sessionId
         }
 
-        val newEventId = lastEventId + 1
-        event.eventId = newEventId
-        lastEventId = newEventId
-        amplitudeScope.launch(amplitudeDispatcher) {
-            storage.write(Storage.Constants.LAST_EVENT_ID, newEventId.toString())
+        event.eventId ?: let {
+            val newEventId = lastEventId + 1
+            event.eventId = newEventId
+            lastEventId = newEventId
+            amplitudeScope.launch(amplitudeDispatcher) {
+                storage.write(Storage.Constants.LAST_EVENT_ID, newEventId.toString())
+            }
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -1,16 +1,12 @@
 package com.amplitude.android.plugins
 
-import com.amplitude.android.Amplitude.Companion.END_SESSION_EVENT
-import com.amplitude.android.Amplitude.Companion.START_SESSION_EVENT
 import com.amplitude.android.BuildConfig
 import com.amplitude.android.Configuration
 import com.amplitude.android.TrackingOptions
 import com.amplitude.common.android.AndroidContextProvider
 import com.amplitude.core.Amplitude
-import com.amplitude.core.Storage
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
-import kotlinx.coroutines.launch
 import java.util.UUID
 
 class AndroidContextPlugin : Plugin {
@@ -58,16 +54,6 @@ class AndroidContextPlugin : Plugin {
         event.timestamp ?: let {
             val eventTime = System.currentTimeMillis()
             event.timestamp = eventTime
-            getAndroidAmplitude().lastEventTime = eventTime
-        }
-        event.timestamp ?. let {
-            if (!(event.eventType == START_SESSION_EVENT || event.eventType == END_SESSION_EVENT)) {
-                if (!getAndroidAmplitude().inForeground) {
-                    getAndroidAmplitude().startNewSessionIfNeeded(it)
-                } else {
-                    getAndroidAmplitude().refreshSessionTime(it)
-                }
-            }
         }
         event.insertId ?: let {
             event.insertId = UUID.randomUUID().toString()
@@ -80,15 +66,6 @@ class AndroidContextPlugin : Plugin {
         }
         event.deviceId ?: let {
             event.deviceId = amplitude.store.deviceId
-        }
-        event.sessionId = getAndroidAmplitude().sessionId
-        event.eventId ?: let {
-            val newEventId = getAndroidAmplitude().lastEventId + 1
-            event.eventId = newEventId
-            getAndroidAmplitude().lastEventId = newEventId
-            amplitude.amplitudeScope.launch(amplitude.amplitudeDispatcher) {
-                amplitude.storage.write(Storage.Constants.LAST_EVENT_ID, newEventId.toString())
-            }
         }
         val trackingOptions = configuration.trackingOptions
         if (configuration.enableCoppaControl) {
@@ -161,10 +138,6 @@ class AndroidContextPlugin : Plugin {
                 event.ingestionMetadata = it.clone()
             }
         }
-    }
-
-    private fun getAndroidAmplitude(): com.amplitude.android.Amplitude {
-        return amplitude as com.amplitude.android.Amplitude
     }
 
     companion object {

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -320,11 +320,14 @@ open class Amplitude internal constructor(
             logger.info("Skip event for opt out config.")
             return
         }
+        processEvent(event)
         amplitudeScope.launch(amplitudeDispatcher) {
             isBuilt.await()
             timeline.process(event)
         }
     }
+
+    protected open fun processEvent(event: BaseEvent) {}
 
     /**
      * Add a plugin.

--- a/core/src/main/java/com/amplitude/core/events/BaseEvent.kt
+++ b/core/src/main/java/com/amplitude/core/events/BaseEvent.kt
@@ -49,6 +49,9 @@ open class BaseEvent : EventOptions() {
         extra ?: let { extra = options.extra }
         callback ?: let { callback = options.callback }
         partnerId ?: let { partnerId = options.partnerId }
+        if (sessionId < 0) {
+            sessionId = options.sessionId
+        }
     }
 
     /**


### PR DESCRIPTION
### Summary

Session-specific logic moved from ContextPlugin to avoid race conditions

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No