### PR TITLE
fix: move session-specific logic to Timeline

### DIFF
--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -1,0 +1,166 @@
+package com.amplitude.android
+
+import com.amplitude.core.Storage
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.platform.Timeline
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+class Timeline : Timeline() {
+    private val eventMessageChannel: Channel<EventQueueMessage> = Channel(Channel.UNLIMITED)
+    var sessionId: Long = -1
+        private set
+    internal var lastEventId: Long = 0
+    var lastEventTime: Long = -1
+
+    internal fun start() {
+        amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
+            amplitude.isBuilt.await()
+
+            sessionId = amplitude.storage.read(Storage.Constants.PREVIOUS_SESSION_ID)?.toLong() ?: -1
+            lastEventId = amplitude.storage.read(Storage.Constants.LAST_EVENT_ID)?.toLong() ?: 0
+            lastEventTime = amplitude.storage.read(Storage.Constants.LAST_EVENT_TIME)?.toLong() ?: -1
+
+            for (message in eventMessageChannel) {
+                processEventMessage(message)
+            }
+        }
+    }
+
+    internal fun stop() {
+        this.eventMessageChannel.cancel()
+    }
+
+    override fun process(incomingEvent: BaseEvent) {
+        if (incomingEvent.timestamp == null) {
+            incomingEvent.timestamp = System.currentTimeMillis()
+        }
+
+        eventMessageChannel.trySend(EventQueueMessage(incomingEvent, (amplitude as Amplitude).inForeground))
+    }
+
+    private suspend fun processEventMessage(message: EventQueueMessage) {
+        val event = message.event
+        var sessionEvents: Iterable<BaseEvent>? = null
+        val eventTimestamp = event.timestamp!!
+        var skipEvent = false
+
+        if (event.eventType == Amplitude.START_SESSION_EVENT) {
+            if (event.sessionId < 0) { // dummy start_session event
+                skipEvent = true
+                sessionEvents = startNewSessionIfNeeded(eventTimestamp)
+            } else {
+                setSessionId(event.sessionId)
+                refreshSessionTime(eventTimestamp)
+            }
+        } else if (event.eventType == Amplitude.END_SESSION_EVENT) {
+            // do nothing
+        } else {
+            if (!message.inForeground) {
+                sessionEvents = startNewSessionIfNeeded(eventTimestamp)
+            } else {
+                refreshSessionTime(eventTimestamp)
+            }
+        }
+
+        if (!skipEvent && event.sessionId < 0) {
+            event.sessionId = sessionId
+        }
+
+        val savedLastEventId = lastEventId
+
+        sessionEvents ?. let {
+            it.forEach { e ->
+                e.eventId ?: let {
+                    val newEventId = lastEventId + 1
+                    e.eventId = newEventId
+                    lastEventId = newEventId
+                }
+            }
+        }
+
+        if (!skipEvent) {
+            event.eventId ?: let {
+                val newEventId = lastEventId + 1
+                event.eventId = newEventId
+                lastEventId = newEventId
+            }
+        }
+
+        if (lastEventId > savedLastEventId) {
+            amplitude.storage.write(Storage.Constants.LAST_EVENT_ID, lastEventId.toString())
+        }
+
+        sessionEvents ?. let {
+            it.forEach { e ->
+                super.process(e)
+            }
+        }
+
+        if (!skipEvent) {
+            super.process(event)
+        }
+    }
+
+    private suspend fun startNewSessionIfNeeded(timestamp: Long): Iterable<BaseEvent>? {
+        if (inSession() && isWithinMinTimeBetweenSessions(timestamp)) {
+            refreshSessionTime(timestamp)
+            return null
+        }
+        return startNewSession(timestamp)
+    }
+
+    private suspend fun setSessionId(timestamp: Long) {
+        sessionId = timestamp
+        amplitude.storage.write(Storage.Constants.PREVIOUS_SESSION_ID, sessionId.toString())
+    }
+
+    private suspend fun startNewSession(timestamp: Long): Iterable<BaseEvent> {
+        val sessionEvents = mutableListOf<BaseEvent>()
+        val trackingSessionEvents = (amplitude.configuration as Configuration).trackingSessionEvents
+
+        // end previous session
+        if (trackingSessionEvents && inSession()) {
+            val sessionEndEvent = BaseEvent()
+            sessionEndEvent.eventType = Amplitude.END_SESSION_EVENT
+            sessionEndEvent.timestamp = if (lastEventTime > 0) lastEventTime else null
+            sessionEndEvent.sessionId = sessionId
+            sessionEvents.add(sessionEndEvent)
+        }
+
+        // start new session
+        setSessionId(timestamp)
+        refreshSessionTime(timestamp)
+        if (trackingSessionEvents) {
+            val sessionStartEvent = BaseEvent()
+            sessionStartEvent.eventType = Amplitude.START_SESSION_EVENT
+            sessionStartEvent.timestamp = timestamp
+            sessionStartEvent.sessionId = sessionId
+            sessionEvents.add(sessionStartEvent)
+        }
+
+        return sessionEvents
+    }
+
+    private suspend fun refreshSessionTime(timestamp: Long) {
+        if (!inSession()) {
+            return
+        }
+        lastEventTime = timestamp
+        amplitude.storage.write(Storage.Constants.LAST_EVENT_TIME, lastEventTime.toString())
+    }
+
+    private fun isWithinMinTimeBetweenSessions(timestamp: Long): Boolean {
+        val sessionLimit: Long = (amplitude.configuration as Configuration).minTimeBetweenSessionsMillis
+        return timestamp - lastEventTime < sessionLimit
+    }
+
+    private fun inSession(): Boolean {
+        return sessionId >= 0
+    }
+}
+
+data class EventQueueMessage(
+    val event: BaseEvent,
+    val inForeground: Boolean
+)

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -119,6 +119,8 @@ class AmplitudeTest {
             event.eventType = "test event"
             amplitude?.track(event)
             advanceUntilIdle()
+            Thread.sleep(100)
+
             val track = slot<BaseEvent>()
             verify { mockedPlugin.track(capture(track)) }
             track.captured.let {
@@ -140,6 +142,8 @@ class AmplitudeTest {
             event.ip = "127.0.0.1"
             amplitude?.track(event)
             advanceUntilIdle()
+            Thread.sleep(100)
+
             val track = slot<BaseEvent>()
             verify { mockedPlugin.track(capture(track)) }
             track.captured.let {
@@ -158,7 +162,7 @@ class AmplitudeTest {
         val mockedPlugin = spyk(StubPlugin())
         amplitude.add(mockedPlugin)
 
-        amplitude.isBuilt!!.await()
+        amplitude.isBuilt.await()
 
         val event1 = BaseEvent()
         event1.eventType = "test event 1"
@@ -317,45 +321,54 @@ class AmplitudeTest {
 
         val amplitude1 = Amplitude(createConfiguration(100, InstanceStorageProvider(storage)))
         amplitude1.isBuilt.await()
+        val timeline1 = amplitude1.timeline as Timeline
 
         amplitude1.onEnterForeground(1000)
+        advanceUntilIdle()
+        Thread.sleep(100)
 
-        Assertions.assertEquals(1000L, amplitude1.sessionId)
-        Assertions.assertEquals(1L, amplitude1.lastEventId)
-        Assertions.assertEquals(1000L, amplitude1.lastEventTime)
+        Assertions.assertEquals(1000L, timeline1.sessionId)
+        Assertions.assertEquals(1L, timeline1.lastEventId)
+        Assertions.assertEquals(1000L, timeline1.lastEventTime)
 
         val event1 = BaseEvent()
         event1.eventType = "test event 1"
         event1.timestamp = 1200
         amplitude1.track(event1)
-
-        Assertions.assertEquals(1000L, amplitude1.sessionId)
-        Assertions.assertEquals(2L, amplitude1.lastEventId)
-        Assertions.assertEquals(1200L, amplitude1.lastEventTime)
-
         advanceUntilIdle()
+        Thread.sleep(100)
+
+        Assertions.assertEquals(1000L, timeline1.sessionId)
+        Assertions.assertEquals(2L, timeline1.lastEventId)
+        Assertions.assertEquals(1200L, timeline1.lastEventTime)
 
         val amplitude2 = Amplitude(createConfiguration(100, InstanceStorageProvider(storage)))
         amplitude2.isBuilt.await()
-
-        Assertions.assertEquals(1000L, amplitude2.sessionId)
-        Assertions.assertEquals(2L, amplitude2.lastEventId)
-        Assertions.assertEquals(1200L, amplitude2.lastEventTime)
-
+        val timeline2 = amplitude2.timeline as Timeline
         advanceUntilIdle()
+        Thread.sleep(100)
+
+        Assertions.assertEquals(1000L, timeline2.sessionId)
+        Assertions.assertEquals(2L, timeline2.lastEventId)
+        Assertions.assertEquals(1200L, timeline2.lastEventTime)
 
         val amplitude3 = Amplitude(createConfiguration(100, InstanceStorageProvider(storage)))
         amplitude3.isBuilt.await()
+        val timeline3 = amplitude3.timeline as Timeline
+        advanceUntilIdle()
+        Thread.sleep(100)
 
-        Assertions.assertEquals(1000L, amplitude3.sessionId)
-        Assertions.assertEquals(2L, amplitude3.lastEventId)
-        Assertions.assertEquals(1200L, amplitude3.lastEventTime)
+        Assertions.assertEquals(1000L, timeline3.sessionId)
+        Assertions.assertEquals(2L, timeline3.lastEventId)
+        Assertions.assertEquals(1200L, timeline3.lastEventTime)
 
         amplitude3.onEnterForeground(1400)
+        advanceUntilIdle()
+        Thread.sleep(100)
 
-        Assertions.assertEquals(1400L, amplitude3.sessionId)
-        Assertions.assertEquals(4L, amplitude3.lastEventId)
-        Assertions.assertEquals(1400L, amplitude3.lastEventTime)
+        Assertions.assertEquals(1400L, timeline3.sessionId)
+        Assertions.assertEquals(4L, timeline3.lastEventId)
+        Assertions.assertEquals(1400L, timeline3.lastEventTime)
     }
 }
 

--- a/core/src/main/java/com/amplitude/core/platform/Timeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Timeline.kt
@@ -3,7 +3,7 @@ package com.amplitude.core.platform
 import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
 
-internal class Timeline {
+open class Timeline {
     internal val plugins: Map<Plugin.Type, Mediator> = mapOf(
         Plugin.Type.Before to Mediator(mutableListOf()),
         Plugin.Type.Enrichment to Mediator(mutableListOf()),
@@ -12,13 +12,11 @@ internal class Timeline {
     )
     lateinit var amplitude: Amplitude
 
-    fun process(incomingEvent: BaseEvent): BaseEvent? {
+    open fun process(incomingEvent: BaseEvent) {
         val beforeResult = applyPlugins(Plugin.Type.Before, incomingEvent)
         val enrichmentResult = applyPlugins(Plugin.Type.Enrichment, beforeResult)
 
         applyPlugins(Plugin.Type.Destination, enrichmentResult)
-
-        return enrichmentResult
     }
 
     fun add(plugin: Plugin) {
@@ -33,7 +31,7 @@ internal class Timeline {
         return result
     }
 
-    fun applyPlugins(mediator: Mediator?, event: BaseEvent?): BaseEvent? {
+    private fun applyPlugins(mediator: Mediator?, event: BaseEvent?): BaseEvent? {
         var result: BaseEvent? = event
         result?.let { e ->
             result = mediator?.execute(e)


### PR DESCRIPTION
### Summary

All session-related logic is extracted to new Timeline class.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No