### PR TITLE
fix: start build() lazily

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -13,6 +13,7 @@ import com.amplitude.id.FileIdentityStorageProvider
 import com.amplitude.id.IdentityConfiguration
 import com.amplitude.id.IdentityContainer
 import com.amplitude.id.IdentityUpdateType
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
@@ -36,7 +37,7 @@ open class Amplitude(
     override fun build(): Deferred<Boolean> {
         val client = this
 
-        val built = amplitudeScope.async(amplitudeDispatcher) {
+        val built = amplitudeScope.async(amplitudeDispatcher, CoroutineStart.LAZY) {
             storage = configuration.storageProvider.getStorage(client)
 
             val storageDirectory = (configuration as Configuration).context.getDir("${FileStorage.STORAGE_PREFIX}-${configuration.instanceName}", Context.MODE_PRIVATE)

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -58,6 +58,7 @@ open class Amplitude internal constructor(
         timeline = this.createTimeline()
         logger = configuration.loggerProvider.getLogger(this)
         isBuilt = build()
+        isBuilt.start()
     }
 
     /**


### PR DESCRIPTION
### Summary

<!-- What does the PR do? -->

`build()` body calls `isBuilt.await()` (somewhere in nested subcalls). The body was started immediately and can use uninitialized `isBuilt`. Now the 'build' body is started lazily just after `isBuilt` was initialized.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No