### PR TITLE
fix: add error handling and logging for file load crash issue

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -48,7 +48,8 @@ open class Amplitude(
                     instanceName = configuration.instanceName,
                     apiKey = configuration.apiKey,
                     identityStorageProvider = FileIdentityStorageProvider(),
-                    storageDirectory = storageDirectory
+                    storageDirectory = storageDirectory,
+                    logger = configuration.loggerProvider.getLogger(client)
                 )
             )
             val listener = AnalyticsIdentityListener(store)

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -72,7 +72,14 @@ open class Amplitude internal constructor(
 
     open fun build(): Deferred<Boolean> {
         storage = configuration.storageProvider.getStorage(this)
-        idContainer = IdentityContainer.getInstance(IdentityConfiguration(instanceName = configuration.instanceName, apiKey = configuration.apiKey, identityStorageProvider = IMIdentityStorageProvider()))
+        idContainer = IdentityContainer.getInstance(
+            IdentityConfiguration(
+                instanceName = configuration.instanceName,
+                apiKey = configuration.apiKey,
+                identityStorageProvider = IMIdentityStorageProvider(),
+                logger = configuration.loggerProvider.getLogger(this)
+            )
+        )
         val listener = AnalyticsIdentityListener(store)
         idContainer.identityManager.addIdentityListener(listener)
         if (idContainer.identityManager.isInitialized()) {

--- a/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
@@ -25,7 +25,7 @@ class FileStorage(
     private val storageDirectory = File("/tmp/amplitude-kotlin/$apiKey")
     private val storageDirectoryEvents = File(storageDirectory, "events")
 
-    internal val propertiesFile = PropertiesFile(storageDirectory, apiKey, STORAGE_PREFIX)
+    internal val propertiesFile = PropertiesFile(storageDirectory, apiKey, STORAGE_PREFIX, null)
     internal val eventsFile = EventsFileManager(storageDirectoryEvents, apiKey, propertiesFile)
     val eventCallbacksMap = mutableMapOf<String, EventCallBack>()
 

--- a/id/build.gradle
+++ b/id/build.gradle
@@ -13,7 +13,9 @@ test {
 }
 
 dependencies {
+    api project(":common")
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation platform("org.junit:junit-bom:5.7.2")
     testImplementation "org.junit.jupiter:junit-jupiter"
+    testImplementation 'io.mockk:mockk:1.12.3'
 }

--- a/id/src/main/java/com/amplitude/id/FileIdentityStorage.kt
+++ b/id/src/main/java/com/amplitude/id/FileIdentityStorage.kt
@@ -19,7 +19,7 @@ class FileIdentityStorage(val configuration: IdentityConfiguration) : IdentitySt
         val instanceName = configuration.instanceName
         val storageDirectory = configuration.storageDirectory ?: File("/tmp/$STORAGE_PREFIX/$instanceName")
         createDirectory(storageDirectory)
-        propertiesFile = PropertiesFile(storageDirectory, instanceName, STORAGE_PREFIX)
+        propertiesFile = PropertiesFile(storageDirectory, instanceName, STORAGE_PREFIX, configuration.logger)
         propertiesFile.load()
         safetyCheck()
     }

--- a/id/src/main/java/com/amplitude/id/IdentityConfiguration.kt
+++ b/id/src/main/java/com/amplitude/id/IdentityConfiguration.kt
@@ -1,5 +1,6 @@
 package com.amplitude.id
 
+import com.amplitude.common.Logger
 import java.io.File
 
 /**
@@ -10,5 +11,6 @@ data class IdentityConfiguration(
     val apiKey: String? = null,
     val experimentApiKey: String? = null,
     val identityStorageProvider: IdentityStorageProvider,
-    val storageDirectory: File? = null
+    val storageDirectory: File? = null,
+    val logger: Logger? = null
 )

--- a/id/src/main/java/com/amplitude/id/utilities/PropertiesFile.kt
+++ b/id/src/main/java/com/amplitude/id/utilities/PropertiesFile.kt
@@ -1,27 +1,34 @@
 package com.amplitude.id.utilities
 
+import com.amplitude.common.Logger
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.util.Properties
 
-class PropertiesFile(directory: File, key: String, prefix: String) : KeyValueStore {
-    private val underlyingProperties: Properties = Properties()
+class PropertiesFile(directory: File, key: String, prefix: String, logger: Logger?) : KeyValueStore {
+    internal var underlyingProperties: Properties = Properties()
     private val propertiesFileName = "$prefix-$key.properties"
     private val propertiesFile = File(directory, propertiesFileName)
+    private val logger = logger
 
     /**
      * Check if underlying file exists, and load properties if true
      */
     fun load() {
         if (propertiesFile.exists()) {
-            FileInputStream(propertiesFile).use {
-                underlyingProperties.load(it)
+            try {
+                FileInputStream(propertiesFile).use {
+                    underlyingProperties.load(it)
+                }
+                return
+            } catch (e: IllegalArgumentException) {
+                propertiesFile.delete()
+                logger?.error("Failed to load property file with path ${propertiesFile.absolutePath}, error stacktrace: ${e.stackTraceToString()}")
             }
-        } else {
-            propertiesFile.parentFile.mkdirs()
-            propertiesFile.createNewFile()
         }
+        propertiesFile.parentFile.mkdirs()
+        propertiesFile.createNewFile()
     }
 
     private fun save() {

--- a/id/src/test/kotlin/com/amplitude/id/FileIdentityStorageTest.kt
+++ b/id/src/test/kotlin/com/amplitude/id/FileIdentityStorageTest.kt
@@ -1,11 +1,19 @@
 package com.amplitude.id
 
+import com.amplitude.common.Logger
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FileIdentityStorageTest {
+    val logger = object : Logger {
+        override var logMode: Logger.LogMode = Logger.LogMode.INFO
+        override fun debug(message: String) {}
+        override fun error(message: String) {}
+        override fun info(message: String) {}
+        override fun warn(message: String) {}
+    }
 
     @Test
     fun `test FileIdentityStorage create and save success`() {
@@ -21,7 +29,8 @@ class FileIdentityStorageTest {
         val identityConfiguration = IdentityConfiguration(
             instanceName = "testInstance",
             identityStorageProvider = identityStorageProvider,
-            apiKey = "test-api-key"
+            apiKey = "test-api-key",
+            logger = logger
         )
         val fileIdentityStorage = identityStorageProvider.getIdentityStorage(identityConfiguration)
         val savedIdentity = fileIdentityStorage.load()
@@ -37,7 +46,8 @@ class FileIdentityStorageTest {
             instanceName = "testInstance",
             identityStorageProvider = identityStorageProvider,
             apiKey = "test-different-api-key",
-            experimentApiKey = "test-experiment-api-key"
+            experimentApiKey = "test-experiment-api-key",
+            logger = logger
         )
         val fileIdentityStorage = identityStorageProvider.getIdentityStorage(identityConfiguration)
         val savedIdentity = fileIdentityStorage.load()
@@ -50,7 +60,8 @@ class FileIdentityStorageTest {
         val identityConfiguration = IdentityConfiguration(
             instanceName = "testInstance",
             identityStorageProvider = identityStorageProvider,
-            apiKey = "test-api-key"
+            apiKey = "test-api-key",
+            logger = logger
         )
         val fileIdentityStorage = identityStorageProvider.getIdentityStorage(identityConfiguration)
         fileIdentityStorage.saveUserId("user_id")

--- a/id/src/test/kotlin/com/amplitude/id/utilities/PropertiesFileTest.kt
+++ b/id/src/test/kotlin/com/amplitude/id/utilities/PropertiesFileTest.kt
@@ -1,0 +1,34 @@
+package com.amplitude.id.utilities
+
+import com.amplitude.common.Logger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.File
+import java.io.InputStream
+import java.util.Properties
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PropertiesFileTest {
+    private lateinit var logger: Logger
+    private lateinit var properties: Properties
+
+    @BeforeEach
+    fun setUp() {
+        logger = mockk<Logger>(relaxed = true)
+        properties = mockk<Properties>(relaxed = true)
+    }
+
+    @Test
+    fun `test loading properties file with exception`() {
+        val propertiesFile = PropertiesFile(File("/tmp"), "key", "prefix", logger)
+        propertiesFile.underlyingProperties = properties
+
+        every { properties.load(any<InputStream>()) } throws IllegalArgumentException()
+        propertiesFile.load()
+        verify(exactly = 1) { logger.error(any()) }
+    }
+}

--- a/id/src/test/kotlin/com/amplitude/id/utilities/PropertiesFileTest.kt
+++ b/id/src/test/kotlin/com/amplitude/id/utilities/PropertiesFileTest.kt
@@ -7,28 +7,49 @@ import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.io.InputStream
 import java.util.Properties
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PropertiesFileTest {
-    private lateinit var logger: Logger
-    private lateinit var properties: Properties
+    @TempDir
+    @JvmField
+    var tempFolder: File? = null
+
+    private lateinit var mockedLogger: Logger
+    private lateinit var mockedProperties: Properties
 
     @BeforeEach
     fun setUp() {
-        logger = mockk<Logger>(relaxed = true)
-        properties = mockk<Properties>(relaxed = true)
+        mockedLogger = mockk<Logger>(relaxed = true)
+        mockedProperties = mockk<Properties>(relaxed = true)
     }
 
     @Test
     fun `test loading properties file with exception`() {
-        val propertiesFile = PropertiesFile(File("/tmp"), "key", "prefix", logger)
-        propertiesFile.underlyingProperties = properties
+        val tempFile = File(tempFolder, "prefix-key.properties")
+        tempFile.createNewFile()
 
-        every { properties.load(any<InputStream>()) } throws IllegalArgumentException()
+        val propertiesFile = PropertiesFile(tempFolder!!, "key", "prefix", mockedLogger)
+        propertiesFile.underlyingProperties = mockedProperties
+        every { mockedProperties.load(any<InputStream>()) } throws IllegalArgumentException()
+
         propertiesFile.load()
-        verify(exactly = 1) { logger.error(any()) }
+        verify(exactly = 1) { mockedLogger.error(any()) }
+    }
+
+    @Test
+    fun `test loading properties file successfully`() {
+        val tempFile = File(tempFolder, "prefix-key.properties")
+        tempFile.createNewFile()
+
+        val propertiesFile = PropertiesFile(tempFolder!!, "key", "prefix", mockedLogger)
+        propertiesFile.underlyingProperties = mockedProperties
+        every { mockedProperties.load(any<InputStream>()) } returns Unit
+
+        propertiesFile.load()
+        verify(exactly = 0) { mockedLogger.error(any()) }
     }
 }


### PR DESCRIPTION
### Summary
This PR is to address the:
```
Fatal Exception: java.lang.IllegalArgumentException
Malformed \uxxxx encoding
```
![image](https://user-images.githubusercontent.com/8689754/200993121-f217119c-f1be-4560-a4a4-ff854891da76.png)

- I cannot reproduce the same error with setting the `device_id` with a special char, like "时间" (any Chinese char), "\u0000". So I think this should be related to the file path, instead of the content.
- I found an article mentioning the similar problem: https://www.ibm.com/support/pages/error-javalangillegalargumentexception-malformed-uxxxx-encoding-when-start-cognos-analytics

So I think it might be the case that the user is running the app inside the Windows machine within the simulator, and have a customized storage configured with "\user" or "\uxxx" inside the path, then when the file system tries to get that file, it treats the \u as unicode. Note I tried to hack my Android Studio by providing a path containing "\u" when creating the properties file, but it automatically removed all backslashes.

Base on this and the lack of information to reproduce, this PR:
- updates the code to not crash due to this error
- adds loggings information if this case happens so we can understand this better

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No