### PR TITLE
fix: Add Index out of bound exception handling for PropertiesFile.save()

### DIFF
--- a/id/src/main/java/com/amplitude/id/utilities/PropertiesFile.kt
+++ b/id/src/main/java/com/amplitude/id/utilities/PropertiesFile.kt
@@ -32,8 +32,12 @@ class PropertiesFile(directory: File, key: String, prefix: String, logger: Logge
     }
 
     private fun save() {
-        FileOutputStream(propertiesFile).use {
-            underlyingProperties.store(it, null)
+        try {
+            FileOutputStream(propertiesFile).use {
+                underlyingProperties.store(it, null)
+            }
+        } catch (e: IndexOutOfBoundsException) {
+            logger?.error("Failed to save property file with path ${propertiesFile.absolutePath}, error stacktrace: ${e.stackTraceToString()}")
         }
     }
 

--- a/id/src/main/java/com/amplitude/id/utilities/PropertiesFile.kt
+++ b/id/src/main/java/com/amplitude/id/utilities/PropertiesFile.kt
@@ -22,7 +22,7 @@ class PropertiesFile(directory: File, key: String, prefix: String, logger: Logge
                     underlyingProperties.load(it)
                 }
                 return
-            } catch (e: IllegalArgumentException) {
+            } catch (e: Exception) {
                 propertiesFile.delete()
                 logger?.error("Failed to load property file with path ${propertiesFile.absolutePath}, error stacktrace: ${e.stackTraceToString()}")
             }
@@ -36,7 +36,7 @@ class PropertiesFile(directory: File, key: String, prefix: String, logger: Logge
             FileOutputStream(propertiesFile).use {
                 underlyingProperties.store(it, null)
             }
-        } catch (e: IndexOutOfBoundsException) {
+        } catch (e: Exception) {
             logger?.error("Failed to save property file with path ${propertiesFile.absolutePath}, error stacktrace: ${e.stackTraceToString()}")
         }
     }

--- a/id/src/test/kotlin/com/amplitude/id/utilities/PropertiesFileTest.kt
+++ b/id/src/test/kotlin/com/amplitude/id/utilities/PropertiesFileTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.io.FileOutputStream
 import java.io.InputStream
 import java.util.Properties
 
@@ -37,6 +38,19 @@ class PropertiesFileTest {
         every { mockedProperties.load(any<InputStream>()) } throws IllegalArgumentException()
 
         propertiesFile.load()
+        verify(exactly = 1) { mockedLogger.error(any()) }
+    }
+
+    @Test
+    fun `test saving properties file with exception`() {
+        val tempFile = File(tempFolder, "prefix-key.properties")
+        tempFile.createNewFile()
+
+        val propertiesFile = PropertiesFile(tempFolder!!, "key", "prefix", mockedLogger)
+        propertiesFile.underlyingProperties = mockedProperties
+        every { mockedProperties.store(any<FileOutputStream>(), null) } throws IndexOutOfBoundsException()
+
+        propertiesFile.putLong("test", 1L)
         verify(exactly = 1) { mockedLogger.error(any()) }
     }
 

--- a/id/src/test/kotlin/com/amplitude/id/utilities/PropertiesFileTest.kt
+++ b/id/src/test/kotlin/com/amplitude/id/utilities/PropertiesFileTest.kt
@@ -35,7 +35,7 @@ class PropertiesFileTest {
 
         val propertiesFile = PropertiesFile(tempFolder!!, "key", "prefix", mockedLogger)
         propertiesFile.underlyingProperties = mockedProperties
-        every { mockedProperties.load(any<InputStream>()) } throws IllegalArgumentException()
+        every { mockedProperties.load(any<InputStream>()) } throws Exception()
 
         propertiesFile.load()
         verify(exactly = 1) { mockedLogger.error(any()) }
@@ -48,7 +48,7 @@ class PropertiesFileTest {
 
         val propertiesFile = PropertiesFile(tempFolder!!, "key", "prefix", mockedLogger)
         propertiesFile.underlyingProperties = mockedProperties
-        every { mockedProperties.store(any<FileOutputStream>(), null) } throws IndexOutOfBoundsException()
+        every { mockedProperties.store(any<FileOutputStream>(), null) } throws Exception()
 
         propertiesFile.putLong("test", 1L)
         verify(exactly = 1) { mockedLogger.error(any()) }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Expection catch and log for PropertiesFile.save()
Change more general Exception catch for PropertiesFile.load()
Unit test for added function

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no