### PR TITLE
feat: add log.debug to send event and handle response

### DIFF
--- a/android/src/main/java/com/amplitude/android/utilities/AndroidLoggerProvider.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidLoggerProvider.kt
@@ -6,7 +6,11 @@ import com.amplitude.core.Amplitude
 import com.amplitude.core.LoggerProvider
 
 class AndroidLoggerProvider() : LoggerProvider {
+    private val logger: Logger by lazy {
+        LogcatLogger()
+    }
+
     override fun getLogger(amplitude: Amplitude): Logger {
-        return LogcatLogger()
+        return logger
     }
 }

--- a/android/src/main/java/com/amplitude/android/utilities/AndroidStorage.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidStorage.kt
@@ -2,6 +2,7 @@ package com.amplitude.android.utilities
 
 import android.content.Context
 import android.content.SharedPreferences
+import com.amplitude.common.Logger
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Configuration
 import com.amplitude.core.EventCallBack
@@ -21,7 +22,8 @@ import java.io.File
 
 class AndroidStorage(
     context: Context,
-    apiKey: String
+    apiKey: String,
+    private val logger: Logger
 ) : Storage, EventsFileStorage {
 
     companion object {
@@ -79,7 +81,8 @@ class AndroidStorage(
             scope,
             dispatcher,
             events as String,
-            eventsString
+            eventsString,
+            logger
         )
     }
 
@@ -103,6 +106,10 @@ class AndroidStorage(
 class AndroidStorageProvider : StorageProvider {
     override fun getStorage(amplitude: Amplitude): Storage {
         val configuration = amplitude.configuration as com.amplitude.android.Configuration
-        return AndroidStorage(configuration.context, configuration.apiKey)
+        return AndroidStorage(
+            configuration.context,
+            configuration.apiKey,
+            configuration.loggerProvider.getLogger(amplitude)
+        )
     }
 }

--- a/android/src/test/java/com/amplitude/android/utilities/AndroidLoggerProviderTest.kt
+++ b/android/src/test/java/com/amplitude/android/utilities/AndroidLoggerProviderTest.kt
@@ -1,0 +1,22 @@
+package com.amplitude.android.utilities
+
+import android.app.Application
+import com.amplitude.android.Amplitude
+import com.amplitude.android.Configuration
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AndroidLoggerProviderTest {
+    @Test
+    fun androidLoggerProvider_getLogger_returnsSingletonInstance() {
+        val testApiKey = "test-123"
+        val context = mockk<Application>(relaxed = true)
+
+        val amplitude = Amplitude(Configuration(testApiKey, context = context!!))
+        val loggerProvider = AndroidLoggerProvider()
+        val logger1 = loggerProvider.getLogger(amplitude)
+        val logger2 = loggerProvider.getLogger(amplitude)
+        Assertions.assertEquals(logger1, logger2)
+    }
+}

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -337,6 +337,7 @@ open class Amplitude internal constructor(
             event.timestamp = System.currentTimeMillis()
         }
 
+        logger.debug("Logged event with type: ${event.eventType}")
         timeline.process(event)
     }
 

--- a/core/src/main/java/com/amplitude/core/utilities/ConsoleLoggerProvider.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/ConsoleLoggerProvider.kt
@@ -6,7 +6,11 @@ import com.amplitude.core.Amplitude
 import com.amplitude.core.LoggerProvider
 
 class ConsoleLoggerProvider() : LoggerProvider {
+    private val logger: Logger by lazy {
+        ConsoleLogger()
+    }
+
     override fun getLogger(amplitude: Amplitude): Logger {
-        return ConsoleLogger()
+        return logger
     }
 }

--- a/core/src/main/java/com/amplitude/core/utilities/FileResponseHandler.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/FileResponseHandler.kt
@@ -1,5 +1,6 @@
 package com.amplitude.core.utilities
 
+import com.amplitude.common.Logger
 import com.amplitude.core.Configuration
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.EventPipeline
@@ -16,10 +17,12 @@ class FileResponseHandler(
     private val scope: CoroutineScope,
     private val dispatcher: CoroutineDispatcher,
     private val eventFilePath: String,
-    private val eventsString: String
+    private val eventsString: String,
+    private val logger: Logger?
 ) : ResponseHandler {
 
     override fun handleSuccessResponse(successResponse: SuccessResponse) {
+        logger?.debug("Handle response, status: ${successResponse.status}")
         val events: List<BaseEvent>
         try {
             events = JSONArray(eventsString).toEvents()
@@ -35,6 +38,7 @@ class FileResponseHandler(
     }
 
     override fun handleBadRequestResponse(badRequestResponse: BadRequestResponse) {
+        logger?.debug("Handle response, status: ${badRequestResponse.status}, error: ${badRequestResponse.error}")
         val events: List<BaseEvent>
         try {
             events = JSONArray(eventsString).toEvents()
@@ -68,6 +72,7 @@ class FileResponseHandler(
     }
 
     override fun handlePayloadTooLargeResponse(payloadTooLargeResponse: PayloadTooLargeResponse) {
+        logger?.debug("Handle response, status: ${payloadTooLargeResponse.status}, error: ${payloadTooLargeResponse.error}")
         val rawEvents: JSONArray
         try {
             rawEvents = JSONArray(eventsString)
@@ -91,14 +96,17 @@ class FileResponseHandler(
     }
 
     override fun handleTooManyRequestsResponse(tooManyRequestsResponse: TooManyRequestsResponse) {
+        logger?.debug("Handle response, status: ${tooManyRequestsResponse.status}, error: ${tooManyRequestsResponse.error}")
         // wait for next time to pick it up
     }
 
     override fun handleTimeoutResponse(timeoutResponse: TimeoutResponse) {
+        logger?.debug("Handle response, status: ${timeoutResponse.status}")
         // wait for next time to try again
     }
 
     override fun handleFailedResponse(failedResponse: FailedResponse) {
+        logger?.debug("Handle response, status: ${failedResponse.status}, error: ${failedResponse.error}")
         // wait for next time to try again
     }
 

--- a/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
@@ -1,5 +1,6 @@
 package com.amplitude.core.utilities
 
+import com.amplitude.common.Logger
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Configuration
 import com.amplitude.core.EventCallBack
@@ -15,7 +16,8 @@ import java.io.BufferedReader
 import java.io.File
 
 class FileStorage(
-    private val apiKey: String
+    private val apiKey: String,
+    private val logger: Logger
 ) : Storage, EventsFileStorage {
 
     companion object {
@@ -82,7 +84,8 @@ class FileStorage(
             scope,
             dispatcher,
             events as String,
-            eventsString
+            eventsString,
+            logger
         )
     }
 
@@ -105,7 +108,10 @@ class FileStorage(
 
 class FileStorageProvider : StorageProvider {
     override fun getStorage(amplitude: Amplitude): Storage {
-        return FileStorage(amplitude.configuration.apiKey)
+        return FileStorage(
+            amplitude.configuration.apiKey,
+            amplitude.configuration.loggerProvider.getLogger(amplitude)
+        )
     }
 }
 

--- a/core/src/test/kotlin/com/amplitude/core/utilities/ConsoleLoggerProviderTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/utilities/ConsoleLoggerProviderTest.kt
@@ -1,0 +1,18 @@
+package com.amplitude.core.utilities
+
+import com.amplitude.core.Configuration
+import com.amplitude.core.utils.testAmplitude
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class ConsoleLoggerProviderTest {
+    @Test
+    fun `test singleton instance`() {
+        val testApiKey = "test-123"
+        val amplitude = testAmplitude(Configuration(testApiKey))
+        val loggerProvider = ConsoleLoggerProvider()
+        val logger1 = loggerProvider.getLogger(amplitude)
+        val logger2 = loggerProvider.getLogger(amplitude)
+        Assertions.assertEquals(logger1, logger2)
+    }
+}


### PR DESCRIPTION
### Summary
- feat: add log.debug to send event and handle response
  - https://github.com/amplitude/Amplitude-Kotlin/issues/94
  - Expose the visibility of handling the responses

Change the logger provider to provide a singleton instance of `Logger`, otherwise, when we set `amplitude.logger.logMode = Logger.LogMode.DEBUG`, it won't work globally.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No