### PR TITLE
fix: catch filenotfound exception when rollover before upload

### DIFF
--- a/core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.FileNotFoundException
-import java.lang.Exception
 import java.util.concurrent.atomic.AtomicInteger
 
 class EventPipeline(
@@ -99,7 +98,13 @@ class EventPipeline(
         uploadChannel.consumeEach {
 
             withContext(amplitude.storageIODispatcher) {
-                storage.rollover()
+                try {
+                    storage.rollover()
+                } catch (e: FileNotFoundException) {
+                    e.message?.let {
+                        amplitude.logger.warn("Event storage file not found: $it")
+                    }
+                }
             }
 
             val eventsData = storage.readEventsContent()


### PR DESCRIPTION
### Summary
- fix: catch filenotfound exception when rollover before upload

It seems that this issue happens when another thread (coroutine) processes the file and delete it before this one, then it tries to get the file. This issue should rarely happen, and is not easy to reproduce. `readEventsContent` will list all available files then open one by one with another catch of FileNotFoundException, so we can safely let it execute.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No