### PR TITLE
fix: fix log session event when optOut is true

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -93,6 +93,10 @@ open class Amplitude(
     fun onEnterForeground(timestamp: Long) {
         inForeground = true
 
+        if ((configuration as Configuration).optOut) {
+            return
+        }
+
         val dummySessionStartEvent = BaseEvent()
         dummySessionStartEvent.eventType = START_SESSION_EVENT
         dummySessionStartEvent.timestamp = timestamp

--- a/android/src/test/java/com/amplitude/android/AmplitudeOtherTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeOtherTest.kt
@@ -3,13 +3,13 @@ package com.amplitude.android
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.amplitude.core.events.BaseEvent
+import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import io.mockk.spyk
-import io.mockk.verify
 
 @RunWith(RobolectricTestRunner::class)
 class AmplitudeOtherTest {

--- a/android/src/test/java/com/amplitude/android/AmplitudeOtherTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeOtherTest.kt
@@ -1,0 +1,51 @@
+package com.amplitude.android
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.amplitude.core.events.BaseEvent
+import io.mockk.spyk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AmplitudeOtherTest {
+    private lateinit var amplitude: Amplitude
+
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        val apiKey = "test-api-key"
+        amplitude = Amplitude(apiKey, context) {
+            this.minTimeBetweenSessionsMillis = 100
+            this.optOut = true
+        }
+    }
+
+    @Test
+    fun `test optOut is true no event should be send`() {
+        val mockedPluginTest = spyk(StubPlugin())
+        amplitude.add(mockedPluginTest)
+
+        val event1 = BaseEvent()
+        event1.eventType = "test event 1"
+        event1.timestamp = 1000
+        amplitude.track(event1)
+
+        amplitude.onEnterForeground(1500)
+
+        val event2 = BaseEvent()
+        event2.eventType = "test event 2"
+        event2.timestamp = 1700
+        amplitude.track(event2)
+
+        amplitude.onExitForeground()
+
+        verify(exactly = 0) { mockedPluginTest.track(any()) }
+    }
+}

--- a/android/src/test/java/com/amplitude/android/AmplitudeOtherTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeOtherTest.kt
@@ -3,13 +3,13 @@ package com.amplitude.android
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.amplitude.core.events.BaseEvent
-import io.mockk.spyk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import io.mockk.spyk
+import io.mockk.verify
 
 @RunWith(RobolectricTestRunner::class)
 class AmplitudeOtherTest {

--- a/android/src/test/java/com/amplitude/android/AmplitudeRobolectricTests.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeRobolectricTests.kt
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class AmplitudeOtherTest {
+class AmplitudeRobolectricTests {
     private lateinit var amplitude: Amplitude
 
     @ExperimentalCoroutinesApi

--- a/android/src/test/java/com/amplitude/android/AmplitudeRobolectricTests.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeRobolectricTests.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.content.Context
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.utilities.ConsoleLoggerProvider
-import com.amplitude.core.utilities.InMemoryStorageProvider
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
@@ -60,7 +59,6 @@ class AmplitudeRobolectricTests {
             context = context!!,
             instanceName = "testInstance",
             loggerProvider = ConsoleLoggerProvider(),
-            identifyInterceptStorageProvider = InMemoryStorageProvider(),
             optOut = optOut ?: false,
             minTimeBetweenSessionsMillis = minTimeBetweenSessionsMillis
                 ?: Configuration.MIN_TIME_BETWEEN_SESSIONS_MILLIS,

--- a/android/src/test/java/com/amplitude/android/AmplitudeRobolectricTests.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeRobolectricTests.kt
@@ -2,8 +2,6 @@ package com.amplitude.android
 
 import android.app.Application
 import android.content.Context
-import androidx.test.core.app.ApplicationProvider
-import com.amplitude.core.StorageProvider
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.utilities.ConsoleLoggerProvider
 import com.amplitude.core.utilities.InMemoryStorageProvider


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

When set `optOut = true`, we still track the session events. Please check here for the origin [issue](https://amplitude.atlassian.net/browse/DXOC-734?atlOrigin=eyJpIjoiMzBkNGU3NGQ2MjlkNDI4MmE0ZDhmYzhjODFjM2E4Y2QiLCJwIjoiaiJ9). 


<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:    No