### PR TITLE
fix: update identify transfer to merge identify only

### DIFF
--- a/android/src/test/java/com/amplitude/android/IdentifyInterceptorTest.kt
+++ b/android/src/test/java/com/amplitude/android/IdentifyInterceptorTest.kt
@@ -210,19 +210,27 @@ class IdentifyInterceptorTest {
         val request: RecordedRequest? = runRequest()
         assertNotNull(request)
         val events = getEventsFromRequest(request!!)
-        assertEquals(2, events.size)
-        val expectedUserProperties = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2", "test-group-type" to "test-group-value")
+        assertEquals(3, events.size)
+        val expectedUserProperties = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2")
         assertEquals(Constants.IDENTIFY_EVENT, events[0].eventType)
         assertEquals(
             expectedUserProperties,
             events[0].userProperties?.get(IdentifyOperation.SET.operationType)
         )
-        assertEquals(mapOf("test-group-type" to "test-group-value"), events[0].groups)
-        val expectedUserProperties2 = mapOf("key3" to "key3-value3", "key4" to "key4-value3")
+
+        val expectedUserProperties1 = mapOf("test-group-type" to "test-group-value")
         assertEquals(Constants.IDENTIFY_EVENT, events[1].eventType)
         assertEquals(
-            expectedUserProperties2,
+            expectedUserProperties1,
             events[1].userProperties?.get(IdentifyOperation.SET.operationType)
+        )
+        assertEquals(mapOf("test-group-type" to "test-group-value"), events[1].groups)
+
+        val expectedUserProperties2 = mapOf("key3" to "key3-value3", "key4" to "key4-value3")
+        assertEquals(Constants.IDENTIFY_EVENT, events[2].eventType)
+        assertEquals(
+            expectedUserProperties2,
+            events[2].userProperties?.get(IdentifyOperation.SET.operationType)
         )
     }
 

--- a/android/src/test/java/com/amplitude/android/IdentifyInterceptorTest.kt
+++ b/android/src/test/java/com/amplitude/android/IdentifyInterceptorTest.kt
@@ -100,10 +100,13 @@ class IdentifyInterceptorTest {
         val request: RecordedRequest? = runRequest()
         assertNotNull(request)
         val events = getEventsFromRequest(request!!)
-        assertEquals(1, events.size)
-        val expectedUserProperties = mapOf("key1" to "key1-value3", "key2" to "key2-value3", "key3" to "key3-value2", "key4" to "key4-value2", "test_key" to "test_value")
-        assertEquals("test_event", events[0].eventType)
-        assertEquals(expectedUserProperties, events[0].userProperties)
+        assertEquals(2, events.size)
+        val expectedUserProperties1 = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2")
+        assertEquals(Constants.IDENTIFY_EVENT, events[0].eventType)
+        assertEquals(expectedUserProperties1, events[0].userProperties?.get(IdentifyOperation.SET.operationType))
+        val expectedUserProperties2 = mapOf("key1" to "key1-value3", "key2" to "key2-value3", "test_key" to "test_value")
+        assertEquals("test_event", events[1].eventType)
+        assertEquals(expectedUserProperties2, events[1].userProperties)
     }
 
     @Test
@@ -121,13 +124,16 @@ class IdentifyInterceptorTest {
         val request: RecordedRequest? = runRequest()
         assertNotNull(request)
         val events = getEventsFromRequest(request!!)
-        assertEquals(2, events.size)
-        val expectedUserProperties = mapOf("key1" to "key1-value3", "key2" to "key2-value3", "key3" to "key3-value2", "key4" to "key4-value2", "test_key" to "test_value")
-        assertEquals("test_event", events[0].eventType)
-        assertEquals(expectedUserProperties, events[0].userProperties)
-        val expectedUserProperties2 = mapOf("key1" to "key1-value4")
-        assertEquals(Constants.IDENTIFY_EVENT, events[1].eventType)
-        assertEquals(expectedUserProperties2, events[1].userProperties?.get(IdentifyOperation.SET.operationType))
+        assertEquals(3, events.size)
+        val expectedUserProperties1 = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2")
+        assertEquals(Constants.IDENTIFY_EVENT, events[0].eventType)
+        assertEquals(expectedUserProperties1, events[0].userProperties?.get(IdentifyOperation.SET.operationType))
+        val expectedUserProperties2 = mapOf("key1" to "key1-value3", "key2" to "key2-value3", "test_key" to "test_value")
+        assertEquals("test_event", events[1].eventType)
+        assertEquals(expectedUserProperties2, events[1].userProperties)
+        val expectedUserProperties3 = mapOf("key1" to "key1-value4")
+        assertEquals(Constants.IDENTIFY_EVENT, events[2].eventType)
+        assertEquals(expectedUserProperties3, events[2].userProperties?.get(IdentifyOperation.SET.operationType))
     }
 
     @Test

--- a/android/src/test/java/com/amplitude/android/IdentifyInterceptorTest.kt
+++ b/android/src/test/java/com/amplitude/android/IdentifyInterceptorTest.kt
@@ -164,16 +164,17 @@ class IdentifyInterceptorTest {
         val request: RecordedRequest? = runRequest()
         assertNotNull(request)
         val events = getEventsFromRequest(request!!)
-        assertEquals(1, events.size)
+        assertEquals(2, events.size)
         val expectedUserProperties = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2")
         assertEquals(Constants.IDENTIFY_EVENT, events[0].eventType)
         assertEquals(
             expectedUserProperties,
             events[0].userProperties?.get(IdentifyOperation.SET.operationType)
         )
+        assertEquals(Constants.IDENTIFY_EVENT, events[1].eventType)
         assertEquals(
             mapOf("key5" to 2),
-            events[0].userProperties?.get(IdentifyOperation.ADD.operationType)
+            events[1].userProperties?.get(IdentifyOperation.ADD.operationType)
         )
     }
 

--- a/core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptor.kt
+++ b/core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptor.kt
@@ -72,7 +72,8 @@ class IdentifyInterceptor(
             }
             else -> {
                 // fetch, merge and attach user properties
-                return fetchAndMergeToNormalEvent(event)
+                transferInterceptedIdentify()
+                return event
             }
         }
     }

--- a/core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptor.kt
+++ b/core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptor.kt
@@ -61,8 +61,14 @@ class IdentifyInterceptor(
                         event
                     }
                     else -> {
-                        // Fetch and merge event
-                        fetchAndMergeToIdentifyEvent(event)
+                        if (isSetGroups(event)) {
+                            // Fetch and merge event
+                            fetchAndMergeToIdentifyEvent(event)
+                        } else {
+                            // send out transfer event
+                            transferInterceptedIdentify()
+                            return event
+                        }
                     }
                 }
             }
@@ -71,7 +77,7 @@ class IdentifyInterceptor(
                 return event
             }
             else -> {
-                // fetch, merge and attach user properties
+                // send out transfer event
                 transferInterceptedIdentify()
                 return event
             }

--- a/core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptor.kt
+++ b/core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptor.kt
@@ -61,14 +61,9 @@ class IdentifyInterceptor(
                         event
                     }
                     else -> {
-                        if (isSetGroups(event)) {
-                            // Fetch and merge event
-                            fetchAndMergeToIdentifyEvent(event)
-                        } else {
-                            // send out transfer event
-                            transferInterceptedIdentify()
-                            return event
-                        }
+                        // send out transfer event
+                        transferInterceptedIdentify()
+                        return event
                     }
                 }
             }

--- a/core/src/test/kotlin/com/amplitude/core/IdentifyInterceptTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/IdentifyInterceptTest.kt
@@ -230,14 +230,19 @@ class IdentifyInterceptTest {
         val request: RecordedRequest? = runRequest()
         assertNotNull(request)
         val events = getEventsFromRequest(request!!)
-        assertEquals(2, events.size)
-        val expectedUserProperties = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2", "test-group-type" to "test-group-value")
+        assertEquals(3, events.size)
+        val expectedUserProperties = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2")
         assertEquals(Constants.IDENTIFY_EVENT, events[0].eventType)
         assertEquals(expectedUserProperties, events[0].userProperties?.get(IdentifyOperation.SET.operationType))
-        assertEquals(mapOf("test-group-type" to "test-group-value"), events[0].groups)
-        val expectedUserProperties2 = mapOf("key3" to "key3-value3", "key4" to "key4-value3")
+
+        val expectedUserProperties1 = mapOf("test-group-type" to "test-group-value")
         assertEquals(Constants.IDENTIFY_EVENT, events[1].eventType)
-        assertEquals(expectedUserProperties2, events[1].userProperties?.get(IdentifyOperation.SET.operationType))
+        assertEquals(expectedUserProperties1, events[1].userProperties?.get(IdentifyOperation.SET.operationType))
+        assertEquals(mapOf("test-group-type" to "test-group-value"), events[1].groups)
+
+        val expectedUserProperties2 = mapOf("key3" to "key3-value3", "key4" to "key4-value3")
+        assertEquals(Constants.IDENTIFY_EVENT, events[2].eventType)
+        assertEquals(expectedUserProperties2, events[2].userProperties?.get(IdentifyOperation.SET.operationType))
     }
 
     @ExperimentalCoroutinesApi

--- a/core/src/test/kotlin/com/amplitude/core/IdentifyInterceptTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/IdentifyInterceptTest.kt
@@ -185,11 +185,12 @@ class IdentifyInterceptTest {
         val request: RecordedRequest? = runRequest()
         assertNotNull(request)
         val events = getEventsFromRequest(request!!)
-        assertEquals(1, events.size)
+        assertEquals(2, events.size)
         val expectedUserProperties = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2")
         assertEquals(Constants.IDENTIFY_EVENT, events[0].eventType)
         assertEquals(expectedUserProperties, events[0].userProperties?.get(IdentifyOperation.SET.operationType))
-        assertEquals(mapOf("key5" to 2), events[0].userProperties?.get(IdentifyOperation.ADD.operationType))
+        assertEquals(Constants.IDENTIFY_EVENT, events[1].eventType)
+        assertEquals(mapOf("key5" to 2), events[1].userProperties?.get(IdentifyOperation.ADD.operationType))
     }
 
     @ExperimentalCoroutinesApi

--- a/core/src/test/kotlin/com/amplitude/core/IdentifyInterceptTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/IdentifyInterceptTest.kt
@@ -23,12 +23,10 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.concurrent.TimeUnit
 
-@Disabled
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class IdentifyInterceptTest {
     private lateinit var server: MockWebServer
@@ -102,10 +100,16 @@ class IdentifyInterceptTest {
         val request: RecordedRequest? = runRequest()
         assertNotNull(request)
         val events = getEventsFromRequest(request!!)
-        assertEquals(1, events.size)
-        val expectedUserProperties = mapOf("key1" to "key1-value3", "key2" to "key2-value3", "key3" to "key3-value2", "key4" to "key4-value2", "test_key" to "test_value")
-        assertEquals("test_event", events[0].eventType)
-        assertEquals(expectedUserProperties, events[0].userProperties)
+        assertEquals(2, events.size)
+        val expectedUserProperties1 = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2")
+        assertEquals(Constants.IDENTIFY_EVENT, events[0].eventType)
+        assertEquals(
+            expectedUserProperties1,
+            events[0].userProperties?.get(IdentifyOperation.SET.operationType)
+        )
+        val expectedUserProperties2 = mapOf("key1" to "key1-value3", "key2" to "key2-value3", "test_key" to "test_value")
+        assertEquals("test_event", events[1].eventType)
+        assertEquals(expectedUserProperties2, events[1].userProperties)
     }
 
     @ExperimentalCoroutinesApi
@@ -127,13 +131,22 @@ class IdentifyInterceptTest {
         val request: RecordedRequest? = runRequest()
         assertNotNull(request)
         val events = getEventsFromRequest(request!!)
-        assertEquals(2, events.size)
-        val expectedUserProperties = mapOf("key1" to "key1-value3", "key2" to "key2-value3", "key3" to "key3-value2", "key4" to "key4-value2", "test_key" to "test_value")
-        assertEquals("test_event", events[0].eventType)
-        assertEquals(expectedUserProperties, events[0].userProperties)
-        val expectedUserProperties2 = mapOf("key1" to "key1-value4")
-        assertEquals(Constants.IDENTIFY_EVENT, events[1].eventType)
-        assertEquals(expectedUserProperties2, events[1].userProperties?.get(IdentifyOperation.SET.operationType))
+        assertEquals(3, events.size)
+        val expectedUserProperties1 = mapOf("key1" to "key1-value2", "key2" to "key2-value2", "key3" to "key3-value2", "key4" to "key4-value2")
+        assertEquals(Constants.IDENTIFY_EVENT, events[0].eventType)
+        assertEquals(
+            expectedUserProperties1,
+            events[0].userProperties?.get(IdentifyOperation.SET.operationType)
+        )
+        val expectedUserProperties2 = mapOf("key1" to "key1-value3", "key2" to "key2-value3", "test_key" to "test_value")
+        assertEquals("test_event", events[1].eventType)
+        assertEquals(expectedUserProperties2, events[1].userProperties)
+        val expectedUserProperties3 = mapOf("key1" to "key1-value4")
+        assertEquals(Constants.IDENTIFY_EVENT, events[2].eventType)
+        assertEquals(
+            expectedUserProperties3,
+            events[2].userProperties?.get(IdentifyOperation.SET.operationType)
+        )
     }
 
     @ExperimentalCoroutinesApi


### PR DESCRIPTION
### Summary

- update identify transfer to merge identify only for now.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no