### PR TITLE
fix: do not fetch advertising Id if adid tracking is disabled

### DIFF
--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -17,7 +17,11 @@ class AndroidContextPlugin : Plugin {
     override fun setup(amplitude: Amplitude) {
         super.setup(amplitude)
         val configuration = amplitude.configuration as Configuration
-        contextProvider = AndroidContextProvider(configuration.context, configuration.locationListening)
+        contextProvider = AndroidContextProvider(
+            configuration.context,
+            configuration.locationListening,
+            configuration.trackingOptions.shouldTrackAdid()
+        )
         initializeDeviceId(configuration)
     }
 

--- a/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt
+++ b/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt
@@ -23,9 +23,10 @@ import java.util.Locale
 import java.util.UUID
 import kotlin.collections.ArrayList
 
-class AndroidContextProvider(private val context: Context, locationListening: Boolean) :
+class AndroidContextProvider(private val context: Context, locationListening: Boolean, shouldTrackAdid: Boolean) :
     ContextProvider {
     var isLocationListening = true
+    var shouldTrackAdid = true
     private var cachedInfo: CachedInfo? = null
         get() {
             if (field == null) {
@@ -204,6 +205,10 @@ class AndroidContextProvider(private val context: Context, locationListening: Bo
         }
 
         private fun fetchAdvertisingId(): String? {
+            if (!shouldTrackAdid) {
+                return null
+            }
+
             // This should not be called on the main thread.
             return if ("Amazon" == fetchManufacturer()) {
                 fetchAndCacheAmazonAdvertisingId
@@ -424,5 +429,6 @@ class AndroidContextProvider(private val context: Context, locationListening: Bo
 
     init {
         isLocationListening = locationListening
+        this.shouldTrackAdid = shouldTrackAdid
     }
 }


### PR DESCRIPTION
Additional note: in Android-Kotlin default value for `limitAdTrackingEnabled` is `true`, in Amplitude-Android - `false`
* https://github.com/amplitude/Amplitude-Kotlin/blob/main/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt#L51
* https://github.com/amplitude/Amplitude-Android/blob/main/src/main/java/com/amplitude/api/DeviceInfo.java#L56

Maybe if adid tracking is disabled `limitAdTrackingEnabled` should be `null`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no