### PR TITLE
fix: make default tracking options java compatible

### DIFF
--- a/android/src/main/java/com/amplitude/android/DefaultTrackingOptions.kt
+++ b/android/src/main/java/com/amplitude/android/DefaultTrackingOptions.kt
@@ -1,6 +1,6 @@
 package com.amplitude.android
 
-class DefaultTrackingOptions(
+open class DefaultTrackingOptions @JvmOverloads constructor(
     var sessions: Boolean = true,
     var appLifecycles: Boolean = false,
     var deepLinks: Boolean = false,
@@ -8,12 +8,15 @@ class DefaultTrackingOptions(
 ) {
     // Prebuilt options for easier usage
     companion object {
+        @JvmField
         val ALL = DefaultTrackingOptions(
             sessions = true,
             appLifecycles = true,
             deepLinks = true,
             screenViews = true
         )
+
+        @JvmField
         val NONE = DefaultTrackingOptions(
             sessions = false,
             appLifecycles = false,


### PR DESCRIPTION
### Summary
- fix: make default tracking options java compatible

`@JvmField` makes the field accessible, see https://www.baeldung.com/kotlin/jvm-field-annotation.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->