### PR TITLE
fix: enable legacy data migration by default

### DIFF
--- a/android/src/main/java/com/amplitude/android/Configuration.kt
+++ b/android/src/main/java/com/amplitude/android/Configuration.kt
@@ -45,7 +45,7 @@ open class Configuration @JvmOverloads constructor(
     override var identifyBatchIntervalMillis: Long = IDENTIFY_BATCH_INTERVAL_MILLIS,
     override var identifyInterceptStorageProvider: StorageProvider = AndroidStorageProvider(),
     override var identityStorageProvider: IdentityStorageProvider = FileIdentityStorageProvider(),
-    var migrateLegacyData: Boolean = false,
+    var migrateLegacyData: Boolean = true,
 ) : Configuration(apiKey, flushQueueSize, flushIntervalMillis, instanceName, optOut, storageProvider, loggerProvider, minIdLength, partnerId, callback, flushMaxRetries, useBatch, serverZone, serverUrl, plan, ingestionMetadata, identifyBatchIntervalMillis, identifyInterceptStorageProvider, identityStorageProvider) {
     companion object {
         const val MIN_TIME_BETWEEN_SESSIONS_MILLIS: Long = 300000


### PR DESCRIPTION
### Summary

Enable `migrateLegacyData` configuration option by default.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No