### PR TITLE
fix: wait until build (including possible legacy data migration) is finished

### DIFF
--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -21,6 +21,9 @@ class Timeline : Timeline() {
 
     internal fun start() {
         amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
+            // Wait until build (including possible legacy data migration) is finished.
+            amplitude.isBuilt.await()
+
             _sessionId.set(amplitude.storage.read(Storage.Constants.PREVIOUS_SESSION_ID)?.toLongOrNull() ?: -1)
             lastEventId = amplitude.storage.read(Storage.Constants.LAST_EVENT_ID)?.toLongOrNull() ?: 0
             lastEventTime = amplitude.storage.read(Storage.Constants.LAST_EVENT_TIME)?.toLongOrNull() ?: -1


### PR DESCRIPTION
### Summary

Wait until build (including possible legacy data migration) is finished - otherwise legacy data (previous session id, last event time/id) can be not saved to the storage yet.
The fix doesn't help with original issue (mailformed json).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no