### PR TITLE
fix: wait until build (including possible legacy data migration) is finished

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   authorize:
     name: Authorize
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: ${{ github.actor }} permission check to do a release
         uses: "lannonbr/repo-permission-check-action@2.0.2"
@@ -22,7 +22,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [authorize]
     steps:
       - name: Checkout

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -21,6 +21,9 @@ class Timeline : Timeline() {
 
     internal fun start() {
         amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
+            // Wait until build (including possible legacy data migration) is finished.
+            amplitude.isBuilt.await()
+
             _sessionId.set(amplitude.storage.read(Storage.Constants.PREVIOUS_SESSION_ID)?.toLongOrNull() ?: -1)
             lastEventId = amplitude.storage.read(Storage.Constants.LAST_EVENT_ID)?.toLongOrNull() ?: 0
             lastEventTime = amplitude.storage.read(Storage.Constants.LAST_EVENT_TIME)?.toLongOrNull() ?: -1


### PR DESCRIPTION
1. Revert reverted commit
2. Run the release action on ubuntu-20.04

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no