### PR TITLE
feat: migrate 'api key' storage data to 'instance name' storage

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -1,13 +1,12 @@
 package com.amplitude.android
 
 import android.content.Context
+import com.amplitude.android.migration.ApiKeyStorageMigration
 import com.amplitude.android.migration.RemnantDataMigration
-import com.amplitude.android.migration.StorageKeyMigration
 import com.amplitude.android.plugins.AnalyticsConnectorIdentityPlugin
 import com.amplitude.android.plugins.AnalyticsConnectorPlugin
 import com.amplitude.android.plugins.AndroidContextPlugin
 import com.amplitude.android.plugins.AndroidLifecyclePlugin
-import com.amplitude.android.utilities.AndroidStorage
 import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.plugins.AmplitudeDestination
@@ -50,7 +49,7 @@ open class Amplitude(
     }
 
     override suspend fun buildInternal(identityConfiguration: IdentityConfiguration) {
-        migrateApiKeyStorages()
+        ApiKeyStorageMigration(this).execute()
 
         if ((this.configuration as Configuration).migrateLegacyData) {
             RemnantDataMigration(this).execute()
@@ -119,22 +118,6 @@ open class Amplitude(
                 (this@Amplitude.timeline as Timeline).stop()
             }
         })
-    }
-
-    private suspend fun migrateApiKeyStorages() {
-        val configuration = this.configuration as Configuration
-
-        val storage = storage as? AndroidStorage
-        if (storage != null) {
-            val apiKeyStorage = AndroidStorage(configuration.context, configuration.apiKey, logger, storage.prefix)
-            StorageKeyMigration(apiKeyStorage, storage, logger).execute()
-        }
-
-        val identifyInterceptStorage = identifyInterceptStorage as? AndroidStorage
-        if (identifyInterceptStorage != null) {
-            val apiKeyStorage = AndroidStorage(configuration.context, configuration.apiKey, logger, identifyInterceptStorage.prefix)
-            StorageKeyMigration(apiKeyStorage, identifyInterceptStorage, logger).execute()
-        }
     }
 
     companion object {

--- a/android/src/main/java/com/amplitude/android/migration/ApiKeyStorageMigration.kt
+++ b/android/src/main/java/com/amplitude/android/migration/ApiKeyStorageMigration.kt
@@ -1,0 +1,26 @@
+package com.amplitude.android.migration
+
+import com.amplitude.android.Amplitude
+import com.amplitude.android.Configuration
+import com.amplitude.android.utilities.AndroidStorage
+
+class ApiKeyStorageMigration(
+    private val amplitude: Amplitude
+) {
+    suspend fun execute() {
+        val configuration = amplitude.configuration as Configuration
+        val logger = amplitude.logger
+
+        val storage = amplitude.storage as? AndroidStorage
+        if (storage != null) {
+            val apiKeyStorage = AndroidStorage(configuration.context, configuration.apiKey, logger, storage.prefix)
+            StorageKeyMigration(apiKeyStorage, storage, logger).execute()
+        }
+
+        val identifyInterceptStorage = amplitude.identifyInterceptStorage as? AndroidStorage
+        if (identifyInterceptStorage != null) {
+            val apiKeyStorage = AndroidStorage(configuration.context, configuration.apiKey, logger, identifyInterceptStorage.prefix)
+            StorageKeyMigration(apiKeyStorage, identifyInterceptStorage, logger).execute()
+        }
+    }
+}

--- a/android/src/main/java/com/amplitude/android/migration/StorageKeyMigration.kt
+++ b/android/src/main/java/com/amplitude/android/migration/StorageKeyMigration.kt
@@ -52,7 +52,7 @@ class StorageKeyMigration(
         }
     }
 
-    private fun moveSimpleValues() {
+    private suspend fun moveSimpleValues() {
         moveSimpleValue(Storage.Constants.PREVIOUS_SESSION_ID)
         moveSimpleValue(Storage.Constants.LAST_EVENT_TIME)
         moveSimpleValue(Storage.Constants.LAST_EVENT_ID)
@@ -65,7 +65,7 @@ class StorageKeyMigration(
         moveFileIndex()
     }
 
-    private fun moveSimpleValue(key: Storage.Constants) {
+    private suspend fun moveSimpleValue(key: Storage.Constants) {
         try {
             val sourceValue = source.read(key) ?: return
 

--- a/android/src/main/java/com/amplitude/android/migration/StorageKeyMigration.kt
+++ b/android/src/main/java/com/amplitude/android/migration/StorageKeyMigration.kt
@@ -1,0 +1,106 @@
+package com.amplitude.android.migration
+
+import com.amplitude.android.utilities.AndroidStorage
+import com.amplitude.common.Logger
+import com.amplitude.core.Storage
+import java.io.File
+import java.util.UUID
+
+class StorageKeyMigration(
+    private val source: AndroidStorage,
+    private val destination: AndroidStorage,
+    private val logger: Logger
+) {
+    suspend fun execute() {
+        if (source.storageKey == destination.storageKey) {
+            return
+        }
+        moveSourceEventFilesToDestination()
+        moveSimpleValues()
+    }
+
+    private suspend fun moveSourceEventFilesToDestination() {
+        try {
+            source.rollover()
+            val sourceEventFiles = source.readEventsContent() as List<String>
+            if (sourceEventFiles.isEmpty()) {
+                return
+            }
+
+            for (sourceEventFilePath in sourceEventFiles) {
+                val sourceEventFile = File(sourceEventFilePath)
+                var destinationEventFile =
+                    File(sourceEventFilePath.replace(source.storageKey, destination.storageKey))
+                if (destinationEventFile.exists()) {
+                    var fileExtension = destinationEventFile.extension
+                    if (fileExtension != "") {
+                        fileExtension = ".$fileExtension"
+                    }
+                    destinationEventFile = File(
+                        destinationEventFile.parent,
+                        "${destinationEventFile.nameWithoutExtension}-${UUID.randomUUID()}$fileExtension"
+                    )
+                }
+                try {
+                    sourceEventFile.renameTo(destinationEventFile)
+                } catch (e: Exception) {
+                    logger.error("can't rename $sourceEventFile to $destinationEventFile: ${e.message}")
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("can't move event files: ${e.message}")
+        }
+    }
+
+    private fun moveSimpleValues() {
+        moveSimpleValue(Storage.Constants.PREVIOUS_SESSION_ID)
+        moveSimpleValue(Storage.Constants.LAST_EVENT_TIME)
+        moveSimpleValue(Storage.Constants.LAST_EVENT_ID)
+
+        moveSimpleValue(Storage.Constants.OPT_OUT)
+        moveSimpleValue(Storage.Constants.Events)
+        moveSimpleValue(Storage.Constants.APP_VERSION)
+        moveSimpleValue(Storage.Constants.APP_BUILD)
+
+        moveFileIndex()
+    }
+
+    private fun moveSimpleValue(key: Storage.Constants) {
+        try {
+            val sourceValue = source.read(key) ?: return
+
+            val destinationValue = destination.read(key)
+            if (destinationValue == null) {
+                try {
+                    destination.write(key, sourceValue)
+                } catch (e: Exception) {
+                    logger.error("can't write destination $key: ${e.message}")
+                    return
+                }
+            }
+
+            source.remove(key)
+        } catch (e: Exception) {
+            logger.error("can't move $key: ${e.message}")
+        }
+    }
+
+    private fun moveFileIndex() {
+        try {
+            val sourceFileIndexKey = "amplitude.events.file.index.${source.storageKey}"
+            val destinationFileIndexKey = "amplitude.events.file.index.${destination.storageKey}"
+            if (source.sharedPreferences.contains(sourceFileIndexKey)) {
+                val fileIndex = source.sharedPreferences.getLong(sourceFileIndexKey, -1)
+                try {
+                    destination.sharedPreferences.edit().putLong(destinationFileIndexKey, fileIndex).commit()
+                } catch (e: Exception) {
+                    logger.error("can't write file index: ${e.message}")
+                    return
+                }
+                source.sharedPreferences.edit().remove(sourceFileIndexKey).commit()
+            }
+        } catch (e: Exception) {
+            logger.error("can't move file index: ${e.message}")
+        }
+    }
+}

--- a/android/src/main/java/com/amplitude/android/utilities/AndroidStorage.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidStorage.kt
@@ -47,11 +47,11 @@ class AndroidStorage(
         }
     }
 
-    override fun write(key: Storage.Constants, value: String) {
+    override suspend fun write(key: Storage.Constants, value: String) {
         sharedPreferences.edit().putString(key.rawVal, value).apply()
     }
 
-    override fun remove(key: Storage.Constants) {
+    override suspend fun remove(key: Storage.Constants) {
         sharedPreferences.edit().remove(key.rawVal).apply()
     }
 

--- a/android/src/test/java/com/amplitude/android/migration/StorageKeyMigrationTest.kt
+++ b/android/src/test/java/com/amplitude/android/migration/StorageKeyMigrationTest.kt
@@ -26,9 +26,11 @@ class StorageKeyMigrationTest {
         val sourceFileIndexKey = "amplitude.events.file.index.${source.storageKey}"
         val destinationFileIndexKey = "amplitude.events.file.index.${destination.storageKey}"
 
-        source.write(Storage.Constants.PREVIOUS_SESSION_ID, "123")
-        source.write(Storage.Constants.LAST_EVENT_TIME, "456")
-        source.write(Storage.Constants.LAST_EVENT_ID, "789")
+        runBlocking {
+            source.write(Storage.Constants.PREVIOUS_SESSION_ID, "123")
+            source.write(Storage.Constants.LAST_EVENT_TIME, "456")
+            source.write(Storage.Constants.LAST_EVENT_ID, "789")
+        }
         source.sharedPreferences.edit().putLong(sourceFileIndexKey, 1234567).commit()
 
         var destinationPreviousSessionId = destination.read(Storage.Constants.PREVIOUS_SESSION_ID)

--- a/android/src/test/java/com/amplitude/android/migration/StorageKeyMigrationTest.kt
+++ b/android/src/test/java/com/amplitude/android/migration/StorageKeyMigrationTest.kt
@@ -1,0 +1,195 @@
+package com.amplitude.android.migration
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.amplitude.android.utilities.AndroidStorage
+import com.amplitude.common.jvm.ConsoleLogger
+import com.amplitude.core.Storage
+import com.amplitude.core.events.BaseEvent
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.jupiter.api.Assertions
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class StorageKeyMigrationTest {
+    @Test
+    fun `simple values should be migrated`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val logger = ConsoleLogger()
+
+        val source = AndroidStorage(context, UUID.randomUUID().toString(), logger, null)
+        val destination = AndroidStorage(context, UUID.randomUUID().toString(), logger, null)
+        val sourceFileIndexKey = "amplitude.events.file.index.${source.storageKey}"
+        val destinationFileIndexKey = "amplitude.events.file.index.${destination.storageKey}"
+
+        source.write(Storage.Constants.PREVIOUS_SESSION_ID, "123")
+        source.write(Storage.Constants.LAST_EVENT_TIME, "456")
+        source.write(Storage.Constants.LAST_EVENT_ID, "789")
+        source.sharedPreferences.edit().putLong(sourceFileIndexKey, 1234567).commit()
+
+        var destinationPreviousSessionId = destination.read(Storage.Constants.PREVIOUS_SESSION_ID)
+        var destinationLastEventTime = destination.read(Storage.Constants.LAST_EVENT_TIME)
+        var destinationLastEventId = destination.read(Storage.Constants.LAST_EVENT_ID)
+        var destinationFileIndex = destination.sharedPreferences.getLong(destinationFileIndexKey, -1)
+
+        Assertions.assertNull(destinationPreviousSessionId)
+        Assertions.assertNull(destinationLastEventTime)
+        Assertions.assertNull(destinationLastEventId)
+        Assertions.assertEquals(-1, destinationFileIndex)
+
+        val migration = StorageKeyMigration(source, destination, logger)
+        runBlocking {
+            migration.execute()
+        }
+
+        val sourcePreviousSessionId = source.read(Storage.Constants.PREVIOUS_SESSION_ID)
+        val sourceLastEventTime = source.read(Storage.Constants.LAST_EVENT_TIME)
+        val sourceLastEventId = source.read(Storage.Constants.LAST_EVENT_ID)
+        val sourceFileIndex = source.sharedPreferences.getLong(sourceFileIndexKey, -1)
+
+        Assertions.assertNull(sourcePreviousSessionId)
+        Assertions.assertNull(sourceLastEventTime)
+        Assertions.assertNull(sourceLastEventId)
+        Assertions.assertEquals(-1, sourceFileIndex)
+
+        destinationPreviousSessionId = destination.read(Storage.Constants.PREVIOUS_SESSION_ID)
+        destinationLastEventTime = destination.read(Storage.Constants.LAST_EVENT_TIME)
+        destinationLastEventId = destination.read(Storage.Constants.LAST_EVENT_ID)
+        destinationFileIndex = destination.sharedPreferences.getLong(destinationFileIndexKey, -1)
+
+        Assertions.assertEquals("123", destinationPreviousSessionId)
+        Assertions.assertEquals("456", destinationLastEventTime)
+        Assertions.assertEquals("789", destinationLastEventId)
+        Assertions.assertEquals(1234567, destinationFileIndex)
+    }
+
+    @Test
+    fun `event files should be migrated`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val logger = ConsoleLogger()
+
+        val source = AndroidStorage(context, UUID.randomUUID().toString(), logger, null)
+        val destination = AndroidStorage(context, UUID.randomUUID().toString(), logger, null)
+
+        runBlocking {
+            source.writeEvent(createEvent(1))
+            source.writeEvent(createEvent(22))
+            source.rollover()
+            source.writeEvent(createEvent(333))
+            source.rollover()
+            source.writeEvent(createEvent(4444))
+            source.rollover()
+        }
+
+        var sourceEventFiles = source.readEventsContent() as List<String>
+        Assertions.assertEquals(3, sourceEventFiles.size)
+
+        val sourceFileSizes = sourceEventFiles.map { File(it).length() }
+
+        var destinationEventFiles = destination.readEventsContent() as List<String>
+        Assertions.assertEquals(0, destinationEventFiles.size)
+
+        val migration = StorageKeyMigration(source, destination, logger)
+        runBlocking {
+            migration.execute()
+        }
+
+        sourceEventFiles = source.readEventsContent() as List<String>
+        Assertions.assertEquals(0, sourceEventFiles.size)
+
+        destinationEventFiles = destination.readEventsContent() as List<String>
+        Assertions.assertEquals(3, destinationEventFiles.size)
+
+        for ((index, destinationEventFile) in destinationEventFiles.withIndex()) {
+            val fileSize = File(destinationEventFile).length()
+            Assertions.assertEquals(sourceFileSizes[index], fileSize)
+        }
+    }
+
+    @Test
+    fun `missing source should not fail`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val logger = ConsoleLogger()
+
+        val source = AndroidStorage(context, UUID.randomUUID().toString(), logger, null)
+        val destination = AndroidStorage(context, UUID.randomUUID().toString(), logger, null)
+
+        var destinationPreviousSessionId = destination.read(Storage.Constants.PREVIOUS_SESSION_ID)
+        var destinationLastEventTime = destination.read(Storage.Constants.LAST_EVENT_TIME)
+        var destinationLastEventId = destination.read(Storage.Constants.LAST_EVENT_ID)
+
+        Assertions.assertNull(destinationPreviousSessionId)
+        Assertions.assertNull(destinationLastEventTime)
+        Assertions.assertNull(destinationLastEventId)
+
+        val migration = StorageKeyMigration(source, destination, logger)
+        runBlocking {
+            migration.execute()
+        }
+
+        destinationPreviousSessionId = destination.read(Storage.Constants.PREVIOUS_SESSION_ID)
+        destinationLastEventTime = destination.read(Storage.Constants.LAST_EVENT_TIME)
+        destinationLastEventId = destination.read(Storage.Constants.LAST_EVENT_ID)
+
+        Assertions.assertNull(destinationPreviousSessionId)
+        Assertions.assertNull(destinationLastEventTime)
+        Assertions.assertNull(destinationLastEventId)
+
+        val destinationEventFiles = destination.readEventsContent() as List<String>
+        Assertions.assertEquals(0, destinationEventFiles.size)
+    }
+
+    @Test
+    fun `event files with duplicated names should be migrated`() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val logger = ConsoleLogger()
+
+        val source = AndroidStorage(context, UUID.randomUUID().toString(), logger, null)
+        val destination = AndroidStorage(context, UUID.randomUUID().toString(), logger, null)
+
+        runBlocking {
+            source.writeEvent(createEvent(1))
+            source.rollover()
+            source.writeEvent(createEvent(22))
+            source.rollover()
+        }
+
+        val sourceEventFiles = source.readEventsContent() as List<String>
+        Assertions.assertEquals(2, sourceEventFiles.size)
+
+        val sourceFileSizes = sourceEventFiles.map { File(it).length() }
+
+        runBlocking {
+            destination.writeEvent(createEvent(333))
+            destination.rollover()
+        }
+
+        var destinationEventFiles = destination.readEventsContent() as List<String>
+        Assertions.assertEquals(1, destinationEventFiles.size)
+
+        val destinationFileSizes = destinationEventFiles.map { File(it).length() }
+
+        val migration = StorageKeyMigration(source, destination, logger)
+        runBlocking {
+            migration.execute()
+        }
+
+        destinationEventFiles = destination.readEventsContent() as List<String>
+        Assertions.assertEquals("-0", destinationEventFiles[0].substring(destinationEventFiles[0].length - 2))
+        Assertions.assertTrue(destinationEventFiles[1].contains("-0-"))
+        Assertions.assertEquals("-1", destinationEventFiles[2].substring(destinationEventFiles[0].length - 2))
+        Assertions.assertEquals(destinationFileSizes[0], File(destinationEventFiles[0]).length())
+        Assertions.assertEquals(sourceFileSizes[0], File(destinationEventFiles[1]).length())
+        Assertions.assertEquals(sourceFileSizes[1], File(destinationEventFiles[2]).length())
+    }
+
+    private fun createEvent(eventIndex: Int): BaseEvent {
+        val event = BaseEvent()
+        event.eventType = "event-$eventIndex"
+        return event
+    }
+}

--- a/core/src/main/java/com/amplitude/core/Storage.kt
+++ b/core/src/main/java/com/amplitude/core/Storage.kt
@@ -20,7 +20,9 @@ interface Storage {
 
     suspend fun writeEvent(event: BaseEvent)
 
-    suspend fun write(key: Constants, value: String)
+    fun write(key: Constants, value: String)
+
+    fun remove(key: Constants)
 
     suspend fun rollover()
 

--- a/core/src/main/java/com/amplitude/core/Storage.kt
+++ b/core/src/main/java/com/amplitude/core/Storage.kt
@@ -20,9 +20,9 @@ interface Storage {
 
     suspend fun writeEvent(event: BaseEvent)
 
-    fun write(key: Constants, value: String)
+    suspend fun write(key: Constants, value: String)
 
-    fun remove(key: Constants)
+    suspend fun remove(key: Constants)
 
     suspend fun rollover()
 

--- a/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
@@ -44,11 +44,11 @@ class FileStorage(
         }
     }
 
-    override fun write(key: Storage.Constants, value: String) {
+    override suspend fun write(key: Storage.Constants, value: String) {
         propertiesFile.putString(key.rawVal, value)
     }
 
-    override fun remove(key: Storage.Constants) {
+    override suspend fun remove(key: Storage.Constants) {
         propertiesFile.remove(key.rawVal)
     }
 

--- a/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/FileStorage.kt
@@ -15,7 +15,7 @@ import org.json.JSONArray
 import java.io.File
 
 class FileStorage(
-    private val apiKey: String,
+    storageKey: String,
     private val logger: Logger,
     private val prefix: String?
 ) : Storage, EventsFileStorage {
@@ -24,12 +24,12 @@ class FileStorage(
         const val STORAGE_PREFIX = "amplitude-kotlin"
     }
 
-    private val storageDirectory = File("/tmp/${getPrefix()}/$apiKey")
+    private val storageDirectory = File("/tmp/${getPrefix()}/$storageKey")
     private val storageDirectoryEvents = File(storageDirectory, "events")
 
-    internal val propertiesFile = PropertiesFile(storageDirectory, apiKey, getPrefix(), null)
-    internal val eventsFile = EventsFileManager(storageDirectoryEvents, apiKey, propertiesFile)
-    val eventCallbacksMap = mutableMapOf<String, EventCallBack>()
+    private val propertiesFile = PropertiesFile(storageDirectory, storageKey, getPrefix(), null)
+    private val eventsFile = EventsFileManager(storageDirectoryEvents, storageKey, propertiesFile)
+    private val eventCallbacksMap = mutableMapOf<String, EventCallBack>()
 
     init {
         propertiesFile.load()
@@ -44,8 +44,12 @@ class FileStorage(
         }
     }
 
-    override suspend fun write(key: Storage.Constants, value: String) {
+    override fun write(key: Storage.Constants, value: String) {
         propertiesFile.putString(key.rawVal, value)
+    }
+
+    override fun remove(key: Storage.Constants) {
+        propertiesFile.remove(key.rawVal)
     }
 
     override suspend fun rollover() {
@@ -110,7 +114,7 @@ class FileStorage(
 class FileStorageProvider : StorageProvider {
     override fun getStorage(amplitude: Amplitude, prefix: String?): Storage {
         return FileStorage(
-            amplitude.configuration.apiKey,
+            amplitude.configuration.instanceName,
             amplitude.configuration.loggerProvider.getLogger(amplitude),
             prefix
         )

--- a/core/src/main/java/com/amplitude/core/utilities/InMemoryStorage.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/InMemoryStorage.kt
@@ -22,11 +22,11 @@ class InMemoryStorage : Storage {
         }
     }
 
-    override fun write(key: Storage.Constants, value: String) {
+    override suspend fun write(key: Storage.Constants, value: String) {
         valuesMap[key.rawVal] = value
     }
 
-    override fun remove(key: Storage.Constants) {
+    override suspend fun remove(key: Storage.Constants) {
         valuesMap.remove(key.rawVal)
     }
 

--- a/core/src/main/java/com/amplitude/core/utilities/InMemoryStorage.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/InMemoryStorage.kt
@@ -22,8 +22,12 @@ class InMemoryStorage : Storage {
         }
     }
 
-    override suspend fun write(key: Storage.Constants, value: String) {
-        valuesMap.put(key.rawVal, value)
+    override fun write(key: Storage.Constants, value: String) {
+        valuesMap[key.rawVal] = value
+    }
+
+    override fun remove(key: Storage.Constants) {
+        valuesMap.remove(key.rawVal)
     }
 
     override suspend fun rollover() {


### PR DESCRIPTION
### Summary

Migrate 'api key' storage data to 'instance name' storage.
Implementation and test are similar to Amplitude-Swift (https://github.com/amplitude/Amplitude-Swift/pull/63)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No