### PR TITLE
fix: do not throw NotImplemented error for existing "legacy database"file if the file is not a sqlite file

### DIFF
--- a/android/src/main/java/com/amplitude/android/migration/DatabaseStorage.kt
+++ b/android/src/main/java/com/amplitude/android/migration/DatabaseStorage.kt
@@ -46,11 +46,13 @@ class DatabaseStorage(context: Context, databaseName: String) : SQLiteOpenHelper
     DatabaseConstants.DATABASE_VERSION
 ) {
     private var file: File = context.getDatabasePath(databaseName)
+    private var isValidDatabaseFile = true
     var currentDbVersion: Int = DatabaseConstants.DATABASE_VERSION
         private set
 
     override fun onCreate(db: SQLiteDatabase) {
-        throw NotImplementedError()
+        // File exists but it is not a legacy database for some reason.
+        this.isValidDatabaseFile = false
     }
 
     override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int, newVersion: Int) {
@@ -121,6 +123,10 @@ class DatabaseStorage(context: Context, databaseName: String) : SQLiteOpenHelper
         var cursor: Cursor? = null
         try {
             val db = readableDatabase
+            if (!isValidDatabaseFile) {
+                return arrayListOf()
+            }
+
             cursor = queryDb(
                 db,
                 table,
@@ -220,6 +226,10 @@ class DatabaseStorage(context: Context, databaseName: String) : SQLiteOpenHelper
         var cursor: Cursor? = null
         try {
             val db = readableDatabase
+            if (!isValidDatabaseFile) {
+                return null
+            }
+
             cursor = queryDb(
                 db,
                 table,

--- a/android/src/test/java/com/amplitude/android/migration/DatabaseStorageTest.kt
+++ b/android/src/test/java/com/amplitude/android/migration/DatabaseStorageTest.kt
@@ -34,13 +34,6 @@ class DatabaseStorageTest {
     }
 
     @Test
-    fun databaseStorage_onCreate_throwsNotImplementedError() {
-        Assertions.assertThrows(NotImplementedError::class.java) {
-            databaseStorage?.onCreate(db!!)
-        }
-    }
-
-    @Test
     fun databaseStorage_onUpgrade_shouldSaveCurrentDbVersion() {
         Assertions.assertEquals(DatabaseConstants.DATABASE_VERSION, databaseStorage?.currentDbVersion)
         databaseStorage?.onUpgrade(db, 1, 2)

--- a/android/src/test/java/com/amplitude/android/migration/DatabaseStorageTest.kt
+++ b/android/src/test/java/com/amplitude/android/migration/DatabaseStorageTest.kt
@@ -3,6 +3,7 @@ package com.amplitude.android.migration
 import android.content.Context
 import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
+import com.amplitude.common.jvm.ConsoleLogger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
@@ -29,7 +30,7 @@ class DatabaseStorageTest {
     @BeforeEach
     fun setUp() {
         context = mockk(relaxed = true)
-        databaseStorage = DatabaseStorage(context!!, "")
+        databaseStorage = DatabaseStorage(context!!, "", ConsoleLogger())
         db = mockk()
     }
 
@@ -57,7 +58,7 @@ class DatabaseStorageTest {
         every { anyConstructed<JSONObject>().put(any(), any<Long>()) } returns JSONObject()
         every { anyConstructed<JSONObject>().get("event_id") } returnsMany listOf(1, 2)
 
-        val mockedDatabaseStorage = spyk(DatabaseStorage(context!!, ""), recordPrivateCalls = true)
+        val mockedDatabaseStorage = spyk(DatabaseStorage(context!!, "", ConsoleLogger()), recordPrivateCalls = true)
         every {
             mockedDatabaseStorage["queryDb"](
                 any<SQLiteDatabase>(),
@@ -79,7 +80,7 @@ class DatabaseStorageTest {
 
     @Test
     fun databaseStorage_removeEvent_returnsEventsContent() {
-        val mockedDatabaseStorage = spyk(DatabaseStorage(context!!, ""), recordPrivateCalls = true)
+        val mockedDatabaseStorage = spyk(DatabaseStorage(context!!, "", ConsoleLogger()), recordPrivateCalls = true)
         every { mockedDatabaseStorage.close() } answers { nothing }
         every { mockedDatabaseStorage.writableDatabase } returns db
         every { db!!.delete(any(), any(), arrayOf("2")) } returns 2

--- a/android/src/test/java/com/amplitude/android/migration/RemnantDataMigrationTest.kt
+++ b/android/src/test/java/com/amplitude/android/migration/RemnantDataMigrationTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.amplitude.android.Amplitude
 import com.amplitude.android.Configuration
 import com.amplitude.core.Storage
+import com.amplitude.core.utilities.ConsoleLoggerProvider
 import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
 import org.junit.Test
@@ -59,6 +60,7 @@ class RemnantDataMigrationTest {
                 context,
                 instanceName = instanceName,
                 migrateLegacyData = migrateLegacyData,
+                loggerProvider = ConsoleLoggerProvider()
             )
         )
 

--- a/android/src/test/resources/not_db_file
+++ b/android/src/test/resources/not_db_file
@@ -1,0 +1,1 @@
+It is not a sqlite database.


### PR DESCRIPTION
### Summary

Possible fix for [DataMigration NotImplementedError](https://github.com/amplitude/Amplitude-Kotlin/issues/146).
Data migration already checks if the Database file exists and skips the migration if it doesn't.
But if the file exists but it is not a sqlite database for some reason - NotImplemented error is thrown.
Now migration is skipped in both cases.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No