### PR TITLE
fix: skip deep link event when url is missing

### DIFF
--- a/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
@@ -91,14 +91,16 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
         val intent = activity.intent
         intent?.let {
             val referrer = getReferrer(activity)?.toString()
-            val url = it.data?.toString()
-            amplitude.track(
-                EventTypes.DEEP_LINK_OPENED,
-                mapOf(
-                    EventProperties.LINK_URL to url,
-                    EventProperties.LINK_REFERRER to referrer,
-                ),
-            )
+            it.data?.let { uri ->
+                val url = uri.toString()
+                amplitude.track(
+                    EventTypes.DEEP_LINK_OPENED,
+                    mapOf(
+                        EventProperties.LINK_URL to url,
+                        EventProperties.LINK_REFERRER to referrer,
+                    ),
+                )
+            }
         }
     }
 

--- a/android/src/test/java/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
+++ b/android/src/test/java/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
@@ -496,4 +496,30 @@ class AndroidLifecyclePluginTest {
         verify(exactly = 0) { mockedPlugin.track(capture(tracks)) }
         Assertions.assertEquals(0, tracks.count())
     }
+
+    @Test
+    fun `test deep link opened event is not tracked when URL is missing`() = runTest {
+        setDispatcher(testScheduler)
+        configuration.defaultTracking.deepLinks = true
+        amplitude.add(androidLifecyclePlugin)
+
+        val mockedPlugin = spyk(StubPlugin())
+        amplitude.add(mockedPlugin)
+        amplitude.isBuilt.await()
+
+        val mockedIntent = mockk<Intent>()
+        every { mockedIntent.data } returns null
+        val mockedActivity = mockk<Activity>()
+        every { mockedActivity.intent } returns mockedIntent
+        every { mockedActivity.referrer } returns Uri.parse("android-app://com.android.unit-test")
+        val mockedBundle = mockk<Bundle>()
+        androidLifecyclePlugin.onActivityCreated(mockedActivity, mockedBundle)
+
+        advanceUntilIdle()
+        Thread.sleep(100)
+
+        val tracks = mutableListOf<BaseEvent>()
+        verify(exactly = 0) { mockedPlugin.track(capture(tracks)) }
+        Assertions.assertEquals(0, tracks.count())
+    }
 }


### PR DESCRIPTION
### Summary
fix: skip deep link event when url is missing

This PR filters the deep link event (triggered with activity creation) by only limiting to the case when `intent.data` is available, this can potentially avoid some noisy.

Note this is a breaking change, the existing users will probably see a drop in the event volume, but I think this change aligns more to a bug fix.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No