### PR TITLE
feat: add client upload time

### DIFF
--- a/core/src/main/java/com/amplitude/core/utilities/HttpClient.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/HttpClient.kt
@@ -12,9 +12,10 @@ import java.io.OutputStream
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
 internal class HttpClient(
     private val configuration: Configuration
@@ -85,7 +86,10 @@ internal class HttpClient(
     }
 
     internal fun getClientUploadTime(): String {
-        return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT)
+        val currentTimeMillis = System.currentTimeMillis()
+        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+        sdf.timeZone = TimeZone.getTimeZone("UTC")
+        return sdf.format(Date(currentTimeMillis))
     }
 
     internal fun getMindIdLength(): Int? {
@@ -144,9 +148,9 @@ abstract class Connection(
 
     private fun getBodyStr(): String {
         if (minIdLength == null) {
-            return "{\"api_key\":\"$apiKey\",\"events\":$events}"
+            return "{\"api_key\":\"$apiKey\",\"client_upload_time\":\"$clientUploadTime\",\"events\":$events}"
         }
-        return "{\"api_key\":\"$apiKey\",\"events\":$events,\"options\":{\"min_id_length\":$minIdLength}}"
+        return "{\"api_key\":\"$apiKey\",\"client_upload_time\":$clientUploadTime,\"events\":$events,\"options\":{\"min_id_length\":$minIdLength}}"
     }
 }
 

--- a/core/src/main/java/com/amplitude/core/utilities/HttpClient.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/HttpClient.kt
@@ -14,7 +14,6 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 import java.util.TimeZone
 
 internal class HttpClient(

--- a/core/src/main/java/com/amplitude/core/utilities/HttpClient.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/HttpClient.kt
@@ -12,6 +12,9 @@ import java.io.OutputStream
 import java.net.HttpURLConnection
 import java.net.MalformedURLException
 import java.net.URL
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 internal class HttpClient(
     private val configuration: Configuration
@@ -26,6 +29,7 @@ internal class HttpClient(
             override fun close() {
                 try {
                     this.setApiKey(getApiKey())
+                    this.setClientUploadTime(getClientUploadTime())
                     this.setMinIdLength(getMindIdLength())
                     this.setBody()
                     this.outputStream?.close()
@@ -80,6 +84,10 @@ internal class HttpClient(
         return configuration.apiKey
     }
 
+    internal fun getClientUploadTime(): String {
+        return ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT)
+    }
+
     internal fun getMindIdLength(): Int? {
         return configuration.minIdLength
     }
@@ -100,6 +108,7 @@ abstract class Connection(
 ) : Closeable {
 
     private lateinit var apiKey: String
+    private lateinit var clientUploadTime: String
     private lateinit var events: String
     private var minIdLength: Int? = null
     internal lateinit var response: Response
@@ -111,6 +120,10 @@ abstract class Connection(
 
     internal fun setApiKey(apiKey: String) {
         this.apiKey = apiKey
+    }
+
+    internal fun setClientUploadTime(clientUploadTime: String) {
+        this.clientUploadTime = clientUploadTime
     }
 
     internal fun setMinIdLength(minIdLength: Int?) {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

https://amplitude.atlassian.net/browse/AMP-87210
Adding client_upload_time so that when client-side clock is drifted, backend can [correct it](https://discourse.amplitude.com/t/is-it-possible-to-enable-event-time-adjustments-if-discrepancy-is-less-than-60-seconds/11627/5?u=justin)
<img width="681" alt="image" src="https://github.com/amplitude/Amplitude-Kotlin/assets/31029607/73dcbcae-1853-4b5e-9c64-0d12f21094c3">


### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->