### PR TITLE
fix: add setSessionId() method

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -14,6 +14,7 @@ import com.amplitude.core.platform.plugins.GetAmpliExtrasPlugin
 import com.amplitude.core.utilities.FileStorage
 import com.amplitude.id.IdentityConfiguration
 import kotlinx.coroutines.launch
+import java.util.Date
 
 open class Amplitude(
     configuration: Configuration
@@ -112,6 +113,21 @@ open class Amplitude(
         }
     }
 
+    fun setSessionId(timestamp: Long): Amplitude {
+        val dummySetSessionEvent = BaseEvent()
+        dummySetSessionEvent.eventType = DUMMY_SET_SESSION_EVENT
+        dummySetSessionEvent.sessionId = timestamp
+        dummySetSessionEvent.timestamp = timestamp
+        timeline.process(dummySetSessionEvent)
+        return this
+    }
+
+    fun setSessionId(date: Date): Amplitude {
+        val timestamp = date.time
+        setSessionId(timestamp)
+        return this
+    }
+
     private fun registerShutdownHook() {
         Runtime.getRuntime().addShutdownHook(object : Thread() {
             override fun run() {
@@ -138,6 +154,10 @@ open class Amplitude(
          * The event type for dummy exit foreground events.
          */
         internal const val DUMMY_EXIT_FOREGROUND_EVENT = "dummy_exit_foreground"
+        /**
+         * The event type for dummy "set session id" events.
+         */
+        internal const val DUMMY_SET_SESSION_EVENT = "dummy_set_session"
     }
 }
 /**

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -87,10 +87,6 @@ open class Amplitude(
     fun onEnterForeground(timestamp: Long) {
         inForeground = true
 
-        if ((configuration as Configuration).optOut) {
-            return
-        }
-
         val dummyEnterForegroundEvent = BaseEvent()
         dummyEnterForegroundEvent.eventType = DUMMY_ENTER_FOREGROUND_EVENT
         dummyEnterForegroundEvent.timestamp = timestamp

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -128,7 +128,7 @@ class Timeline : Timeline() {
         val configuration = amplitude.configuration as Configuration
         // If any trackingSessionEvents is false (default value is true), means it is manually set
         @Suppress("DEPRECATION")
-        val trackingSessionEvents = configuration.trackingSessionEvents && configuration.defaultTracking.sessions
+        val trackingSessionEvents = configuration.trackingSessionEvents && configuration.defaultTracking.sessions && !configuration.optOut
 
         // end previous session
         if (trackingSessionEvents && inSession()) {
@@ -158,7 +158,7 @@ class Timeline : Timeline() {
         val configuration = amplitude.configuration as Configuration
         // If any trackingSessionEvents is false (default value is true), means it is manually set
         @Suppress("DEPRECATION")
-        val trackingSessionEvents = configuration.trackingSessionEvents && configuration.defaultTracking.sessions
+        val trackingSessionEvents = configuration.trackingSessionEvents && configuration.defaultTracking.sessions && !configuration.optOut
 
         if (trackingSessionEvents && inSession()) {
             val sessionEndEvent = BaseEvent()


### PR DESCRIPTION
### Summary

Adds `setSessionId()` method (similar to Amplitude-Swift implementation)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No