### PR TITLE
fix: remove a data race when auto-generated device id is used instead of custom device id

### DIFF
--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -38,19 +38,19 @@ class AndroidContextPlugin : Plugin {
         if (!configuration.newDeviceIdPerInstall && configuration.useAdvertisingIdForDeviceId && !contextProvider.isLimitAdTrackingEnabled()) {
             val advertisingId = contextProvider.advertisingId
             if (advertisingId != null && validDeviceId(advertisingId)) {
-                amplitude.setDeviceId(advertisingId)
+                setDeviceId(advertisingId)
                 return
             }
         }
         if (configuration.useAppSetIdForDeviceId) {
             val appSetId = contextProvider.appSetId
             if (appSetId != null && validDeviceId(appSetId)) {
-                amplitude.setDeviceId("${appSetId}S")
+                setDeviceId("${appSetId}S")
                 return
             }
         }
         val randomId = AndroidContextProvider.generateUUID() + "R"
-        amplitude.setDeviceId(randomId)
+        setDeviceId(randomId)
     }
 
     private fun applyContextData(event: BaseEvent) {
@@ -142,6 +142,10 @@ class AndroidContextPlugin : Plugin {
                 event.ingestionMetadata = it.clone()
             }
         }
+    }
+
+    private fun setDeviceId(deviceId: String) {
+        amplitude.idContainer.identityManager.editIdentity().setDeviceId(deviceId).commit()
     }
 
     companion object {

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -182,6 +182,47 @@ class AmplitudeTest {
         }
     }
 
+    @Test
+    fun test_setDeviceId_generatedDeviceIdShouldBeUsed() = runTest {
+        setDispatcher(testScheduler)
+        val n = 100
+        val clients = arrayOfNulls<Amplitude>(n)
+        for (i in 0 until n) {
+            val configuration = createConfiguration()
+            configuration.instanceName = "generated-instance-$i"
+            val amplitude = Amplitude(configuration)
+            clients[i] = amplitude
+        }
+
+        advanceUntilIdle()
+        Thread.sleep(1000)
+
+        for (i in 0 until n) {
+            Assertions.assertTrue(clients[i]?.getDeviceId()?.endsWith('R') ?: false)
+        }
+    }
+
+    @Test
+    fun test_setDeviceId_customDeviceIdShouldBeUsed() = runTest {
+        setDispatcher(testScheduler)
+        val n = 100
+        val clients = mutableListOf<Amplitude>()
+        for (i in 0 until n) {
+            val configuration = createConfiguration()
+            configuration.instanceName = "custom-instance-$i"
+            val amplitude = Amplitude(configuration)
+            amplitude.setDeviceId("custom-device-$i")
+            clients.add(amplitude)
+        }
+
+        advanceUntilIdle()
+        Thread.sleep(1000)
+
+        for (i in 0 until n) {
+            Assertions.assertEquals("custom-device-$i", clients[i].getDeviceId())
+        }
+    }
+
     companion object {
         const val instanceName = "testInstance"
     }


### PR DESCRIPTION
### Summary

1. Adds a new configuration option `deviceId` to prevent device id auto-generation.
2. Adds a new internal `setDeviceId()` method that sets device id if current and expected device ids are equal.
3. Switches `amplitudeDispatcher` to `single thread` mode
4. Adds tests that reproduce the fixed data race.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No