### PR TITLE
fix: remove beta and release to Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Amplitude-Kotlin
 
-This is Amplitude's latest version of the Kotlin SDK, covering Android (beta).
+This is Amplitude's latest version of the Kotlin SDK, covering Android.
 
 ## Installation and Quick Start
 Please visit our :100:[Developer Center](https://developers.amplitude.com/docs/kotlin-android-beta) for instructions on installing and using our the SDK.


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Remove "beta" in README
- This PR is mainly for releasing another patch release to Maven as `v1.12.0` is only released to Github but not to Maven

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->