### PR TITLE
ci: save reports as artifacts

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -18,3 +18,15 @@ jobs:
         run: ./gradlew testDebugUnitTest
       - name: Lint
         run: ./gradlew ktlintCheck
+      - name: Upload build results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          # artifacts name
+          name: build-results
+          # copy reports of all packages
+          path: '**/build/reports/**'
+          # artifact will expire in 7 days.
+          retention-days: 7
+
+


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary


Save `./gradlew` commands results as artifacts
<img width="1282" alt="Screenshot 2023-12-29 at 16 03 10" src="https://github.com/amplitude/Amplitude-Kotlin/assets/31029607/bcbf7bcb-f464-4369-a60c-084c704ecc4e">
<img width="979" alt="image" src="https://github.com/amplitude/Amplitude-Kotlin/assets/31029607/44754972-61e5-422a-b90c-2ae755322fd3">



### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->