### PR TITLE
fix: race condition when setting device id in android

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -60,7 +60,12 @@ open class Amplitude(
         if (this.configuration.offline != AndroidNetworkConnectivityCheckerPlugin.Disabled) {
             add(AndroidNetworkConnectivityCheckerPlugin())
         }
-        androidContextPlugin = AndroidContextPlugin()
+        androidContextPlugin = object : AndroidContextPlugin() {
+            override fun setDeviceId(deviceId: String) {
+                // call internal method to set deviceId immediately i.e. dont' wait for build() to complete
+                this@Amplitude.setDeviceIdInternal(deviceId)
+            }
+        }
         add(androidContextPlugin)
         add(GetAmpliExtrasPlugin())
         add(AndroidLifecyclePlugin())

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -9,7 +9,7 @@ import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
 import java.util.UUID
 
-class AndroidContextPlugin : Plugin {
+open class AndroidContextPlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
     override lateinit var amplitude: Amplitude
     private lateinit var contextProvider: AndroidContextProvider
@@ -38,19 +38,19 @@ class AndroidContextPlugin : Plugin {
         if (!configuration.newDeviceIdPerInstall && configuration.useAdvertisingIdForDeviceId && !contextProvider.isLimitAdTrackingEnabled()) {
             val advertisingId = contextProvider.advertisingId
             if (advertisingId != null && validDeviceId(advertisingId)) {
-                amplitude.setDeviceId(advertisingId)
+                setDeviceId(advertisingId)
                 return
             }
         }
         if (configuration.useAppSetIdForDeviceId) {
             val appSetId = contextProvider.appSetId
             if (appSetId != null && validDeviceId(appSetId)) {
-                amplitude.setDeviceId("${appSetId}S")
+                setDeviceId("${appSetId}S")
                 return
             }
         }
         val randomId = AndroidContextProvider.generateUUID() + "R"
-        amplitude.setDeviceId(randomId)
+        setDeviceId(randomId)
     }
 
     private fun applyContextData(event: BaseEvent) {
@@ -142,6 +142,10 @@ class AndroidContextPlugin : Plugin {
                 event.ingestionMetadata = it.clone()
             }
         }
+    }
+
+    protected open fun setDeviceId(deviceId: String) {
+        amplitude.setDeviceId(deviceId)
     }
 
     companion object {

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -187,6 +187,15 @@ class AmplitudeTest {
         }
     }
 
+    @Test
+    fun amplitude_getDeviceId_should_return_not_null_after_isBuilt() = runTest {
+        setDispatcher(testScheduler)
+        if (amplitude?.isBuilt!!.await()) {
+            Assertions.assertNotNull(amplitude?.store?.deviceId)
+            Assertions.assertNotNull(amplitude?.getDeviceId())
+        }
+    }
+
     companion object {
         const val instanceName = "testInstance"
     }

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -224,6 +224,17 @@ open class Amplitude internal constructor(
     }
 
     /**
+     * <b>INTERNAL METHOD!</b>
+     *
+     * Sets device id immediately without waiting for build() to complete.
+     * 
+     * <b>Note: only do this if you know what you are doing!</b>
+     */
+    protected fun setDeviceIdInternal(deviceId: String) {
+        idContainer.identityManager.editIdentity().setDeviceId(deviceId).commit()
+    }
+
+    /**
      * Sets a custom device id. <b>Note: only do this if you know what you are doing!</b>
      *
      * @param deviceId custom device id
@@ -232,7 +243,7 @@ open class Amplitude internal constructor(
     fun setDeviceId(deviceId: String): Amplitude {
         amplitudeScope.launch(amplitudeDispatcher) {
             isBuilt.await()
-            idContainer.identityManager.editIdentity().setDeviceId(deviceId).commit()
+            setDeviceIdInternal(deviceId)
         }
         return this
     }


### PR DESCRIPTION
# Summary

## Error
* `amplitude.getDeviceId()` was returning `null` after `amplitude.isBuilt()`.

## Fix
* `deviceId` is now always set before `isBuilt()` is true

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No