### PR TITLE
feat: added deviceId to Configuration options

### DIFF
--- a/android/src/main/java/com/amplitude/android/Configuration.kt
+++ b/android/src/main/java/com/amplitude/android/Configuration.kt
@@ -47,7 +47,30 @@ open class Configuration @JvmOverloads constructor(
     override var identityStorageProvider: IdentityStorageProvider = FileIdentityStorageProvider(),
     var migrateLegacyData: Boolean = true,
     override var offline: Boolean? = false,
-) : Configuration(apiKey, flushQueueSize, flushIntervalMillis, instanceName, optOut, storageProvider, loggerProvider, minIdLength, partnerId, callback, flushMaxRetries, useBatch, serverZone, serverUrl, plan, ingestionMetadata, identifyBatchIntervalMillis, identifyInterceptStorageProvider, identityStorageProvider, offline) {
+    override var deviceId: String? = null,
+) : Configuration(
+    apiKey,
+    flushQueueSize,
+    flushIntervalMillis,
+    instanceName,
+    optOut,
+    storageProvider,
+    loggerProvider,
+    minIdLength,
+    partnerId,
+    callback,
+    flushMaxRetries,
+    useBatch,
+    serverZone,
+    serverUrl,
+    plan,
+    ingestionMetadata,
+    identifyBatchIntervalMillis,
+    identifyInterceptStorageProvider,
+    identityStorageProvider,
+    offline,
+    deviceId,
+) {
     companion object {
         const val MIN_TIME_BETWEEN_SESSIONS_MILLIS: Long = 300000
     }

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -31,10 +31,20 @@ open class AndroidContextPlugin : Plugin {
     }
 
     fun initializeDeviceId(configuration: Configuration) {
-        val deviceId = amplitude.store.deviceId
+        // Check configuration
+        var deviceId = configuration.deviceId
+        if (deviceId != null) {
+            setDeviceId(deviceId)
+            return
+        }
+
+        // Check store
+        deviceId = amplitude.store.deviceId
         if (deviceId != null && validDeviceId(deviceId) && !deviceId.endsWith("S")) {
             return
         }
+
+        // Check new device id per install
         if (!configuration.newDeviceIdPerInstall && configuration.useAdvertisingIdForDeviceId && !contextProvider.isLimitAdTrackingEnabled()) {
             val advertisingId = contextProvider.advertisingId
             if (advertisingId != null && validDeviceId(advertisingId)) {
@@ -42,6 +52,8 @@ open class AndroidContextPlugin : Plugin {
                 return
             }
         }
+
+        // Check app set id
         if (configuration.useAppSetIdForDeviceId) {
             val appSetId = contextProvider.appSetId
             if (appSetId != null && validDeviceId(appSetId)) {
@@ -49,6 +61,8 @@ open class AndroidContextPlugin : Plugin {
                 return
             }
         }
+
+        // Generate random id
         val randomId = AndroidContextProvider.generateUUID() + "R"
         setDeviceId(randomId)
     }

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -74,7 +74,11 @@ class AmplitudeTest {
         amplitudeDispatcherField.set(amplitude, dispatcher)
     }
 
-    private fun createConfiguration(minTimeBetweenSessionsMillis: Long? = null, storageProvider: StorageProvider = InMemoryStorageProvider()): Configuration {
+    private fun createConfiguration(
+        minTimeBetweenSessionsMillis: Long? = null,
+        storageProvider: StorageProvider = InMemoryStorageProvider(),
+        deviceId: String? = null,
+    ): Configuration {
         val configuration = Configuration(
             apiKey = "api-key",
             context = context!!,
@@ -85,6 +89,10 @@ class AmplitudeTest {
             identifyInterceptStorageProvider = InMemoryStorageProvider(),
             identityStorageProvider = IMIdentityStorageProvider(),
         )
+
+        if (deviceId != null) {
+            configuration.deviceId = deviceId
+        }
 
         if (minTimeBetweenSessionsMillis != null) {
             configuration.minTimeBetweenSessionsMillis = minTimeBetweenSessionsMillis
@@ -193,6 +201,21 @@ class AmplitudeTest {
         if (amplitude?.isBuilt!!.await()) {
             Assertions.assertNotNull(amplitude?.store?.deviceId)
             Assertions.assertNotNull(amplitude?.getDeviceId())
+            // Should be a random id (ends with R)
+            Assertions.assertTrue(amplitude?.getDeviceId()?.endsWith("R") == true)
+        }
+    }
+
+    @Test
+    fun amplitude_should_set_deviceId_from_configuration() = runTest {
+        val testDeviceId = "test device id"
+        // set device Id in the config
+        amplitude = Amplitude(createConfiguration(deviceId = testDeviceId))
+        setDispatcher(testScheduler)
+
+        if (amplitude?.isBuilt!!.await()) {
+            Assertions.assertEquals(testDeviceId, amplitude?.store?.deviceId)
+            Assertions.assertNotNull(testDeviceId, amplitude?.getDeviceId())
         }
     }
 

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -215,7 +215,7 @@ class AmplitudeTest {
 
         if (amplitude?.isBuilt!!.await()) {
             Assertions.assertEquals(testDeviceId, amplitude?.store?.deviceId)
-            Assertions.assertNotNull(testDeviceId, amplitude?.getDeviceId())
+            Assertions.assertEquals(testDeviceId, amplitude?.getDeviceId())
         }
     }
 

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -201,8 +201,6 @@ class AmplitudeTest {
         if (amplitude?.isBuilt!!.await()) {
             Assertions.assertNotNull(amplitude?.store?.deviceId)
             Assertions.assertNotNull(amplitude?.getDeviceId())
-            // Should be a random id (ends with R)
-            Assertions.assertTrue(amplitude?.getDeviceId()?.endsWith("R") == true)
         }
     }
 

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -113,7 +113,12 @@ open class Amplitude internal constructor(
     protected open suspend fun buildInternal(identityConfiguration: IdentityConfiguration) {
         createIdentityContainer(identityConfiguration)
         EventBridgeContainer.getInstance(configuration.instanceName).eventBridge.setEventReceiver(EventChannel.EVENT, AnalyticsEventReceiver(this))
-        add(ContextPlugin())
+        add(object : ContextPlugin() {
+            override fun setDeviceId(deviceId: String) {
+                // set device id immediately, don't wait for isBuilt
+                setDeviceIdInternal(deviceId)
+            }
+        })
         add(GetAmpliExtrasPlugin())
         add(AmplitudeDestination())
     }

--- a/core/src/main/java/com/amplitude/core/Configuration.kt
+++ b/core/src/main/java/com/amplitude/core/Configuration.kt
@@ -31,6 +31,7 @@ open class Configuration @JvmOverloads constructor(
     open var identifyInterceptStorageProvider: StorageProvider = InMemoryStorageProvider(),
     open var identityStorageProvider: IdentityStorageProvider = IMIdentityStorageProvider(),
     open var offline: Boolean? = false,
+    open var deviceId: String? = null,
 ) {
 
     companion object {

--- a/core/src/main/java/com/amplitude/core/platform/plugins/ContextPlugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/plugins/ContextPlugin.kt
@@ -1,17 +1,32 @@
 package com.amplitude.core.platform.plugins
 
 import com.amplitude.core.Amplitude
+import com.amplitude.core.Configuration
 import com.amplitude.core.Constants
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
 import java.util.UUID
 
-class ContextPlugin : Plugin {
+open class ContextPlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
     override lateinit var amplitude: Amplitude
 
     override fun setup(amplitude: Amplitude) {
         super.setup(amplitude)
+        initializeDeviceId(amplitude.configuration)
+    }
+
+    protected open fun setDeviceId(deviceId: String) {
+        amplitude.setDeviceId(deviceId)
+    }
+
+    private fun initializeDeviceId(configuration: Configuration) {
+        // Check configuration
+        var deviceId = configuration.deviceId
+        if (deviceId != null) {
+            setDeviceId(deviceId)
+            return
+        }
     }
 
     private fun applyContextData(event: BaseEvent) {

--- a/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
@@ -46,12 +46,14 @@ internal class AmplitudeTest {
         val testApiKey = "test-123"
         val plan = Plan("test-branch", "test")
         val ingestionMetadata = IngestionMetadata("ampli", "2.0.0")
-        amplitude = testAmplitude(Configuration(
-            testApiKey,
-            plan = plan,
-            ingestionMetadata = ingestionMetadata,
-            serverUrl = server.url("/").toString()
-        ))
+        amplitude = testAmplitude(
+            Configuration(
+                testApiKey,
+                plan = plan,
+                ingestionMetadata = ingestionMetadata,
+                serverUrl = server.url("/").toString()
+            )
+        )
     }
 
     @AfterEach
@@ -64,11 +66,13 @@ internal class AmplitudeTest {
         @Test
         fun `set deviceId`() {
             val deviceId = "test-device-id"
-            amplitude = testAmplitude(Configuration(
-                "api-key",
-                deviceId = deviceId,
-                serverUrl = server.url("/").toString()
-            ))
+            amplitude = testAmplitude(
+                Configuration(
+                    "api-key",
+                    deviceId = deviceId,
+                    serverUrl = server.url("/").toString()
+                )
+            )
             amplitude.isBuilt.invokeOnCompletion {
                 assertEquals(deviceId, amplitude.store.deviceId)
                 assertEquals(deviceId, amplitude.getDeviceId())

--- a/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
@@ -46,12 +46,34 @@ internal class AmplitudeTest {
         val testApiKey = "test-123"
         val plan = Plan("test-branch", "test")
         val ingestionMetadata = IngestionMetadata("ampli", "2.0.0")
-        amplitude = testAmplitude(Configuration(testApiKey, plan = plan, ingestionMetadata = ingestionMetadata, serverUrl = server.url("/").toString()))
+        amplitude = testAmplitude(Configuration(
+            testApiKey,
+            plan = plan,
+            ingestionMetadata = ingestionMetadata,
+            serverUrl = server.url("/").toString()
+        ))
     }
 
     @AfterEach
     fun shutdown() {
         server.shutdown()
+    }
+
+    @Nested
+    inner class TestConfiguration {
+        @Test
+        fun `set deviceId`() {
+            val deviceId = "test-device-id"
+            amplitude = testAmplitude(Configuration(
+                "api-key",
+                deviceId = deviceId,
+                serverUrl = server.url("/").toString()
+            ))
+            amplitude.isBuilt.invokeOnCompletion {
+                assertEquals(deviceId, amplitude.store.deviceId)
+                assertEquals(deviceId, amplitude.getDeviceId())
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
### Summary

Adds `deviceId` to `Configuration` options to set the initial deviceId (instead of generating it, or reading from storage)

```
val deviceId = "test device id"
val amplitude = Amplitude(Configuration(deviceId = deviceId))
amplitude.isBuilt.invokeOnCompletion {
    assertEqual(deviceId, amplitude.getDeviceId());
}
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No