### PR TITLE
fix: catch potential internal Errors from Properties.save() and load()

### DIFF
--- a/id/src/main/java/com/amplitude/id/utilities/PropertiesFile.kt
+++ b/id/src/main/java/com/amplitude/id/utilities/PropertiesFile.kt
@@ -22,7 +22,7 @@ class PropertiesFile(directory: File, key: String, prefix: String, logger: Logge
                     underlyingProperties.load(it)
                 }
                 return
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 propertiesFile.delete()
                 logger?.error("Failed to load property file with path ${propertiesFile.absolutePath}, error stacktrace: ${e.stackTraceToString()}")
             }
@@ -36,7 +36,9 @@ class PropertiesFile(directory: File, key: String, prefix: String, logger: Logge
             FileOutputStream(propertiesFile).use {
                 underlyingProperties.store(it, null)
             }
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
+            // Note: we need to catch Throwable to handle both Exceptions and Errors
+            // Properties.store has an error in Android 8 that throws a AssertionError (vs Exception)
             logger?.error("Failed to save property file with path ${propertiesFile.absolutePath}, error stacktrace: ${e.stackTraceToString()}")
         }
     }


### PR DESCRIPTION
### Summary

* Fix for #172 
* I added additional error handling to catch the AssertionError and prevent a crash.
* Since this error is internal to Android, I don’t think there is much we can do to fix it.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No