### PR TITLE
feat(upload): Accept HTTP 200 responses with empty body

### DIFF
--- a/core/src/main/java/com/amplitude/core/utilities/HttpClient.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/HttpClient.kt
@@ -38,7 +38,12 @@ internal class HttpClient(
                     try {
                         inputStream = getInputStream(this.connection)
                         responseBody = inputStream.bufferedReader().use(BufferedReader::readText)
-                        this.response = HttpResponse.createHttpResponse(responseCode, JSONObject(responseBody))
+                        val jsonResponse = if (responseBody.isNullOrEmpty()) {
+                            null
+                        } else {
+                            JSONObject(responseBody)
+                        }
+                        this.response = HttpResponse.createHttpResponse(responseCode, jsonResponse)
                     } catch (e: IOException) {
                         this.response = HttpResponse.createHttpResponse(408, null)
                     } finally {


### PR DESCRIPTION
### Summary

When using a third party server, we may encounter valid HTTP 200 responses that do not include a JSON body.

In the current SDK it is assumed that the response always has a JSON form and the request fails otherwise even though the response code is 200.

The failure is due to the creation of a `JSONObject(responseBody)` object that is passed to the function that creates the HTTP response. If that `responseBody` is null, empty or does not contain a json string, that call will throw an exception and the request is considered a failure.

In this change, if the response is null or empty, it is still passed to the function that creates the response, and, if it is a 200 response, it will be considered a successful response.

This behavior is equivalent to the behavior of the Amplitude Swift SDK, that accepts empty responses (https://github.com/amplitude/Amplitude-Swift/blob/35f253db41cf68d220390946c7ad7f344665d763/Sources/Amplitude/Utilities/HttpClient.swift#L35)

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No