### PR TITLE
fix: only take unique error logs and control limit

### DIFF
--- a/core/src/main/java/com/amplitude/core/utilities/Diagnostics.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/Diagnostics.kt
@@ -4,7 +4,7 @@ import java.util.Collections
 
 class Diagnostics() {
     private var malformedEvents: MutableList<String>? = null
-    private var errorLogs: MutableSet<String>? = null
+    private var errorLogs: MutableSet<String> = Collections.synchronizedSet(mutableSetOf())
 
     companion object {
         private const val MAX_ERROR_LOGS = 10
@@ -18,17 +18,14 @@ class Diagnostics() {
     }
 
     fun addErrorLog(log: String) {
-        if (errorLogs == null) {
-            errorLogs = Collections.synchronizedSet(mutableSetOf())
+        errorLogs.add(log)
+        while (errorLogs.size > MAX_ERROR_LOGS) {
+            errorLogs.remove(errorLogs.first())
         }
-        if (errorLogs!!.size >= MAX_ERROR_LOGS) {
-            return
-        }
-        errorLogs?.add(log)
     }
 
     fun hasDiagnostics(): Boolean {
-        return (malformedEvents != null && malformedEvents!!.isNotEmpty()) || (errorLogs != null && errorLogs!!.isNotEmpty())
+        return (malformedEvents != null && malformedEvents!!.isNotEmpty()) || errorLogs.isNotEmpty()
     }
 
     /**
@@ -43,12 +40,12 @@ class Diagnostics() {
         if (malformedEvents != null && malformedEvents!!.isNotEmpty()) {
             diagnostics["malformed_events"] = malformedEvents!!
         }
-        if (errorLogs != null && errorLogs!!.isNotEmpty()) {
-            diagnostics["error_logs"] = errorLogs!!.toList()
+        if (errorLogs.isNotEmpty()) {
+            diagnostics["error_logs"] = errorLogs.toList()
         }
         val result = diagnostics.toJSONObject().toString()
         malformedEvents?.clear()
-        errorLogs?.clear()
+        errorLogs.clear()
         return result
     }
 }

--- a/core/src/main/java/com/amplitude/core/utilities/Diagnostics.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/Diagnostics.kt
@@ -4,7 +4,11 @@ import java.util.Collections
 
 class Diagnostics() {
     private var malformedEvents: MutableList<String>? = null
-    private var errorLogs: MutableList<String>? = null
+    private var errorLogs: MutableSet<String>? = null
+
+    companion object {
+        private const val MAX_ERROR_LOGS = 10
+    }
 
     fun addMalformedEvent(event: String) {
         if (malformedEvents == null) {
@@ -15,7 +19,7 @@ class Diagnostics() {
 
     fun addErrorLog(log: String) {
         if (errorLogs == null) {
-            errorLogs = Collections.synchronizedList(mutableListOf())
+            errorLogs = Collections.synchronizedSet(mutableSetOf())
         }
         errorLogs?.add(log)
     }
@@ -37,11 +41,13 @@ class Diagnostics() {
             diagnostics["malformed_events"] = malformedEvents!!
         }
         if (errorLogs != null && errorLogs!!.isNotEmpty()) {
-            diagnostics["error_logs"] = errorLogs!!
+            // pick the first MAX_ERROR_LOGS from the set and convert to list
+            val errorLogsToTake = errorLogs!!.take(MAX_ERROR_LOGS)
+            diagnostics["error_logs"] = errorLogsToTake
+            errorLogs?.removeAll(errorLogsToTake.toSet())
         }
         val result = diagnostics.toJSONObject().toString()
         malformedEvents?.clear()
-        errorLogs?.clear()
         return result
     }
 }

--- a/core/src/main/java/com/amplitude/core/utilities/Diagnostics.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/Diagnostics.kt
@@ -21,6 +21,9 @@ class Diagnostics() {
         if (errorLogs == null) {
             errorLogs = Collections.synchronizedSet(mutableSetOf())
         }
+        if (errorLogs!!.size >= MAX_ERROR_LOGS) {
+            return
+        }
         errorLogs?.add(log)
     }
 
@@ -41,13 +44,11 @@ class Diagnostics() {
             diagnostics["malformed_events"] = malformedEvents!!
         }
         if (errorLogs != null && errorLogs!!.isNotEmpty()) {
-            // pick the first MAX_ERROR_LOGS from the set and convert to list
-            val errorLogsToTake = errorLogs!!.take(MAX_ERROR_LOGS)
-            diagnostics["error_logs"] = errorLogsToTake
-            errorLogs?.removeAll(errorLogsToTake.toSet())
+            diagnostics["error_logs"] = errorLogs!!.toList()
         }
         val result = diagnostics.toJSONObject().toString()
         malformedEvents?.clear()
+        errorLogs?.clear()
         return result
     }
 }

--- a/core/src/test/kotlin/com/amplitude/core/utilities/DiagnosticsTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/utilities/DiagnosticsTest.kt
@@ -23,6 +23,28 @@ class DiagnosticsTest {
     }
 
     @Test
+    fun `test duplicate error logs`() {
+        val diagnostics = Diagnostics()
+        diagnostics.addErrorLog("log")
+        diagnostics.addErrorLog("log")
+        assertTrue(diagnostics.hasDiagnostics())
+        assertEquals("{\"error_logs\":[\"log\"]}", diagnostics.extractDiagnostics())
+    }
+
+    @Test
+    fun `test we only take first 10 error logs if many`() {
+        val diagnostics = Diagnostics()
+        for (i in 1..15) {
+            diagnostics.addErrorLog("log$i")
+        }
+        assertTrue(diagnostics.hasDiagnostics())
+        assertEquals(
+            "{\"error_logs\":[\"log1\",\"log2\",\"log3\",\"log4\",\"log5\",\"log6\",\"log7\",\"log8\",\"log9\",\"log10\"]}",
+            diagnostics.extractDiagnostics(),
+        )
+    }
+
+    @Test
     fun `test hasDiagnostics`() {
         val diagnostics = Diagnostics()
         assertFalse(diagnostics.hasDiagnostics())

--- a/core/src/test/kotlin/com/amplitude/core/utilities/DiagnosticsTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/utilities/DiagnosticsTest.kt
@@ -39,7 +39,7 @@ class DiagnosticsTest {
         }
         assertTrue(diagnostics.hasDiagnostics())
         assertEquals(
-            "{\"error_logs\":[\"log1\",\"log2\",\"log3\",\"log4\",\"log5\",\"log6\",\"log7\",\"log8\",\"log9\",\"log10\"]}",
+            "{\"error_logs\":[\"log6\",\"log7\",\"log8\",\"log9\",\"log10\",\"log11\",\"log12\",\"log13\",\"log14\",\"log15\"]}",
             diagnostics.extractDiagnostics(),
         )
         assertFalse(diagnostics.hasDiagnostics())

--- a/core/src/test/kotlin/com/amplitude/core/utilities/DiagnosticsTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/utilities/DiagnosticsTest.kt
@@ -32,7 +32,7 @@ class DiagnosticsTest {
     }
 
     @Test
-    fun `test we only take first 10 error logs if many`() {
+    fun `test we only take have 10 error logs if many`() {
         val diagnostics = Diagnostics()
         for (i in 1..15) {
             diagnostics.addErrorLog("log$i")
@@ -42,6 +42,7 @@ class DiagnosticsTest {
             "{\"error_logs\":[\"log1\",\"log2\",\"log3\",\"log4\",\"log5\",\"log6\",\"log7\",\"log8\",\"log9\",\"log10\"]}",
             diagnostics.extractDiagnostics(),
         )
+        assertFalse(diagnostics.hasDiagnostics())
     }
 
     @Test


### PR DESCRIPTION
### Summary

- only take unique error logs
- control how many error logs we send each time

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no