### PR TITLE
fix: session id not set before plugin setup

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -15,6 +15,7 @@ import com.amplitude.core.platform.plugins.AmplitudeDestination
 import com.amplitude.core.platform.plugins.GetAmpliExtrasPlugin
 import com.amplitude.core.utilities.FileStorage
 import com.amplitude.id.IdentityConfiguration
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.launch
 
 open class Amplitude(
@@ -51,10 +52,19 @@ open class Amplitude(
         )
     }
 
+    override fun build(): Deferred<Boolean> {
+        val deferred = super.build()
+
+        // Start session before adding plugins
+        (timeline as Timeline).initSession()
+
+        return deferred
+    }
+
     override suspend fun buildInternal(identityConfiguration: IdentityConfiguration) {
         // Migrations
         ApiKeyStorageMigration(this).execute()
-        if ((this.configuration as Configuration).migrateLegacyData) {
+        if ((configuration as Configuration).migrateLegacyData) {
             RemnantDataMigration(this).execute()
         }
 
@@ -84,8 +94,7 @@ open class Amplitude(
             }
         }
 
-        val androidTimeline = timeline as Timeline
-        androidTimeline.start()
+        (timeline as Timeline).start()
     }
 
     /**

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -26,13 +26,15 @@ class Timeline : Timeline() {
     internal var sessionId: Long = Session.EMPTY_SESSION_ID
         get() = if (session == null) Session.EMPTY_SESSION_ID else session.sessionId
 
-    internal suspend fun start() {
+    internal fun initSession() {
         this.session = Session(
             amplitude.configuration as Configuration,
             amplitude.storage,
             amplitude.store
         )
+    }
 
+    internal suspend fun start() {
         val sessionEvents = session.startNewSessionIfNeeded(
             SystemTime.getCurrentTimeMillis(),
             amplitude.configuration.sessionId
@@ -49,9 +51,11 @@ class Timeline : Timeline() {
             }
         }
 
-        runBlocking {
-            sessionEvents?.forEach {
-                processImmediately(it)
+        if (!amplitude.configuration.optOut) {
+            runBlocking {
+                sessionEvents?.forEach {
+                    processImmediately(it)
+                }
             }
         }
     }

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -232,7 +232,6 @@ class AmplitudeTest {
         }
     }
 
-
     @Test
     fun amplitude_should_set_sessionId_before_plugin_setup() = runTest {
         class SessionIdPlugin() : DestinationPlugin() {
@@ -250,7 +249,6 @@ class AmplitudeTest {
                 Assertions.assertNotNull(sessionId)
             }
         }
-
 
         // set session Id in the config
         val config = createConfiguration()

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -100,9 +100,10 @@ open class Amplitude internal constructor(
     protected open fun build(): Deferred<Boolean> {
         val amplitude = this
 
+        storage = configuration.storageProvider.getStorage(amplitude)
+
         val built =
             amplitudeScope.async(amplitudeDispatcher, CoroutineStart.LAZY) {
-                storage = configuration.storageProvider.getStorage(amplitude)
                 identifyInterceptStorage =
                     configuration.identifyInterceptStorageProvider.getStorage(
                         amplitude,


### PR DESCRIPTION
### Summary

[AMP-96567]

*  ensure sessionId is set before Plugin.setup is called

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No

[AMP-96567]: https://amplitude.atlassian.net/browse/AMP-96567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ