### PR TITLE
fix: fix storage timing issue, set sessionId before plugin.setup

### DIFF
--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -26,17 +26,15 @@ class Timeline : Timeline() {
     internal var sessionId: Long = Session.EMPTY_SESSION_ID
         get() = if (session == null) Session.EMPTY_SESSION_ID else session.sessionId
 
-    internal fun initSession() {
+    internal suspend fun start(timestamp: Long? = null) {
         this.session = Session(
             amplitude.configuration as Configuration,
             amplitude.storage,
             amplitude.store
         )
-    }
 
-    internal suspend fun start() {
         val sessionEvents = session.startNewSessionIfNeeded(
-            SystemTime.getCurrentTimeMillis(),
+            timestamp ?: SystemTime.getCurrentTimeMillis(),
             amplitude.configuration.sessionId
         )
 

--- a/android/src/main/java/com/amplitude/android/utilities/Session.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/Session.kt
@@ -9,8 +9,8 @@ import java.util.concurrent.atomic.AtomicLong
 
 class Session(
     private var configuration: Configuration,
-    private var storage: Storage? = null,
-    private var state: State? = null,
+    internal var storage: Storage? = null,
+    internal var state: State? = null,
 ) {
     companion object {
         const val EMPTY_SESSION_ID = -1L

--- a/android/src/test/java/com/amplitude/android/AmplitudeSessionTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeSessionTest.kt
@@ -482,11 +482,12 @@ class AmplitudeSessionTest {
 
     @Test
     fun amplitude_explicitSessionForEventShouldBePreserved() = runTest {
-        val amplitude = Amplitude(createConfiguration())
-        setDispatcher(amplitude, testScheduler)
-
+        val config = createConfiguration()
         val mockedPlugin = spyk(StubPlugin())
-        amplitude.add(mockedPlugin)
+        config.plugins = listOf(mockedPlugin)
+
+        val amplitude = Amplitude(config)
+        setDispatcher(amplitude, testScheduler)
 
         amplitude.isBuilt.await()
 

--- a/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/java/com/amplitude/android/AmplitudeTest.kt
@@ -234,6 +234,8 @@ class AmplitudeTest {
 
     @Test
     fun amplitude_should_set_sessionId_before_plugin_setup() = runTest {
+        var setupSessionId: Long? = null
+
         class SessionIdPlugin() : DestinationPlugin() {
             override val type: Plugin.Type = Plugin.Type.Destination
 
@@ -244,9 +246,10 @@ class AmplitudeTest {
 
                 this.amplitude = amplitude
 
-                val sessionId = (amplitude as Amplitude).sessionId
+                setupSessionId = (amplitude as Amplitude).sessionId
 
-                Assertions.assertNotNull(sessionId)
+                Assertions.assertNotNull(setupSessionId)
+                Assertions.assertNotEquals(-1L, setupSessionId)
             }
         }
 
@@ -254,13 +257,15 @@ class AmplitudeTest {
         val config = createConfiguration()
         // isolate storage from other tests
         config.instanceName = "session-id-for-plugin-setup"
+        config.plugins = listOf(SessionIdPlugin())
         val amp = Amplitude(config)
-        amp.add(SessionIdPlugin())
 
         setDispatcher(testScheduler)
 
         if (amp?.isBuilt!!.await()) {
             Assertions.assertNotNull(amp?.sessionId)
+            Assertions.assertNotEquals(-1L, amp?.sessionId)
+            Assertions.assertEquals(setupSessionId, amp?.sessionId)
         }
     }
 

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -100,10 +100,9 @@ open class Amplitude internal constructor(
     protected open fun build(): Deferred<Boolean> {
         val amplitude = this
 
-        storage = configuration.storageProvider.getStorage(amplitude)
-
         val built =
             amplitudeScope.async(amplitudeDispatcher, CoroutineStart.LAZY) {
+                storage = configuration.storageProvider.getStorage(amplitude)
                 identifyInterceptStorage =
                     configuration.identifyInterceptStorageProvider.getStorage(
                         amplitude,


### PR DESCRIPTION
### Summary

* fix storage timing issue from last commit
  * after the last change sometimes deviceId would not be loaded in time for the session events. This fix resolves that issue by moving the storage creation back into the proper coroutine.
* set sessionId before plugin.setup
  * this is once again part of buildInternal so that the storage is fully setup
  * We load the initial session id prior to the internal calls to `add(plugin)`
  * Note - If plugins require accurate values for `sessionId` in `setup` they must be added via config e.g. `amplitude(Configuration(plugins = listOf(pluginThatNeedsSessionIdInSetup)`
* Improved sessionId check in Plugin.setup to verify that a valid session id is set (not -1) 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No