### PR TITLE
feat: Capture top-level Fragments with Autocapture

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,7 +63,9 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
     implementation 'com.amplitude:analytics-connector:1.0.0'
     implementation 'androidx.core:core-ktx:1.7.0'
-    compileOnly 'androidx.compose.ui:ui:1.6.7'
+    implementation 'androidx.activity:activity-ktx:1.9.1'
+    compileOnly 'androidx.fragment:fragment-ktx:1.8.2'
+    compileOnly 'androidx.compose.ui:ui:1.6.8'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 

--- a/android/src/main/java/com/amplitude/android/internal/fragments/AutocaptureFragmentLifecycleCallbacks.kt
+++ b/android/src/main/java/com/amplitude/android/internal/fragments/AutocaptureFragmentLifecycleCallbacks.kt
@@ -7,8 +7,8 @@ import com.amplitude.android.utilities.DefaultEventUtils.EventProperties
 import com.amplitude.android.utilities.DefaultEventUtils.EventTypes
 import com.amplitude.common.Logger
 
-class AutocaptureFragmentLifecycleCallbacks(
-    private val track: (String, Map<String, Any?>) -> Unit,
+internal class AutocaptureFragmentLifecycleCallbacks(
+    private val track: TrackEventCallback,
     private val logger: Logger
 ) : FragmentManager.FragmentLifecycleCallbacks() {
     override fun onFragmentResumed(fm: FragmentManager, f: Fragment) {

--- a/android/src/main/java/com/amplitude/android/internal/fragments/AutocaptureFragmentLifecycleCallbacks.kt
+++ b/android/src/main/java/com/amplitude/android/internal/fragments/AutocaptureFragmentLifecycleCallbacks.kt
@@ -1,5 +1,7 @@
 package com.amplitude.android.internal.fragments
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.amplitude.android.utilities.DefaultEventUtils.Companion.screenName
@@ -7,6 +9,7 @@ import com.amplitude.android.utilities.DefaultEventUtils.EventProperties
 import com.amplitude.android.utilities.DefaultEventUtils.EventTypes
 import com.amplitude.common.Logger
 
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal class AutocaptureFragmentLifecycleCallbacks(
     private val track: TrackEventCallback,
     private val logger: Logger

--- a/android/src/main/java/com/amplitude/android/internal/fragments/AutocaptureFragmentLifecycleCallbacks.kt
+++ b/android/src/main/java/com/amplitude/android/internal/fragments/AutocaptureFragmentLifecycleCallbacks.kt
@@ -1,0 +1,42 @@
+package com.amplitude.android.internal.fragments
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import com.amplitude.android.utilities.DefaultEventUtils.Companion.screenName
+import com.amplitude.android.utilities.DefaultEventUtils.EventProperties
+import com.amplitude.android.utilities.DefaultEventUtils.EventTypes
+import com.amplitude.common.Logger
+
+class AutocaptureFragmentLifecycleCallbacks(
+    private val track: (String, Map<String, Any?>) -> Unit,
+    private val logger: Logger
+) : FragmentManager.FragmentLifecycleCallbacks() {
+    override fun onFragmentResumed(fm: FragmentManager, f: Fragment) {
+        super.onFragmentResumed(fm, f)
+
+        val className = f.javaClass.canonicalName ?: f.javaClass.simpleName ?: null
+        val fragmentIdentifier = runCatching {
+            // The id could be the `android:id` value supplied in a layout or the container view ID
+            // supplied when adding the fragment.
+            f.resources.getResourceEntryName(f.id)
+        }.onFailure {
+            logger.error("Failed to get resource entry name: $it")
+        }.getOrNull()
+        val screenName = runCatching {
+            f.activity?.screenName
+        }.onFailure {
+            logger.error("Failed to get screen name: $it")
+        }.getOrNull()
+        val fragmentTag = f.tag
+
+        track(
+            EventTypes.FRAGMENT_VIEWED,
+            mapOf(
+                EventProperties.FRAGMENT_CLASS to className,
+                EventProperties.FRAGMENT_IDENTIFIER to fragmentIdentifier,
+                EventProperties.SCREEN_NAME to screenName,
+                EventProperties.FRAGMENT_TAG to fragmentTag,
+            )
+        )
+    }
+}

--- a/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
+++ b/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
@@ -1,0 +1,14 @@
+package com.amplitude.android.internal.fragments
+
+import android.app.Activity
+import androidx.fragment.app.FragmentActivity
+import com.amplitude.core.Amplitude
+
+object FragmentActivityHandler {
+    fun Activity.attachFragmentLifecycleCallbacks(amplitude: Amplitude) {
+        (this as? FragmentActivity)?.supportFragmentManager?.registerFragmentLifecycleCallbacks(
+            AutocaptureFragmentLifecycleCallbacks(amplitude::track, amplitude.logger),
+            false
+        )
+    }
+}

--- a/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
+++ b/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
@@ -19,16 +19,16 @@ internal object FragmentActivityHandler {
             val callback = AutocaptureFragmentLifecycleCallbacks(track, logger)
             supportFragmentManager.registerFragmentLifecycleCallbacks(callback, false)
             callbacksMap.getOrPut(this) { mutableListOf() }.add(callback)
-        }
+        } ?: logger.debug("Activity is not a FragmentActivity")
     }
 
-    fun Activity.unregisterFragmentLifecycleCallbacks() {
+    fun Activity.unregisterFragmentLifecycleCallbacks(logger: Logger) {
         (this as? FragmentActivity)?.apply {
             callbacksMap.remove(this)?.let { callbacks ->
                 for (callback in callbacks) {
                     supportFragmentManager.unregisterFragmentLifecycleCallbacks(callback)
                 }
             }
-        }
+        } ?: logger.debug("Activity is not a FragmentActivity")
     }
 }

--- a/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
+++ b/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
@@ -20,9 +20,11 @@ internal object FragmentActivityHandler {
     }
 
     fun Activity.unregisterFragmentLifecycleCallbacks() {
-        (this as? FragmentActivity)?.let { fragmentActivity ->
-            callbacksMap.remove(fragmentActivity)?.forEach {
-                fragmentActivity.supportFragmentManager.unregisterFragmentLifecycleCallbacks(it)
+        (this as? FragmentActivity)?.apply {
+            callbacksMap.remove(this)?.let { callbacks ->
+                for (callback in callbacks) {
+                    supportFragmentManager.unregisterFragmentLifecycleCallbacks(callback)
+                }
             }
         }
     }

--- a/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
+++ b/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
@@ -1,12 +1,15 @@
 package com.amplitude.android.internal.fragments
 
 import android.app.Activity
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.fragment.app.FragmentActivity
 import com.amplitude.common.Logger
 import java.util.WeakHashMap
 
 internal typealias TrackEventCallback = (String, Map<String, Any?>) -> Unit
 
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 internal object FragmentActivityHandler {
     private val callbacksMap =
         WeakHashMap<FragmentActivity, MutableList<AutocaptureFragmentLifecycleCallbacks>>()

--- a/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
+++ b/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
@@ -2,13 +2,31 @@ package com.amplitude.android.internal.fragments
 
 import android.app.Activity
 import androidx.fragment.app.FragmentActivity
-import com.amplitude.core.Amplitude
+import com.amplitude.common.Logger
+import java.util.WeakHashMap
 
-object FragmentActivityHandler {
-    fun Activity.attachFragmentLifecycleCallbacks(amplitude: Amplitude) {
-        (this as? FragmentActivity)?.supportFragmentManager?.registerFragmentLifecycleCallbacks(
-            AutocaptureFragmentLifecycleCallbacks(amplitude::track, amplitude.logger),
-            false
-        )
+internal typealias TrackEventCallback = (String, Map<String, Any?>) -> Unit
+
+internal object FragmentActivityHandler {
+    private val callbacksMap =
+        WeakHashMap<FragmentActivity, AutocaptureFragmentLifecycleCallbacks>()
+
+    fun Activity.registerFragmentLifecycleCallbacks(track: TrackEventCallback, logger: Logger) {
+        (this as? FragmentActivity)?.let { fragmentActivity ->
+            val callback = AutocaptureFragmentLifecycleCallbacks(track, logger)
+            fragmentActivity.supportFragmentManager
+                .registerFragmentLifecycleCallbacks(callback, false)
+            callbacksMap[fragmentActivity] = callback
+        }
+    }
+
+    fun Activity.unregisterFragmentLifecycleCallbacks() {
+        (this as? FragmentActivity)?.let { fragmentActivity ->
+            callbacksMap[fragmentActivity]?.let { callback ->
+                fragmentActivity.supportFragmentManager
+                    .unregisterFragmentLifecycleCallbacks(callback)
+                callbacksMap.remove(fragmentActivity)
+            }
+        }
     }
 }

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -4,11 +4,14 @@ import android.app.Activity
 import android.app.Application
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import com.amplitude.android.AutocaptureOption
 import com.amplitude.android.Configuration
 import com.amplitude.android.ExperimentalAmplitudeFeature
+import com.amplitude.android.internal.fragments.FragmentActivityHandler.attachFragmentLifecycleCallbacks
 import com.amplitude.android.utilities.DefaultEventUtils
+import com.amplitude.android.utilities.LoadClass
 import com.amplitude.core.Amplitude
 import com.amplitude.core.platform.Plugin
 import java.util.concurrent.atomic.AtomicBoolean
@@ -50,6 +53,12 @@ class AndroidLifecyclePlugin : Application.ActivityLifecycleCallbacks, Plugin {
         }
         if (AutocaptureOption.DEEP_LINKS in androidConfiguration.autocapture) {
             DefaultEventUtils(androidAmplitude).trackDeepLinkOpenedEvent(activity)
+        }
+        if (AutocaptureOption.SCREEN_VIEWS in androidConfiguration.autocapture &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+            LoadClass().isClassAvailable(FRAGMENT_ACTIVITY_CLASS_NAME, amplitude.logger)
+        ) {
+            activity.attachFragmentLifecycleCallbacks(amplitude)
         }
     }
 
@@ -100,6 +109,7 @@ class AndroidLifecyclePlugin : Application.ActivityLifecycleCallbacks, Plugin {
     }
 
     companion object {
+        private const val FRAGMENT_ACTIVITY_CLASS_NAME = "androidx.fragment.app.FragmentActivity"
         @JvmStatic
         fun getCurrentTimeMillis(): Long {
             return System.currentTimeMillis()

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -4,14 +4,11 @@ import android.app.Activity
 import android.app.Application
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import com.amplitude.android.AutocaptureOption
 import com.amplitude.android.Configuration
 import com.amplitude.android.ExperimentalAmplitudeFeature
-import com.amplitude.android.internal.fragments.FragmentActivityHandler.attachFragmentLifecycleCallbacks
 import com.amplitude.android.utilities.DefaultEventUtils
-import com.amplitude.android.utilities.LoadClass
 import com.amplitude.core.Amplitude
 import com.amplitude.core.platform.Plugin
 import java.util.concurrent.atomic.AtomicBoolean
@@ -54,11 +51,8 @@ class AndroidLifecyclePlugin : Application.ActivityLifecycleCallbacks, Plugin {
         if (AutocaptureOption.DEEP_LINKS in androidConfiguration.autocapture) {
             DefaultEventUtils(androidAmplitude).trackDeepLinkOpenedEvent(activity)
         }
-        if (AutocaptureOption.SCREEN_VIEWS in androidConfiguration.autocapture &&
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-            LoadClass().isClassAvailable(FRAGMENT_ACTIVITY_CLASS_NAME, amplitude.logger)
-        ) {
-            activity.attachFragmentLifecycleCallbacks(amplitude)
+        if (AutocaptureOption.SCREEN_VIEWS in androidConfiguration.autocapture) {
+            DefaultEventUtils(androidAmplitude).startFragmentViewedEventTracking(activity)
         }
     }
 
@@ -101,6 +95,9 @@ class AndroidLifecyclePlugin : Application.ActivityLifecycleCallbacks, Plugin {
     }
 
     override fun onActivityDestroyed(activity: Activity) {
+        if (AutocaptureOption.SCREEN_VIEWS in androidConfiguration.autocapture) {
+            DefaultEventUtils(androidAmplitude).stopFragmentViewedEventTracking(activity)
+        }
     }
 
     override fun teardown() {
@@ -109,7 +106,6 @@ class AndroidLifecyclePlugin : Application.ActivityLifecycleCallbacks, Plugin {
     }
 
     companion object {
-        private const val FRAGMENT_ACTIVITY_CLASS_NAME = "androidx.fragment.app.FragmentActivity"
         @JvmStatic
         fun getCurrentTimeMillis(): Long {
             return System.currentTimeMillis()

--- a/android/src/main/java/com/amplitude/android/utilities/ComposeUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/ComposeUtils.kt
@@ -2,14 +2,13 @@ package com.amplitude.android.utilities
 
 import com.amplitude.common.Logger
 
-object ComposeUtils {
-    private val loadClass = LoadClass()
+internal object ComposeUtils {
     private const val COMPOSE_CLASS_NAME = "androidx.compose.ui.node.Owner"
     private const val COMPOSE_GESTURE_LOCATOR_CLASS_NAME =
         "com.amplitude.android.internal.locators.ComposeViewTargetLocator"
 
     fun isComposeAvailable(logger: Logger? = null): Boolean {
-        return loadClass.isClassAvailable(COMPOSE_CLASS_NAME, logger) &&
-            loadClass.isClassAvailable(COMPOSE_GESTURE_LOCATOR_CLASS_NAME, logger)
+        return LoadClass.isClassAvailable(COMPOSE_CLASS_NAME, logger) &&
+            LoadClass.isClassAvailable(COMPOSE_GESTURE_LOCATOR_CLASS_NAME, logger)
     }
 }

--- a/android/src/main/java/com/amplitude/android/utilities/ComposeUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/ComposeUtils.kt
@@ -2,16 +2,14 @@ package com.amplitude.android.utilities
 
 import com.amplitude.common.Logger
 
-class ComposeUtils {
-    companion object {
-        private val loadClass = LoadClass()
-        private const val COMPOSE_CLASS_NAME = "androidx.compose.ui.node.Owner"
-        private const val COMPOSE_GESTURE_LOCATOR_CLASS_NAME =
-            "com.amplitude.android.internal.locators.ComposeViewTargetLocator"
+object ComposeUtils {
+    private val loadClass = LoadClass()
+    private const val COMPOSE_CLASS_NAME = "androidx.compose.ui.node.Owner"
+    private const val COMPOSE_GESTURE_LOCATOR_CLASS_NAME =
+        "com.amplitude.android.internal.locators.ComposeViewTargetLocator"
 
-        fun isComposeAvailable(logger: Logger? = null): Boolean {
-            return loadClass.isClassAvailable(COMPOSE_CLASS_NAME, logger) &&
-                loadClass.isClassAvailable(COMPOSE_GESTURE_LOCATOR_CLASS_NAME, logger)
-        }
+    fun isComposeAvailable(logger: Logger? = null): Boolean {
+        return loadClass.isClassAvailable(COMPOSE_CLASS_NAME, logger) &&
+            loadClass.isClassAvailable(COMPOSE_GESTURE_LOCATOR_CLASS_NAME, logger)
     }
 }

--- a/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
@@ -22,6 +22,7 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
         const val APPLICATION_BACKGROUNDED = "[Amplitude] Application Backgrounded"
         const val DEEP_LINK_OPENED = "[Amplitude] Deep Link Opened"
         const val SCREEN_VIEWED = "[Amplitude] Screen Viewed"
+        const val FRAGMENT_VIEWED = "[Amplitude] Fragment Viewed"
         const val ELEMENT_INTERACTED = "[Amplitude] Element Interacted"
     }
 
@@ -34,6 +35,9 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
         const val LINK_URL = "[Amplitude] Link URL"
         const val LINK_REFERRER = "[Amplitude] Link Referrer"
         const val SCREEN_NAME = "[Amplitude] Screen Name"
+        const val FRAGMENT_CLASS = "[Amplitude] Fragment Class"
+        const val FRAGMENT_IDENTIFIER = "[Amplitude] Fragment Identifier"
+        const val FRAGMENT_TAG = "[Amplitude] Fragment Tag"
         const val ACTION = "[Amplitude] Action"
         const val TARGET_CLASS = "[Amplitude] Target Class"
         const val TARGET_RESOURCE = "[Amplitude] Target Resource"

--- a/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
@@ -163,13 +163,17 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
     }
 
     fun startFragmentViewedEventTracking(activity: Activity) {
-        if (isFragmentActivityAvailable) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+            LoadClass.isClassAvailable(FRAGMENT_ACTIVITY_CLASS_NAME, amplitude.logger)
+        ) {
             activity.registerFragmentLifecycleCallbacks(amplitude::track, amplitude.logger)
         }
     }
 
     fun stopFragmentViewedEventTracking(activity: Activity) {
-        if (isFragmentActivityAvailable) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+            LoadClass.isClassAvailable(FRAGMENT_ACTIVITY_CLASS_NAME, amplitude.logger)
+        ) {
             activity.unregisterFragmentLifecycleCallbacks()
         }
     }
@@ -193,10 +197,6 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
                 return info?.loadLabel(packageManager)?.toString() ?: info?.name
             }
     }
-
-    private val isFragmentActivityAvailable: Boolean =
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-            LoadClass.isClassAvailable(FRAGMENT_ACTIVITY_CLASS_NAME, amplitude.logger)
 
     private fun getReferrer(activity: Activity): Uri? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {

--- a/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
@@ -174,7 +174,7 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
             LoadClass.isClassAvailable(FRAGMENT_ACTIVITY_CLASS_NAME, amplitude.logger)
         ) {
-            activity.unregisterFragmentLifecycleCallbacks()
+            activity.unregisterFragmentLifecycleCallbacks(amplitude.logger)
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/utilities/LoadClass.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/LoadClass.kt
@@ -3,7 +3,7 @@ package com.amplitude.android.utilities
 import com.amplitude.common.Logger
 
 /** An Adapter for making Class.forName testable  */
-class LoadClass {
+object LoadClass {
     /**
      * Try to load a class via reflection
      *


### PR DESCRIPTION
### Summary

This PR adds support for capturing top-level Fragments with the `screenView` configuration of Autocapture.

#### New Event
- `[Amplitude] Fragment Viewed`, this event is fired when the Fragment becomes visible on the screen.

#### New properties
- `[Amplitude] Fragment Class`, the canonical class name of the Fragment.
- `[Amplitude] Fragment Identifier`, the entry name of the fragment based on its internal id. The entry name is the id specified in the layout.
-  `[Amplitude] Screen Name`
- `[Amplitude] Fragment Tag`, the tag attached to the fragment.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no