### PR TITLE
fix: Add target text capture for Android Views in Autocapture

### DIFF
--- a/android/src/main/java/com/amplitude/android/internal/ViewTarget.kt
+++ b/android/src/main/java/com/amplitude/android/internal/ViewTarget.kt
@@ -14,6 +14,7 @@ data class ViewTarget(
     val className: String?,
     val resourceName: String?,
     val tag: String?,
+    val text: String?,
     val source: String,
     val hierarchy: String?,
 ) {

--- a/android/src/main/java/com/amplitude/android/internal/gestures/AutocaptureGestureListener.kt
+++ b/android/src/main/java/com/amplitude/android/internal/gestures/AutocaptureGestureListener.kt
@@ -15,6 +15,7 @@ import com.amplitude.android.utilities.DefaultEventUtils.EventProperties.TARGET_
 import com.amplitude.android.utilities.DefaultEventUtils.EventProperties.TARGET_RESOURCE
 import com.amplitude.android.utilities.DefaultEventUtils.EventProperties.TARGET_SOURCE
 import com.amplitude.android.utilities.DefaultEventUtils.EventProperties.TARGET_TAG
+import com.amplitude.android.utilities.DefaultEventUtils.EventProperties.TARGET_TEXT
 import com.amplitude.android.utilities.DefaultEventUtils.EventTypes.ELEMENT_INTERACTED
 import com.amplitude.common.Logger
 import java.lang.ref.WeakReference
@@ -51,6 +52,7 @@ class AutocaptureGestureListener(
             TARGET_CLASS to target.className,
             TARGET_RESOURCE to target.resourceName,
             TARGET_TAG to target.tag,
+            TARGET_TEXT to target.text,
             TARGET_SOURCE to
                 target.source
                     .replace("_", " ")

--- a/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
+++ b/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
@@ -28,7 +28,9 @@ internal class AndroidViewTargetLocator : ViewTargetLocator {
         val className = javaClass.canonicalName ?: javaClass.simpleName ?: null
         val resourceName = resourceIdWithFallback
         val hierarchy = hierarchy
-        val tag = tag?.toString()
+        val tag = tag
+            ?.takeIf { it is String || it is Number || it is Boolean || it is Char }
+            ?.toString()
         val text = (this as? TextView)?.text?.toString()
         return ViewTarget(this, className, resourceName, tag, text, SOURCE, hierarchy)
     }

--- a/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
+++ b/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
@@ -28,8 +28,9 @@ internal class AndroidViewTargetLocator : ViewTargetLocator {
         val className = javaClass.canonicalName ?: javaClass.simpleName ?: null
         val resourceName = resourceIdWithFallback
         val hierarchy = hierarchy
+        val tag = tag?.toString()
         val text = (this as? TextView)?.text?.toString()
-        return ViewTarget(this, className, resourceName, tag as? String, text, SOURCE, hierarchy)
+        return ViewTarget(this, className, resourceName, tag, text, SOURCE, hierarchy)
     }
 
     private fun View.touchWithinBounds(position: Pair<Float, Float>): Boolean {

--- a/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
+++ b/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
@@ -1,6 +1,7 @@
 package com.amplitude.android.internal.locators
 
 import android.view.View
+import android.widget.TextView
 import com.amplitude.android.internal.ViewResourceUtils.resourceIdWithFallback
 import com.amplitude.android.internal.ViewTarget
 import com.amplitude.android.internal.ViewTarget.Type
@@ -27,7 +28,8 @@ internal class AndroidViewTargetLocator : ViewTargetLocator {
         val className = javaClass.canonicalName ?: javaClass.simpleName ?: null
         val resourceName = resourceIdWithFallback
         val hierarchy = hierarchy
-        return ViewTarget(this, className, resourceName, null, SOURCE, hierarchy)
+        val text = (this as? TextView)?.text?.toString()
+        return ViewTarget(this, className, resourceName, tag as? String, text, SOURCE, hierarchy)
     }
 
     private fun View.touchWithinBounds(position: Pair<Float, Float>): Boolean {

--- a/android/src/main/java/com/amplitude/android/internal/locators/ComposeViewTargetLocator.java
+++ b/android/src/main/java/com/amplitude/android/internal/locators/ComposeViewTargetLocator.java
@@ -107,7 +107,7 @@ public class ComposeViewTargetLocator implements ViewTargetLocator {
         if (targetTag == null) {
             return null;
         } else {
-            return new ViewTarget(null, null, null, targetTag, SOURCE, null);
+            return new ViewTarget(null, null, null, targetTag, null, SOURCE, null);
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
@@ -38,6 +38,7 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
         const val TARGET_CLASS = "[Amplitude] Target Class"
         const val TARGET_RESOURCE = "[Amplitude] Target Resource"
         const val TARGET_TAG = "[Amplitude] Target Tag"
+        const val TARGET_TEXT = "[Amplitude] Target Text"
         const val TARGET_SOURCE = "[Amplitude] Target Source"
         const val HIERARCHY = "[Amplitude] Hierarchy"
     }

--- a/android/src/test/java/com/amplitude/android/internal/gestures/AutocaptureGestureListenerClickTest.kt
+++ b/android/src/test/java/com/amplitude/android/internal/gestures/AutocaptureGestureListenerClickTest.kt
@@ -146,6 +146,7 @@ class AutocaptureGestureListenerClickTest {
                     "[Amplitude] Target Class" to "android.view.View",
                     "[Amplitude] Target Resource" to "test_button",
                     "[Amplitude] Target Tag" to null,
+                    "[Amplitude] Target Text" to null,
                     "[Amplitude] Target Source" to "Android View",
                     "[Amplitude] Hierarchy" to "View",
                     "[Amplitude] Screen Name" to null,


### PR DESCRIPTION
### Summary

This PR adds support for tracking the localized text of Android Views in Autocapture.

#### New property

`[Amplitude] Target Text`, the text of the clickable target in Android Views.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no