### PR TITLE
fix: Track buttons text only for clickable elements in Autocapture

### DIFF
--- a/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
+++ b/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
@@ -1,7 +1,7 @@
 package com.amplitude.android.internal.locators
 
 import android.view.View
-import android.widget.TextView
+import android.widget.Button
 import com.amplitude.android.internal.ViewResourceUtils.resourceIdWithFallback
 import com.amplitude.android.internal.ViewTarget
 import com.amplitude.android.internal.ViewTarget.Type
@@ -31,7 +31,7 @@ internal class AndroidViewTargetLocator : ViewTargetLocator {
         val tag = tag
             ?.takeIf { it is String || it is Number || it is Boolean || it is Char }
             ?.toString()
-        val text = (this as? TextView)?.text?.toString()
+        val text = (this as? Button)?.text?.toString()
         return ViewTarget(this, className, resourceName, tag, text, SOURCE, hierarchy)
     }
 


### PR DESCRIPTION
### Summary

This PR limits tracking clickable elements text to buttons only.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no