### PR TITLE
fix: don't delete old profile file for backwards compatibility

### DIFF
--- a/android/src/main/java/com/amplitude/android/migration/IdentityStorageMigration.kt
+++ b/android/src/main/java/com/amplitude/android/migration/IdentityStorageMigration.kt
@@ -18,7 +18,9 @@ class IdentityStorageMigration(
             if (identity.deviceId != null) {
                 destination.saveDeviceId(identity.deviceId)
             }
-            source.delete()
+            // Since we are not doing a major version upgrade, keep the old profile file around
+            // just in case someone decides to rollback back to the older version of the SDK.
+//            source.delete()
         } catch (e: Exception) {
             logger.error("Unable to migrate file identity storage: ${e.message}")
         }


### PR DESCRIPTION
### Summary

Don't delete the old profile file since we are not doing a major version upgrade. Deleting this file prevents will cause issues when a customer rolls back the Amplitude SDK to an older version or rollsback their app.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->