### PR TITLE
fix: type mismatch on `queryDb`

### DIFF
--- a/android/src/main/java/com/amplitude/android/migration/DatabaseStorage.kt
+++ b/android/src/main/java/com/amplitude/android/migration/DatabaseStorage.kt
@@ -67,7 +67,7 @@ class DatabaseStorage(
 
     private fun queryDb(
         db: SQLiteDatabase,
-        table: String?,
+        table: String,
         columns: Array<String?>?,
         selection: String?,
         selectionArgs: Array<String?>?,


### PR DESCRIPTION
### Summary

Adding support for API version 35's sqlite library. The field table is non nullable.

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->