### PR TITLE
fix: initialize custom http client with configuration

### DIFF
--- a/core/src/main/java/com/amplitude/core/Configuration.kt
+++ b/core/src/main/java/com/amplitude/core/Configuration.kt
@@ -57,7 +57,7 @@ open class Configuration @JvmOverloads constructor(
         }
     }
 
-    internal fun getApiHost(): String {
+    fun getApiHost(): String {
         return this.serverUrl ?: with(this) {
             when {
                 serverZone == ServerZone.EU && useBatch -> Constants.EU_BATCH_API_HOST

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/CustomOkHttpClient.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/CustomOkHttpClient.kt
@@ -1,5 +1,6 @@
 package com.amplitude.android.sample
 
+import com.amplitude.android.Configuration
 import com.amplitude.core.utilities.http.AnalyticsRequest
 import com.amplitude.core.utilities.http.AnalyticsResponse
 import com.amplitude.core.utilities.http.HttpClientInterface
@@ -9,15 +10,25 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import java.io.IOException
 
-class CustomOkHttpClient(val apiKey: String) : HttpClientInterface {
+class CustomOkHttpClient : HttpClientInterface {
     private val okHttpClient = OkHttpClient()
+    private lateinit var configuration: Configuration
+
+    fun initialize(configuration: Configuration) {
+        this.configuration = configuration
+    }
 
     override fun upload(events: String, diagnostics: String?): AnalyticsResponse {
         val mediaType = "application/json; charset=utf-8".toMediaTypeOrNull()
-        val ampRequest = AnalyticsRequest(apiKey, events, diagnostics = diagnostics)
+        val ampRequest = AnalyticsRequest(
+            configuration.apiKey,
+            events,
+            diagnostics = diagnostics,
+            minIdLength = configuration.minIdLength
+        )
         val formBody: RequestBody = RequestBody.create(mediaType, ampRequest.getBodyStr())
         val request: Request =
-            Request.Builder().url("https://api.amplitude.com/2/httpapi").post(formBody).build()
+            Request.Builder().url(configuration.getApiHost()).post(formBody).build()
 
         try {
             val response = okHttpClient.newCall(request).execute()

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/MainApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/MainApplication.kt
@@ -20,20 +20,22 @@ class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        // init instance
-        amplitude = Amplitude(
-            Configuration(
-                apiKey = AMPLITUDE_API_KEY,
-                context = applicationContext,
-                autocapture = autocaptureOptions {
-                    +sessions
-                    +appLifecycles
-                    +deepLinks
-                    +screenViews
-                },
-                httpClient = CustomOkHttpClient(AMPLITUDE_API_KEY),
-            )
+        val httpClient = CustomOkHttpClient()
+        val configuration = Configuration(
+            apiKey = AMPLITUDE_API_KEY,
+            context = applicationContext,
+            autocapture = autocaptureOptions {
+                +sessions
+                +appLifecycles
+                +deepLinks
+                +screenViews
+            },
+            httpClient = httpClient,
         )
+        httpClient.initialize(configuration)
+
+        // init instance
+        amplitude = Amplitude(configuration)
 
         // Sample for Experiment Integration
         val experimentConfig = ExperimentConfig.builder()


### PR DESCRIPTION
### Summary
- Making `getApiHost` accessible to customers
- Update example to show how to use custom clients with config

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->