### PR TITLE
chore: Update Developer Center docs hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 This is Amplitude's latest version of the Kotlin SDK, covering Android.
 
 ## Installation and Quick Start
-Please visit our :100:[Developer Center](https://developers.amplitude.com/docs/kotlin-android-beta) for instructions on installing and using our SDK.
+Please visit our :100:[Developer Center](https://amplitude.com/docs/sdks/analytics/android/android-kotlin-sdk) for instructions on installing and using our SDK.
 
 ## Doc
 See our [Kotlin SDK Reference](http://amplitude.github.io/Amplitude-Kotlin/) for a list and description of all available SDK methods.


### PR DESCRIPTION
### Summary

The 💯  Developer Center hyperlink was pointing to a broken link and directing users to the homepage of our docs (https://amplitude.com/docs) rather than directly to the Kotlin SDK docs. Points the hyperlink to the current docs (https://amplitude.com/docs/sdks/analytics/android/android-kotlin-sdk).


### Checklist

* [ ✅] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no