### PR TITLE
fix: ignore illegal state exception on addShutdownHook w/c happens wh…

### DIFF
--- a/core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
@@ -171,13 +171,19 @@ class EventPipeline(
 
     private fun registerShutdownHook() {
         // close the stream if the app shuts down
-        Runtime.getRuntime().addShutdownHook(
-            object : Thread() {
-                override fun run() {
-                    this@EventPipeline.stop()
-                }
-            },
-        )
+        try {
+            Runtime.getRuntime().addShutdownHook(
+                object : Thread() {
+                    override fun run() {
+                        this@EventPipeline.stop()
+                    }
+                },
+            )
+        } catch (e: IllegalStateException) {
+            // Once the shutdown sequence has begun it is impossible to register a shutdown hook,
+            // so we just ignore the IllegalStateException that's thrown.
+            // https://developer.android.com/reference/java/lang/Runtime#addShutdownHook(java.lang.Thread)
+        }
     }
 }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉
Please fill out the following sections to help us quickly review your pull request. 
--->

### Summary

<!-- What does the PR do? -->

Ignore illegal state exception on addShutdownHook w/c happens when shutdown sequence has begun.
This PR aims to fix this reported crash https://github.com/amplitude/Amplitude-Kotlin/issues/225

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->