### PR TITLE
fix: add consumer-rules for useAppSetIdForDeviceId = true

### DIFF
--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,14 @@
+# We rely on these Google Play services AppSet classes when useAppSetIdForDeviceId = true
+-keep class com.google.android.gms.appset.AppSet {
+  public getClient(android.content.Context);
+}
+-keep class com.google.android.gms.appset.AppSetIdClient {
+  public getAppSetIdInfo();
+}
+-keep class com.google.android.gms.appset.AppSetIdInfo {
+  public getId();
+}
+-keep class com.google.android.gms.tasks.Tasks {
+  public await(com.google.android.gms.tasks.Task);
+}
+-keep class com.google.android.gms.tasks.Task


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds `consumer-rules.pro` to fix errors when minify is enabled and `useAppSetIdForDeviceId = true`.
Fixes https://github.com/amplitude/Amplitude-Kotlin/issues/205

Tested locally with both minify and app set flag enabled.

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->