### PR TITLE
fix: respect play services flags inside context provider

### DIFF
--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -20,7 +20,8 @@ open class AndroidContextPlugin : Plugin {
         contextProvider = AndroidContextProvider(
             configuration.context,
             configuration.locationListening,
-            configuration.trackingOptions.shouldTrackAdid()
+            configuration.trackingOptions.shouldTrackAdid(),
+            configuration.trackingOptions.shouldTrackAppSetId()
         )
         initializeDeviceId(configuration)
     }

--- a/common-android/build.gradle
+++ b/common-android/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
     testImplementation 'com.google.android.gms:play-services-base:18.0.1'
     testImplementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+    testImplementation 'com.google.android.gms:play-services-appset:16.0.2'
     testImplementation 'io.mockk:mockk:1.12.3'
     testImplementation 'org.robolectric:robolectric:4.12.1'
     testImplementation 'androidx.test:core:1.4.0'

--- a/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt
+++ b/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt
@@ -20,7 +20,8 @@ import java.util.Locale
 class AndroidContextProvider(
     private val context: Context,
     private val locationListening: Boolean,
-    private val shouldTrackAdid: Boolean
+    private val shouldTrackAdid: Boolean,
+    private val shouldTrackAppSetId: Boolean
 ) : ContextProvider {
     private val cachedInfo: CachedInfo by lazy { CachedInfo() }
 
@@ -193,6 +194,10 @@ class AndroidContextProvider(
         }
 
         private fun fetchAppSetId(): String? {
+            if (!shouldTrackAppSetId) {
+                return null
+            }
+
             try {
                 val AppSet = Class
                     .forName("com.google.android.gms.appset.AppSet")

--- a/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt
+++ b/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt
@@ -29,7 +29,7 @@ class AndroidContextProvider(
      * Internal class serves as a cache
      */
     inner class CachedInfo {
-        var advertisingId: String?
+        val advertisingId: String?
         val country: String?
         val versionName: String?
         val osName: String
@@ -41,7 +41,7 @@ class AndroidContextProvider(
         val language: String
         var limitAdTrackingEnabled: Boolean = true
         val gpsEnabled: Boolean
-        var appSetId: String?
+        val appSetId: String?
 
         init {
             osName = OS_NAME
@@ -52,12 +52,12 @@ class AndroidContextProvider(
             language = locale.language
 
             // order is important here, some fields are checked before fetching the data
-            advertisingId = fetchAdvertisingId()
+            advertisingId = if (shouldTrackAdid) fetchAdvertisingId() else null
             versionName = fetchVersionName()
             carrier = fetchCarrier()
             country = fetchCountry()
             gpsEnabled = checkGPSEnabled()
-            appSetId = fetchAppSetId()
+            appSetId = if (shouldTrackAppSetId) fetchAppSetId() else null
         }
 
         /**
@@ -180,24 +180,17 @@ class AndroidContextProvider(
         private val countryFromLocale: String
             get() = locale.country
 
-        private fun fetchAdvertisingId(): String? {
-            if (!shouldTrackAdid) {
-                return null
-            }
-
-            // This should not be called on the main thread.
-            return if ("Amazon" == manufacturer) {
-                fetchAndCacheAmazonAdvertisingId
+        /**
+         * This should not be called on the main thread.
+         */
+        private fun fetchAdvertisingId(): String? =
+            if ("Amazon" == manufacturer) {
+                fetchAndCacheAmazonAdvertisingId()
             } else {
-                fetchAndCacheGoogleAdvertisingId
+                fetchAndCacheGoogleAdvertisingId()
             }
-        }
 
         private fun fetchAppSetId(): String? {
-            if (!shouldTrackAppSetId) {
-                return null
-            }
-
             try {
                 val AppSet = Class
                     .forName("com.google.android.gms.appset.AppSet")
@@ -210,7 +203,7 @@ class AndroidContextProvider(
                     Tasks.getMethod("await", Class.forName("com.google.android.gms.tasks.Task"))
                 val appSetInfo = await.invoke(null, taskWithAppSetInfo)
                 val getId = appSetInfo.javaClass.getMethod("getId")
-                appSetId = getId.invoke(appSetInfo) as String
+                return getId.invoke(appSetInfo) as String
             } catch (e: ClassNotFoundException) {
                 LogcatLogger.logger
                     .warn("Google Play Services SDK not found for app set id!")
@@ -221,48 +214,47 @@ class AndroidContextProvider(
                     "Encountered an error connecting to Google Play Services for app set id"
                 )
             }
-            return appSetId
+
+            return null
         }
 
-        private val fetchAndCacheAmazonAdvertisingId: String?
-            get() {
-                val cr = context.contentResolver
-                limitAdTrackingEnabled = Secure.getInt(cr, SETTING_LIMIT_AD_TRACKING, 0) == 1
-                advertisingId = Secure.getString(cr, SETTING_ADVERTISING_ID)
-                return advertisingId
+        private fun fetchAndCacheAmazonAdvertisingId(): String? {
+            val cr = context.contentResolver
+            limitAdTrackingEnabled = Secure.getInt(cr, SETTING_LIMIT_AD_TRACKING, 0) == 1
+            return Secure.getString(cr, SETTING_ADVERTISING_ID)
+        }
+
+        private fun fetchAndCacheGoogleAdvertisingId(): String? {
+            try {
+                val AdvertisingIdClient = Class
+                    .forName("com.google.android.gms.ads.identifier.AdvertisingIdClient")
+                val getAdvertisingInfo = AdvertisingIdClient.getMethod(
+                    "getAdvertisingIdInfo",
+                    Context::class.java
+                )
+                val advertisingInfo = getAdvertisingInfo.invoke(null, context)
+                val isLimitAdTrackingEnabled = advertisingInfo.javaClass.getMethod(
+                    "isLimitAdTrackingEnabled"
+                )
+                val limitAdTrackingEnabled = isLimitAdTrackingEnabled
+                    .invoke(advertisingInfo) as? Boolean
+                this.limitAdTrackingEnabled =
+                    limitAdTrackingEnabled != null && limitAdTrackingEnabled
+                val getId = advertisingInfo.javaClass.getMethod("getId")
+                return getId.invoke(advertisingInfo) as String
+            } catch (e: ClassNotFoundException) {
+                LogcatLogger.logger
+                    .warn("Google Play Services SDK not found for advertising id!")
+            } catch (e: InvocationTargetException) {
+                LogcatLogger.logger
+                    .warn("Google Play Services not available for advertising id")
+            } catch (e: Exception) {
+                LogcatLogger.logger.error(
+                    "Encountered an error connecting to Google Play Services for advertising id"
+                )
             }
-        private val fetchAndCacheGoogleAdvertisingId: String?
-            get() {
-                try {
-                    val AdvertisingIdClient = Class
-                        .forName("com.google.android.gms.ads.identifier.AdvertisingIdClient")
-                    val getAdvertisingInfo = AdvertisingIdClient.getMethod(
-                        "getAdvertisingIdInfo",
-                        Context::class.java
-                    )
-                    val advertisingInfo = getAdvertisingInfo.invoke(null, context)
-                    val isLimitAdTrackingEnabled = advertisingInfo.javaClass.getMethod(
-                        "isLimitAdTrackingEnabled"
-                    )
-                    val limitAdTrackingEnabled = isLimitAdTrackingEnabled
-                        .invoke(advertisingInfo) as? Boolean
-                    this.limitAdTrackingEnabled =
-                        limitAdTrackingEnabled != null && limitAdTrackingEnabled
-                    val getId = advertisingInfo.javaClass.getMethod("getId")
-                    advertisingId = getId.invoke(advertisingInfo) as String
-                } catch (e: ClassNotFoundException) {
-                    LogcatLogger.logger
-                        .warn("Google Play Services SDK not found for advertising id!")
-                } catch (e: InvocationTargetException) {
-                    LogcatLogger.logger
-                        .warn("Google Play Services not available for advertising id")
-                } catch (e: Exception) {
-                    LogcatLogger.logger.error(
-                        "Encountered an error connecting to Google Play Services for advertising id"
-                    )
-                }
-                return advertisingId
-            }
+            return null
+        }
 
         private fun checkGPSEnabled(): Boolean {
             // This should not be called on the main thread.

--- a/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt
+++ b/common-android/src/main/java/com/amplitude/common/android/AndroidContextProvider.kt
@@ -22,7 +22,6 @@ class AndroidContextProvider(
     private val locationListening: Boolean,
     private val shouldTrackAdid: Boolean
 ) : ContextProvider {
-
     private val cachedInfo: CachedInfo by lazy { CachedInfo() }
 
     /**


### PR DESCRIPTION
- this should now respect the value set from tracking options

<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Adds `shouldTrackAppSetId` to context provider, this respects the value set from tracking options.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->