### PR TITLE
fix: ANR fix attempt on network change

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -119,11 +119,8 @@ open class Amplitude(
         dummyExitForegroundEvent.timestamp = timestamp
         timeline.process(dummyExitForegroundEvent)
 
-        amplitudeScope.launch(amplitudeDispatcher) {
-            isBuilt.await()
-            if ((configuration as Configuration).flushEventsOnClose) {
-                flush()
-            }
+        if ((configuration as Configuration).flushEventsOnClose) {
+            flush()
         }
     }
 

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -484,8 +484,12 @@ open class Amplitude internal constructor(
     }
 
     fun flush() {
-        this.timeline.applyClosure {
-            (it as? EventPlugin)?.flush()
+        amplitudeScope.launch(amplitudeDispatcher) {
+            isBuilt.await()
+
+            timeline.applyClosure {
+                (it as? EventPlugin)?.flush()
+            }
         }
     }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This is an attempt to fix an ANR: it seems that the stack trace point to the call on `amplitude.flush()` from `AndroidNetworkConnectivityCheckerPlugin` which happens Activity onCreate. 

<img width="987" alt="image" src="https://github.com/user-attachments/assets/d16fd83b-3658-4d21-a36f-3a60cbac4844" />

In this PR, we ensure that flush is uniformly launched on the Amplitude dispatcher.

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->