### PR TITLE
fix: remove synchronized on mediator

### DIFF
--- a/core/src/main/java/com/amplitude/core/platform/Mediator.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Mediator.kt
@@ -5,7 +5,7 @@ import com.amplitude.core.events.GroupIdentifyEvent
 import com.amplitude.core.events.IdentifyEvent
 import com.amplitude.core.events.RevenueEvent
 
-internal class Mediator(internal val plugins: MutableList<Plugin>) {
+internal class Mediator(private val plugins: MutableList<Plugin>) {
     fun add(plugin: Plugin) = synchronized(plugins) {
         plugins.add(plugin)
     }
@@ -58,4 +58,9 @@ internal class Mediator(internal val plugins: MutableList<Plugin>) {
             closure(it)
         }
     }
+
+    /**
+     * Only visible for testing
+     */
+    internal fun size() = plugins.size
 }

--- a/core/src/main/java/com/amplitude/core/platform/Mediator.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Mediator.kt
@@ -4,17 +4,16 @@ import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.events.GroupIdentifyEvent
 import com.amplitude.core.events.IdentifyEvent
 import com.amplitude.core.events.RevenueEvent
+import java.util.concurrent.CopyOnWriteArrayList
 
-internal class Mediator(private val plugins: MutableList<Plugin>) {
-    fun add(plugin: Plugin) = synchronized(plugins) {
+internal class Mediator(private val plugins: CopyOnWriteArrayList<Plugin>) {
+    fun add(plugin: Plugin) {
         plugins.add(plugin)
     }
 
-    fun remove(plugin: Plugin) = synchronized(plugins) {
-        plugins.removeAll { it === plugin }
-    }
+    fun remove(plugin: Plugin) = plugins.removeAll { it === plugin }
 
-    fun execute(event: BaseEvent): BaseEvent? = synchronized(plugins) {
+    fun execute(event: BaseEvent): BaseEvent? {
         var result: BaseEvent? = event
 
         plugins.forEach { plugin ->
@@ -53,7 +52,7 @@ internal class Mediator(private val plugins: MutableList<Plugin>) {
         return result
     }
 
-    fun applyClosure(closure: (Plugin) -> Unit) = synchronized(plugins) {
+    fun applyClosure(closure: (Plugin) -> Unit) {
         plugins.forEach {
             closure(it)
         }

--- a/core/src/main/java/com/amplitude/core/platform/Mediator.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Mediator.kt
@@ -6,7 +6,9 @@ import com.amplitude.core.events.IdentifyEvent
 import com.amplitude.core.events.RevenueEvent
 import java.util.concurrent.CopyOnWriteArrayList
 
-internal class Mediator(private val plugins: CopyOnWriteArrayList<Plugin>) {
+internal class Mediator(
+    private val plugins: CopyOnWriteArrayList<Plugin> = CopyOnWriteArrayList()
+) {
     fun add(plugin: Plugin) {
         plugins.add(plugin)
     }

--- a/core/src/main/java/com/amplitude/core/platform/Timeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Timeline.kt
@@ -2,14 +2,13 @@ package com.amplitude.core.platform
 
 import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
-import java.util.concurrent.CopyOnWriteArrayList
 
 open class Timeline {
     internal val plugins: Map<Plugin.Type, Mediator> = mapOf(
-        Plugin.Type.Before to Mediator(CopyOnWriteArrayList()),
-        Plugin.Type.Enrichment to Mediator(CopyOnWriteArrayList()),
-        Plugin.Type.Destination to Mediator(CopyOnWriteArrayList()),
-        Plugin.Type.Utility to Mediator(CopyOnWriteArrayList())
+        Plugin.Type.Before to Mediator(),
+        Plugin.Type.Enrichment to Mediator(),
+        Plugin.Type.Destination to Mediator(),
+        Plugin.Type.Utility to Mediator()
     )
     lateinit var amplitude: Amplitude
 

--- a/core/src/main/java/com/amplitude/core/platform/Timeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Timeline.kt
@@ -2,13 +2,14 @@ package com.amplitude.core.platform
 
 import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
+import java.util.concurrent.CopyOnWriteArrayList
 
 open class Timeline {
     internal val plugins: Map<Plugin.Type, Mediator> = mapOf(
-        Plugin.Type.Before to Mediator(mutableListOf()),
-        Plugin.Type.Enrichment to Mediator(mutableListOf()),
-        Plugin.Type.Destination to Mediator(mutableListOf()),
-        Plugin.Type.Utility to Mediator(mutableListOf())
+        Plugin.Type.Before to Mediator(CopyOnWriteArrayList()),
+        Plugin.Type.Enrichment to Mediator(CopyOnWriteArrayList()),
+        Plugin.Type.Destination to Mediator(CopyOnWriteArrayList()),
+        Plugin.Type.Utility to Mediator(CopyOnWriteArrayList())
     )
     lateinit var amplitude: Amplitude
 

--- a/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
@@ -316,10 +316,10 @@ internal class AmplitudeTest {
                 override lateinit var amplitude: Amplitude
             }
             amplitude.add(middleware)
-            amplitude.timeline.plugins[Plugin.Type.Enrichment]?.plugins?.let {
+            amplitude.timeline.plugins[Plugin.Type.Enrichment]?.size()?.let {
                 assertEquals(
                     2,
-                    it.size
+                    it
                 )
             } ?: fail()
         }
@@ -332,10 +332,10 @@ internal class AmplitudeTest {
             }
             amplitude.add(middleware)
             amplitude.remove(middleware)
-            amplitude.timeline.plugins[Plugin.Type.Enrichment]?.plugins?.let {
+            amplitude.timeline.plugins[Plugin.Type.Enrichment]?.size()?.let {
                 assertEquals(
                     1, // SegmentLog is the other added at startup
-                    it.size
+                    it
                 )
             } ?: fail()
         }

--- a/core/src/test/kotlin/com/amplitude/core/platform/MediatorTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/MediatorTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
@@ -26,7 +27,7 @@ class MediatorTest {
 
     @Test
     @Timeout(3, unit = TimeUnit.SECONDS)
-    fun `two threads that call flush twice on two destination plugins`() {
+    fun `call flush twice on two destination plugins`() {
         val fakeDestinationPlugins = List(2) { FakeDestinationPlugin() }
         fakeDestinationPlugins.forEach {
             mediator.add(it)
@@ -50,5 +51,44 @@ class MediatorTest {
         fakeDestinationPlugins.forEach {
             assertEquals(2, it.amountOfWorkDone.get())
         }
+    }
+
+    @Test
+    @Timeout(5, unit = TimeUnit.SECONDS)
+    fun `flush, add a new plugin, and flush again on two destination plugins`() {
+        val fakeDestinationPlugin1 = FakeDestinationPlugin()
+        val fakeDestinationPlugin2 = FakeDestinationPlugin()
+
+        mediator.add(fakeDestinationPlugin1)
+
+        val work = {
+            mediator.applyClosure {
+                (it as EventPlugin).flush()
+            }
+        }
+
+        // flush and add
+        val latch = CountDownLatch(2)
+        val t1 = thread {
+            work()
+            latch.countDown()
+        }
+        val t2 = thread {
+            // add plugin 2, work() should catch up with the newly added plugin
+            mediator.add(fakeDestinationPlugin2)
+            latch.countDown()
+        }
+        latch.await()
+
+        // flush again
+        val t3 = thread {
+            work()
+        }
+        t1.join()
+        t2.join()
+        t3.join()
+
+        assertEquals(2, fakeDestinationPlugin1.amountOfWorkDone.get())
+        assertEquals(2, fakeDestinationPlugin2.amountOfWorkDone.get())
     }
 }

--- a/core/src/test/kotlin/com/amplitude/core/platform/MediatorTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/MediatorTest.kt
@@ -1,0 +1,74 @@
+package com.amplitude.core.platform
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+class MediatorTest {
+    private val mediator = Mediator(CopyOnWriteArrayList())
+
+    /**
+     * Fake [DestinationPlugin] that does work on [flush] for 1 second
+     */
+    private class FakeDestinationPlugin : DestinationPlugin() {
+        var workDone = false
+
+        override fun flush() {
+            super.flush()
+            println("$this start work ${System.currentTimeMillis()} ${Thread.currentThread().name}")
+            Thread.sleep(1_000)
+            println("$this end work ${System.currentTimeMillis()} ${Thread.currentThread().name}")
+            workDone = true
+        }
+    }
+
+    @Test
+    @Timeout(2, unit = TimeUnit.SECONDS)
+    fun `multiple threads that call flush on destination plugin`() {
+        val fakeDestinationPlugins = List(10) { FakeDestinationPlugin() }
+        fakeDestinationPlugins.forEach {
+            mediator.add(it)
+        }
+
+        // simulate 10 threads executing flush on 10 different [DestinationPlugin]s
+        val executor = Executors.newFixedThreadPool(10)
+        fakeDestinationPlugins.forEach {
+            executor.submit {
+                it.flush()
+            }
+        }
+        executor.shutdown()
+        executor.awaitTermination(2, TimeUnit.SECONDS)
+
+        assertTrue {
+            fakeDestinationPlugins.all { it.workDone }
+        }
+    }
+
+    @Test
+    @Timeout(2, unit = TimeUnit.SECONDS)
+    fun `two threads that call flush on destination plugin`() {
+        val fakeDestinationPlugins = List(2) { FakeDestinationPlugin() }
+        fakeDestinationPlugins.forEach {
+            mediator.add(it)
+        }
+
+        // simulate 2 threads executing flush on 2 different DestinationPlugins
+        val t1 = thread {
+            fakeDestinationPlugins[0].flush()
+        }
+        val t2 = thread {
+            fakeDestinationPlugins[1].flush()
+        }
+        t1.join()
+        t2.join()
+
+        assertTrue {
+            fakeDestinationPlugins.all { it.workDone }
+        }
+    }
+}

--- a/core/src/test/kotlin/com/amplitude/core/platform/MediatorTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/MediatorTest.kt
@@ -1,11 +1,11 @@
 package com.amplitude.core.platform
 
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 class MediatorTest {
@@ -15,60 +15,40 @@ class MediatorTest {
      * Fake [DestinationPlugin] that does work on [flush] for 1 second
      */
     private class FakeDestinationPlugin : DestinationPlugin() {
-        var workDone = false
+        var amountOfWorkDone = AtomicInteger()
 
         override fun flush() {
             super.flush()
-            println("$this start work ${System.currentTimeMillis()} ${Thread.currentThread().name}")
             Thread.sleep(1_000)
-            println("$this end work ${System.currentTimeMillis()} ${Thread.currentThread().name}")
-            workDone = true
+            amountOfWorkDone.incrementAndGet()
         }
     }
 
     @Test
-    @Timeout(2, unit = TimeUnit.SECONDS)
-    fun `multiple threads that call flush on destination plugin`() {
-        val fakeDestinationPlugins = List(10) { FakeDestinationPlugin() }
-        fakeDestinationPlugins.forEach {
-            mediator.add(it)
-        }
-
-        // simulate 10 threads executing flush on 10 different [DestinationPlugin]s
-        val executor = Executors.newFixedThreadPool(10)
-        fakeDestinationPlugins.forEach {
-            executor.submit {
-                it.flush()
-            }
-        }
-        executor.shutdown()
-        executor.awaitTermination(2, TimeUnit.SECONDS)
-
-        assertTrue {
-            fakeDestinationPlugins.all { it.workDone }
-        }
-    }
-
-    @Test
-    @Timeout(2, unit = TimeUnit.SECONDS)
-    fun `two threads that call flush on destination plugin`() {
+    @Timeout(3, unit = TimeUnit.SECONDS)
+    fun `two threads that call flush twice on two destination plugins`() {
         val fakeDestinationPlugins = List(2) { FakeDestinationPlugin() }
         fakeDestinationPlugins.forEach {
             mediator.add(it)
         }
 
         // simulate 2 threads executing flush on 2 different DestinationPlugins
+        val work = {
+            mediator.applyClosure {
+                (it as EventPlugin).flush()
+            }
+        }
         val t1 = thread {
-            fakeDestinationPlugins[0].flush()
+            work()
         }
         val t2 = thread {
-            fakeDestinationPlugins[1].flush()
+            work()
         }
         t1.join()
         t2.join()
 
-        assertTrue {
-            fakeDestinationPlugins.all { it.workDone }
+        fakeDestinationPlugins.forEach {
+            assertEquals(2, it.amountOfWorkDone.get())
         }
     }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Removes `synchronized` blocks on `Mediator` in favor of `CopyOnWriteArrayList` instead.

It would be good to review this PR on a per commit basis.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->