### PR TITLE
fix: compose autocapture properties update

### DIFF
--- a/android/src/main/java/com/amplitude/android/internal/ViewHierarchyScanner.kt
+++ b/android/src/main/java/com/amplitude/android/internal/ViewHierarchyScanner.kt
@@ -72,21 +72,24 @@ internal object ViewHierarchyScanner {
             if (view is ViewGroup) {
                 queue.addAll(view.children)
             }
-
-            // Applies the locators until a target is found. If the target type is clickable, check
-            // the children in case the target is a child which is also clickable.
-            viewTargetLocators.any { locator ->
-                with(locator) {
-                    view.locate(targetPosition, targetType)?.let { newTarget ->
-                        if (targetType == ViewTarget.Type.Clickable) {
-                            target = newTarget
-                            return@any true
-                        } else {
-                            return newTarget
+            try {
+                // Applies the locators until a target is found. If the target type is clickable, check
+                // the children in case the target is a child which is also clickable.
+                viewTargetLocators.any { locator ->
+                    with(locator) {
+                        view.locate(targetPosition, targetType)?.let { newTarget ->
+                            if (targetType == ViewTarget.Type.Clickable) {
+                                target = newTarget
+                                return@any true
+                            } else {
+                                return newTarget
+                            }
                         }
+                        false
                     }
-                    false
                 }
+            } catch (t: Throwable) {
+                logger.error("Error while locating target")
             }
         }
 

--- a/android/src/main/java/com/amplitude/android/internal/ViewHierarchyScanner.kt
+++ b/android/src/main/java/com/amplitude/android/internal/ViewHierarchyScanner.kt
@@ -88,8 +88,8 @@ internal object ViewHierarchyScanner {
                         false
                     }
                 }
-            } catch (t: Throwable) {
-                logger.error("Error while locating target")
+            } catch (e: ClassCastException) {
+                logger.error("Error while locating target in view hierarchy: $e")
             }
         }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
<!-- What does the PR do? -->
Jira ticket: https://amplitude.atlassian.net/browse/AMP-126719
With Compose update to new version it's internal implementation of testTag changed from `SemanticsModifier` to `TestTagElement`
The only common part is Inspectable Value params that we can iterate.
Tested on versions:
from 1.5.+
to 1.7.+

Supported tags:
`Modifier.testTag("some value")`
`Modifier.semantics { testTag = "some value" }`
Clickable nodes added support for clickable InspectableValue.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no