### PR TITLE
fix: make DefaultEventUtils internal

### DIFF
--- a/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
@@ -16,7 +16,7 @@ import com.amplitude.android.internal.locators.ViewTargetLocators.ALL
 import com.amplitude.core.Storage
 import kotlinx.coroutines.launch
 
-class DefaultEventUtils(private val amplitude: Amplitude) {
+internal class DefaultEventUtils(private val amplitude: Amplitude) {
     object EventTypes {
         const val APPLICATION_INSTALLED = "[Amplitude] Application Installed"
         const val APPLICATION_UPDATED = "[Amplitude] Application Updated"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Prevent access of `DefaultEventUtils` as it's prone to misuse (e.g. Amplitude supplied `!isBuilt` yet)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->