### PR TITLE
fix: update network listener to cover cases where network is blocked

### DIFF
--- a/android/src/main/java/com/amplitude/android/plugins/AndroidNetworkConnectivityCheckerPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidNetworkConnectivityCheckerPlugin.kt
@@ -38,10 +38,10 @@ class AndroidNetworkConnectivityCheckerPlugin : Plugin {
                 }
             }
         networkListener = AndroidNetworkListener(
-            (amplitude.configuration as Configuration).context,
-            amplitude.logger
+            context = (amplitude.configuration as Configuration).context,
+            logger = amplitude.logger,
+            networkCallback = networkChangeHandler
         )
-        networkListener.setNetworkChangeCallback(networkChangeHandler)
         networkListener.startListening()
     }
 

--- a/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkListener.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkListener.kt
@@ -6,16 +6,24 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
 import android.net.Network
 import android.net.NetworkCapabilities
+import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
+import android.net.NetworkCapabilities.NET_CAPABILITY_VALIDATED
 import android.net.NetworkRequest
-import android.os.Build
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import androidx.annotation.VisibleForTesting
 import com.amplitude.common.Logger
 
-class AndroidNetworkListener(private val context: Context, private val logger: Logger) {
-    private var networkCallback: NetworkChangeCallback? = null
+class AndroidNetworkListener(
+    private val context: Context,
+    private val logger: Logger,
+    private val networkCallback: NetworkChangeCallback,
+) {
     private var networkCallbackForLowerApiLevels: BroadcastReceiver? = null
-    private var networkCallbackForHigherApiLevels: ConnectivityManager.NetworkCallback? = null
+    private var networkCallbackForHigherApiLevels: NetworkCallback? = null
 
     interface NetworkChangeCallback {
         fun onNetworkAvailable()
@@ -23,13 +31,9 @@ class AndroidNetworkListener(private val context: Context, private val logger: L
         fun onNetworkUnavailable()
     }
 
-    fun setNetworkChangeCallback(callback: NetworkChangeCallback) {
-        this.networkCallback = callback
-    }
-
     fun startListening() {
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
                 setupNetworkCallback()
             } else {
                 setupBroadcastReceiver()
@@ -48,29 +52,57 @@ class AndroidNetworkListener(private val context: Context, private val logger: L
     @SuppressLint("NewApi", "MissingPermission")
     // startListening() checks API level
     // ACCESS_NETWORK_STATE permission should be added manually by users to enable this feature
-    private fun setupNetworkCallback() {
-        val connectivityManager =
-            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        val networkRequest =
-            NetworkRequest.Builder()
-                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                .build()
+    @VisibleForTesting
+    internal fun setupNetworkCallback() {
+        val connectivityManager = context
+            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val networkRequest = NetworkRequest.Builder()
+            .addCapability(NET_CAPABILITY_INTERNET)
+            .build()
 
-        networkCallbackForHigherApiLevels =
-            object : ConnectivityManager.NetworkCallback() {
-                override fun onAvailable(network: Network) {
-                    networkCallback?.onNetworkAvailable()
-                }
+        networkCallbackForHigherApiLevels = object : NetworkCallback() {
+            private var networkState: NetworkState? = null
 
-                override fun onLost(network: Network) {
-                    networkCallback?.onNetworkUnavailable()
-                }
+            override fun onAvailable(network: Network) {
+                // A default network is available, set the network state and callback
+                networkState = NetworkState(
+                    network = network,
+                    networkCallback = networkCallback,
+                    available = true,
+                    blocked = false
+                )
             }
 
-        connectivityManager.registerNetworkCallback(
-            networkRequest,
-            networkCallbackForHigherApiLevels!!
-        )
+            override fun onUnavailable() {
+                // no network is found
+                networkCallback.onNetworkUnavailable()
+            }
+
+            override fun onLost(network: Network) {
+                networkState?.update(network, available = false)
+            }
+
+            override fun onCapabilitiesChanged(
+                network: Network,
+                networkCapabilities: NetworkCapabilities,
+            ) {
+                val capable = networkCapabilities.hasCapability(NET_CAPABILITY_INTERNET)
+                val validated = networkCapabilities.hasCapability(NET_CAPABILITY_VALIDATED)
+                networkState?.update(network, available = capable && validated)
+            }
+
+            override fun onBlockedStatusChanged(
+                network: Network,
+                blocked: Boolean,
+            ) {
+                networkState?.update(network, blocked = blocked)
+            }
+        }.also { callbackForHigherApiLevels ->
+            connectivityManager.registerNetworkCallback(
+                networkRequest,
+                callbackForHigherApiLevels
+            )
+        }
     }
 
     private fun setupBroadcastReceiver() {
@@ -82,15 +114,15 @@ class AndroidNetworkListener(private val context: Context, private val logger: L
                     intent: Intent,
                 ) {
                     if (ConnectivityManager.CONNECTIVITY_ACTION == intent.action) {
-                        val connectivityManager =
-                            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+                        val connectivityManager = context
+                            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
                         val activeNetwork = connectivityManager.activeNetworkInfo
                         val isConnected = activeNetwork?.isConnectedOrConnecting == true
 
                         if (isConnected) {
-                            networkCallback?.onNetworkAvailable()
+                            networkCallback.onNetworkAvailable()
                         } else {
-                            networkCallback?.onNetworkUnavailable()
+                            networkCallback.onNetworkUnavailable()
                         }
                     }
                 }
@@ -102,7 +134,7 @@ class AndroidNetworkListener(private val context: Context, private val logger: L
 
     fun stopListening() {
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
                 val connectivityManager =
                     context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
                 networkCallbackForHigherApiLevels?.let {
@@ -125,6 +157,55 @@ class AndroidNetworkListener(private val context: Context, private val logger: L
             // https://github.com/amplitude/Amplitude-Kotlin/issues/220
             // https://github.com/amplitude/Amplitude-Kotlin/issues/197
             logger.warn("Error stopping network listener: ${throwable.message}")
+        }
+    }
+
+    /**
+     * NetworkState is used to track the state of a network connection.
+     * It considers the availability and blocked status of the network before notifying the callback.
+     *
+     * On initialization, it checks if the network is available and not blocked.
+     */
+    private class NetworkState(
+        private val network: Network,
+        private val networkCallback: NetworkChangeCallback,
+        private var available: Boolean,
+        private var blocked: Boolean,
+    ) {
+        init {
+            notifyNetworkCallback()
+        }
+
+        /**
+         * Notify the network callback based on the current state of the network.
+         * Ideally called only when the state changes (e.g. initialized, available or blocked toggled).
+         */
+        private fun notifyNetworkCallback() {
+            if (available && !blocked) {
+                networkCallback.onNetworkAvailable()
+            } else {
+                networkCallback.onNetworkUnavailable()
+            }
+        }
+
+        /**
+         * Update the availability/blocked state and notify the callback if necessary.
+         * Checks if we're on the same network, else just ignore.
+         */
+        fun update(
+            network: Network,
+            available: Boolean = this.available,
+            blocked: Boolean = this.blocked,
+        ) {
+            @SuppressLint("NewApi")
+            if (this.network != network) return
+            val toggled = this.available != available || this.blocked != blocked
+            this.available = available
+            this.blocked = blocked
+
+            if (toggled) {
+                notifyNetworkCallback()
+            }
         }
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkListenerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkListenerTest.kt
@@ -1,0 +1,113 @@
+package com.amplitude.android.utilities
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import com.amplitude.common.Logger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.slot
+import io.mockk.verify
+import kotlin.test.Test
+import org.junit.Before
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+
+class AndroidNetworkListenerTest {
+    private val fakeContext = mockk<Context>(relaxed = true)
+    private val fakeLogger = mockk<Logger>(relaxed = true)
+    private val fakeConnectivityManager = mockk<ConnectivityManager>(relaxed = true)
+
+    @Before
+    fun setup() {
+        every {
+            fakeContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+        } returns fakeConnectivityManager
+
+        mockkConstructor(NetworkRequest.Builder::class)
+        every {
+            anyConstructed<NetworkRequest.Builder>().addCapability(any()).build()
+        } returns mockk()
+    }
+
+    @Test
+    fun `setup network callback should notify states`() {
+        val networkChangeCallback = object : AndroidNetworkListener.NetworkChangeCallback {
+            var available = false
+            override fun onNetworkAvailable() {
+                available = true
+            }
+
+            override fun onNetworkUnavailable() {
+                available = false
+            }
+        }
+        val networkListener = AndroidNetworkListener(
+            context = fakeContext,
+            logger = fakeLogger,
+            networkCallback = networkChangeCallback
+        )
+
+        networkListener.setupNetworkCallback()
+        val networkCallbackSlot = slot<NetworkCallback>()
+        verify {
+            fakeConnectivityManager.registerNetworkCallback(
+                any<NetworkRequest>(), capture(networkCallbackSlot)
+            )
+        }
+        val networkCallback = networkCallbackSlot.captured
+        val network = mockk<Network>()
+        val availableCapability = mockk<NetworkCapabilities>() {
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } returns true
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) } returns true
+        }
+        val unavailableCapability = mockk<NetworkCapabilities>() {
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } returns true
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) } returns false
+        }
+
+        // available: true, blocked: false
+        networkCallback.onAvailable(network)
+        assertTrue(networkChangeCallback.available)
+
+        // available: true, blocked: false -> true
+        networkCallback.onBlockedStatusChanged(network, true)
+        assertFalse(networkChangeCallback.available)
+
+        // available: true, blocked: true (nothing toggled)
+        networkCallback.onCapabilitiesChanged(network, availableCapability)
+        assertFalse(networkChangeCallback.available) // still blocked
+
+        // available: true, blocked: true -> false
+        networkCallback.onBlockedStatusChanged(network, false)
+        assertTrue(networkChangeCallback.available)
+
+        // available: true -> false, blocked: false
+        networkCallback.onCapabilitiesChanged(network, unavailableCapability)
+        assertFalse(networkChangeCallback.available) // now unavailable
+
+        // available: false -> true, blocked: false
+        networkCallback.onCapabilitiesChanged(network, availableCapability)
+        assertTrue(networkChangeCallback.available)
+
+        // available: true -> false, blocked: false
+        networkCallback.onLost(network)
+        assertFalse(networkChangeCallback.available)
+
+        // available: false -> true, blocked: false
+        networkCallback.onCapabilitiesChanged(network, availableCapability)
+        assertTrue(networkChangeCallback.available) // available again
+
+        // available: true, blocked: false (new state)
+        networkCallback.onAvailable(mockk())
+        assertTrue(networkChangeCallback.available)
+
+        // N/A
+        networkCallback.onUnavailable()
+        assertFalse(networkChangeCallback.available)
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkListenerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkListenerTest.kt
@@ -66,9 +66,10 @@ class AndroidNetworkListenerTest {
             every { hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) } returns true
         }
         val unavailableCapability = mockk<NetworkCapabilities>() {
-            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } returns true
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } returns false
             every { hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) } returns false
         }
+        every { fakeConnectivityManager.getNetworkCapabilities(network) } returns availableCapability
 
         // available: true, blocked: false
         networkCallback.onAvailable(network)
@@ -103,7 +104,7 @@ class AndroidNetworkListenerTest {
         assertTrue(networkChangeCallback.available) // available again
 
         // available: true, blocked: false (new state)
-        networkCallback.onAvailable(mockk())
+        networkCallback.onAvailable(network)
         assertTrue(networkChangeCallback.available)
 
         // N/A


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
When the app is backgrounded, the network actually gets blocked (`onBlockedStatusChanged(...)`). We want to set our app to offline when this happens.
As part of this PR, we've also shortened the feedback loop once the internet goes back through `onCapabilitiesChanged(...)` callback. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->