### PR TITLE
fix: use range for common success/failure status codes

### DIFF
--- a/android/src/test/kotlin/com/amplitude/android/ResponseHandlerIntegrationTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/ResponseHandlerIntegrationTest.kt
@@ -114,7 +114,7 @@ class ResponseHandlerIntegrationTest {
         amplitude.isBuilt.await()
 
         // verify it will attempt to retry, but single event file will be removed
-        val code = HttpStatus.PAYLOAD_TOO_LARGE.code
+        val code = HttpStatus.PAYLOAD_TOO_LARGE.range.first
         val body = "{\"code\": \"$code\", \"error\": \"payload too large\"}"
         server.enqueue(MockResponse().setBody(body).setResponseCode(code))
         amplitude.track("test event 1", options = options)
@@ -151,12 +151,12 @@ class ResponseHandlerIntegrationTest {
                 storageProvider = InMemoryStorageProvider()
             )
         )
-        val expectedSuccesEvents = 5
+        val expectedSuccessEvents = 5
         server.enqueue(
             MockResponse().setBody("{\"code\": \"413\", \"error\": \"payload too large\"}")
                 .setResponseCode(413)
         )
-        repeat(expectedSuccesEvents) {
+        repeat(expectedSuccessEvents) {
             server.enqueue(MockResponse().setBody("{\"code\": \"200\"}").setResponseCode(200))
         }
         var eventsProcessed = 0
@@ -205,8 +205,8 @@ class ResponseHandlerIntegrationTest {
 
         // verify we completed processing for the events after file split
         assertEquals(4, server.requestCount)
-        assertEquals(expectedSuccesEvents, statusMap[200])
-        assertEquals(expectedSuccesEvents, eventsProcessed)
+        assertEquals(expectedSuccessEvents, statusMap[200])
+        assertEquals(expectedSuccessEvents, eventsProcessed)
     }
 
     @Test
@@ -271,22 +271,22 @@ class ResponseHandlerIntegrationTest {
 
     @Test
     fun `test handle bad request response retry`() = runTest {
-        testRequestFailureAndRetry(HttpStatus.BAD_REQUEST.code)
+        testRequestFailureAndRetry(HttpStatus.BAD_REQUEST.range.first)
     }
 
     @Test
     fun `test handle too many requests response retry`() = runTest {
-        testRequestFailureAndRetry(HttpStatus.TOO_MANY_REQUESTS.code)
+        testRequestFailureAndRetry(HttpStatus.TOO_MANY_REQUESTS.range.first)
     }
 
     @Test
     fun `test handle timeout response retry`() = runTest {
-        testRequestFailureAndRetry(HttpStatus.TIMEOUT.code)
+        testRequestFailureAndRetry(HttpStatus.TIMEOUT.range.first)
     }
 
     @Test
     fun `test handle failed response retry`() = runTest {
-        testRequestFailureAndRetry(HttpStatus.FAILED.code)
+        testRequestFailureAndRetry(HttpStatus.FAILED.range.first)
     }
 
     private suspend fun TestScope.testRequestFailureAndRetry(code: Int) {

--- a/android/src/test/kotlin/com/amplitude/android/ResponseHandlerIntegrationTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/ResponseHandlerIntegrationTest.kt
@@ -114,7 +114,7 @@ class ResponseHandlerIntegrationTest {
         amplitude.isBuilt.await()
 
         // verify it will attempt to retry, but single event file will be removed
-        val code = HttpStatus.PAYLOAD_TOO_LARGE.range.first
+        val code = HttpStatus.PAYLOAD_TOO_LARGE.statusCode
         val body = "{\"code\": \"$code\", \"error\": \"payload too large\"}"
         server.enqueue(MockResponse().setBody(body).setResponseCode(code))
         amplitude.track("test event 1", options = options)
@@ -271,22 +271,22 @@ class ResponseHandlerIntegrationTest {
 
     @Test
     fun `test handle bad request response retry`() = runTest {
-        testRequestFailureAndRetry(HttpStatus.BAD_REQUEST.range.first)
+        testRequestFailureAndRetry(HttpStatus.BAD_REQUEST.statusCode)
     }
 
     @Test
     fun `test handle too many requests response retry`() = runTest {
-        testRequestFailureAndRetry(HttpStatus.TOO_MANY_REQUESTS.range.first)
+        testRequestFailureAndRetry(HttpStatus.TOO_MANY_REQUESTS.statusCode)
     }
 
     @Test
     fun `test handle timeout response retry`() = runTest {
-        testRequestFailureAndRetry(HttpStatus.TIMEOUT.range.first)
+        testRequestFailureAndRetry(HttpStatus.TIMEOUT.statusCode)
     }
 
     @Test
     fun `test handle failed response retry`() = runTest {
-        testRequestFailureAndRetry(HttpStatus.FAILED.range.first)
+        testRequestFailureAndRetry(HttpStatus.FAILED.statusCode)
     }
 
     private suspend fun TestScope.testRequestFailureAndRetry(code: Int) {

--- a/core/src/main/java/com/amplitude/core/utilities/FileResponseHandler.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/FileResponseHandler.kt
@@ -35,7 +35,7 @@ class FileResponseHandler(
         val eventFilePath = events as String
         logger?.debug("Handle response, status: ${successResponse.status}")
         val eventsList = parseEvents(eventsString, eventFilePath).toEvents()
-        triggerEventsCallback(eventsList, HttpStatus.SUCCESS.code, "Event sent success.")
+        triggerEventsCallback(eventsList, HttpStatus.SUCCESS.range.first, "Event sent success.")
         scope.launch(storageDispatcher) {
             storage.removeFile(eventFilePath)
         }
@@ -52,7 +52,7 @@ class FileResponseHandler(
         val eventFilePath = events as String
         val eventsList = parseEvents(eventsString, eventFilePath).toEvents()
         if (badRequestResponse.isInvalidApiKeyResponse()) {
-            triggerEventsCallback(eventsList, HttpStatus.BAD_REQUEST.code, badRequestResponse.error)
+            triggerEventsCallback(eventsList, HttpStatus.BAD_REQUEST.range.first, badRequestResponse.error)
             scope.launch(storageDispatcher) {
                 storage.removeFile(eventFilePath)
             }
@@ -77,7 +77,7 @@ class FileResponseHandler(
             return true
         }
 
-        triggerEventsCallback(eventsToDrop, HttpStatus.BAD_REQUEST.code, badRequestResponse.error)
+        triggerEventsCallback(eventsToDrop, HttpStatus.BAD_REQUEST.range.first, badRequestResponse.error)
         eventsToRetry.forEach {
             eventPipeline.put(it)
         }
@@ -104,7 +104,7 @@ class FileResponseHandler(
         if (rawEvents.length() == 1) {
             val eventsList = rawEvents.toEvents()
             triggerEventsCallback(
-                eventsList, HttpStatus.PAYLOAD_TOO_LARGE.code, payloadTooLargeResponse.error
+                eventsList, HttpStatus.PAYLOAD_TOO_LARGE.range.first, payloadTooLargeResponse.error
             )
             scope.launch(storageDispatcher) {
                 storage.removeFile(eventFilePath)

--- a/core/src/main/java/com/amplitude/core/utilities/FileResponseHandler.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/FileResponseHandler.kt
@@ -35,7 +35,7 @@ class FileResponseHandler(
         val eventFilePath = events as String
         logger?.debug("Handle response, status: ${successResponse.status}")
         val eventsList = parseEvents(eventsString, eventFilePath).toEvents()
-        triggerEventsCallback(eventsList, HttpStatus.SUCCESS.range.first, "Event sent success.")
+        triggerEventsCallback(eventsList, HttpStatus.SUCCESS.statusCode, "Event sent success.")
         scope.launch(storageDispatcher) {
             storage.removeFile(eventFilePath)
         }
@@ -52,7 +52,7 @@ class FileResponseHandler(
         val eventFilePath = events as String
         val eventsList = parseEvents(eventsString, eventFilePath).toEvents()
         if (badRequestResponse.isInvalidApiKeyResponse()) {
-            triggerEventsCallback(eventsList, HttpStatus.BAD_REQUEST.range.first, badRequestResponse.error)
+            triggerEventsCallback(eventsList, HttpStatus.BAD_REQUEST.statusCode, badRequestResponse.error)
             scope.launch(storageDispatcher) {
                 storage.removeFile(eventFilePath)
             }
@@ -77,7 +77,7 @@ class FileResponseHandler(
             return true
         }
 
-        triggerEventsCallback(eventsToDrop, HttpStatus.BAD_REQUEST.range.first, badRequestResponse.error)
+        triggerEventsCallback(eventsToDrop, HttpStatus.BAD_REQUEST.statusCode, badRequestResponse.error)
         eventsToRetry.forEach {
             eventPipeline.put(it)
         }
@@ -104,7 +104,7 @@ class FileResponseHandler(
         if (rawEvents.length() == 1) {
             val eventsList = rawEvents.toEvents()
             triggerEventsCallback(
-                eventsList, HttpStatus.PAYLOAD_TOO_LARGE.range.first, payloadTooLargeResponse.error
+                eventsList, HttpStatus.PAYLOAD_TOO_LARGE.statusCode, payloadTooLargeResponse.error
             )
             scope.launch(storageDispatcher) {
                 storage.removeFile(eventFilePath)

--- a/core/src/main/java/com/amplitude/core/utilities/InMemoryResponseHandler.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/InMemoryResponseHandler.kt
@@ -33,7 +33,7 @@ internal class InMemoryResponseHandler(
         eventsString: String,
     ) {
         triggerEventsCallback(
-            events as List<BaseEvent>, HttpStatus.SUCCESS.range.first, "Event sent success."
+            events as List<BaseEvent>, HttpStatus.SUCCESS.statusCode, "Event sent success."
         )
     }
 
@@ -44,7 +44,7 @@ internal class InMemoryResponseHandler(
     ): Boolean {
         val eventsList = events as List<BaseEvent>
         if (badRequestResponse.isInvalidApiKeyResponse()) {
-            triggerEventsCallback(eventsList, HttpStatus.BAD_REQUEST.range.first, badRequestResponse.error)
+            triggerEventsCallback(eventsList, HttpStatus.BAD_REQUEST.statusCode, badRequestResponse.error)
             return false
         }
         val droppedIndices = badRequestResponse.getEventIndicesToDrop()
@@ -57,7 +57,7 @@ internal class InMemoryResponseHandler(
                 eventsToRetry.add(event)
             }
         }
-        triggerEventsCallback(eventsToDrop, HttpStatus.BAD_REQUEST.range.first, badRequestResponse.error)
+        triggerEventsCallback(eventsToDrop, HttpStatus.BAD_REQUEST.statusCode, badRequestResponse.error)
         eventsToRetry.forEach {
             eventPipeline.put(it)
         }
@@ -72,7 +72,7 @@ internal class InMemoryResponseHandler(
         val eventsList = events as List<BaseEvent>
         if (eventsList.size == 1) {
             triggerEventsCallback(
-                eventsList, HttpStatus.PAYLOAD_TOO_LARGE.range.first, payloadTooLargeResponse.error
+                eventsList, HttpStatus.PAYLOAD_TOO_LARGE.statusCode, payloadTooLargeResponse.error
             )
             return
         }
@@ -105,7 +105,7 @@ internal class InMemoryResponseHandler(
             }
         }
         triggerEventsCallback(
-            eventsToDrop, HttpStatus.TOO_MANY_REQUESTS.range.first, tooManyRequestsResponse.error
+            eventsToDrop, HttpStatus.TOO_MANY_REQUESTS.statusCode, tooManyRequestsResponse.error
         )
         eventsToRetryNow.forEach {
             eventPipeline.put(it)
@@ -147,7 +147,7 @@ internal class InMemoryResponseHandler(
                 eventsToRetry.add(event)
             }
         }
-        triggerEventsCallback(eventsToDrop, HttpStatus.FAILED.range.first, failedResponse.error)
+        triggerEventsCallback(eventsToDrop, HttpStatus.FAILED.statusCode, failedResponse.error)
         eventsToRetry.forEach {
             eventPipeline.put(it)
         }

--- a/core/src/main/java/com/amplitude/core/utilities/InMemoryResponseHandler.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/InMemoryResponseHandler.kt
@@ -33,7 +33,7 @@ internal class InMemoryResponseHandler(
         eventsString: String,
     ) {
         triggerEventsCallback(
-            events as List<BaseEvent>, HttpStatus.SUCCESS.code, "Event sent success."
+            events as List<BaseEvent>, HttpStatus.SUCCESS.range.first, "Event sent success."
         )
     }
 
@@ -44,7 +44,7 @@ internal class InMemoryResponseHandler(
     ): Boolean {
         val eventsList = events as List<BaseEvent>
         if (badRequestResponse.isInvalidApiKeyResponse()) {
-            triggerEventsCallback(eventsList, HttpStatus.BAD_REQUEST.code, badRequestResponse.error)
+            triggerEventsCallback(eventsList, HttpStatus.BAD_REQUEST.range.first, badRequestResponse.error)
             return false
         }
         val droppedIndices = badRequestResponse.getEventIndicesToDrop()
@@ -57,7 +57,7 @@ internal class InMemoryResponseHandler(
                 eventsToRetry.add(event)
             }
         }
-        triggerEventsCallback(eventsToDrop, HttpStatus.BAD_REQUEST.code, badRequestResponse.error)
+        triggerEventsCallback(eventsToDrop, HttpStatus.BAD_REQUEST.range.first, badRequestResponse.error)
         eventsToRetry.forEach {
             eventPipeline.put(it)
         }
@@ -72,7 +72,7 @@ internal class InMemoryResponseHandler(
         val eventsList = events as List<BaseEvent>
         if (eventsList.size == 1) {
             triggerEventsCallback(
-                eventsList, HttpStatus.PAYLOAD_TOO_LARGE.code, payloadTooLargeResponse.error
+                eventsList, HttpStatus.PAYLOAD_TOO_LARGE.range.first, payloadTooLargeResponse.error
             )
             return
         }
@@ -105,7 +105,7 @@ internal class InMemoryResponseHandler(
             }
         }
         triggerEventsCallback(
-            eventsToDrop, HttpStatus.TOO_MANY_REQUESTS.code, tooManyRequestsResponse.error
+            eventsToDrop, HttpStatus.TOO_MANY_REQUESTS.range.first, tooManyRequestsResponse.error
         )
         eventsToRetryNow.forEach {
             eventPipeline.put(it)
@@ -147,7 +147,7 @@ internal class InMemoryResponseHandler(
                 eventsToRetry.add(event)
             }
         }
-        triggerEventsCallback(eventsToDrop, HttpStatus.FAILED.code, failedResponse.error)
+        triggerEventsCallback(eventsToDrop, HttpStatus.FAILED.range.first, failedResponse.error)
         eventsToRetry.forEach {
             eventPipeline.put(it)
         }

--- a/core/src/main/java/com/amplitude/core/utilities/http/AnalyticsResponse.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/http/AnalyticsResponse.kt
@@ -265,5 +265,8 @@ enum class HttpStatus(
     TIMEOUT(408),
     PAYLOAD_TOO_LARGE(413),
     TOO_MANY_REQUESTS(429),
-    FAILED(500, 500..599),
+    FAILED(500, 500..599);
+
+    val statusCode: Int
+        get() = range.first
 }

--- a/core/src/test/kotlin/com/amplitude/core/utilities/HttpClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/utilities/HttpClientTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -22,7 +23,7 @@ import java.util.concurrent.TimeUnit
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HttpClientTest {
     private lateinit var server: MockWebServer
-    val apiKey = "API_KEY"
+    private val apiKey = "API_KEY"
 
     @ExperimentalCoroutinesApi
     @BeforeEach
@@ -49,7 +50,7 @@ class HttpClientTest {
         event.eventType = "test"
 
         val httpClient = spyk(HttpClient(config))
-        val response = httpClient.upload(JSONUtil.eventsToString(listOf(event)))
+        httpClient.upload(JSONUtil.eventsToString(listOf(event)))
 
         val request = runRequest()
         val result = JSONObject(request?.body?.readUtf8())
@@ -73,7 +74,7 @@ class HttpClientTest {
 
         val httpClient = spyk(HttpClient(config))
 
-        val response = httpClient.upload(JSONUtil.eventsToString(listOf(event)))
+        httpClient.upload(JSONUtil.eventsToString(listOf(event)))
 
         val request = runRequest()
         val result = JSONObject(request?.body?.readUtf8())
@@ -100,7 +101,7 @@ class HttpClientTest {
         diagnostics.addErrorLog("error")
         diagnostics.addMalformedEvent("malformed-event")
 
-        val response = httpClient.upload(JSONUtil.eventsToString(listOf(event)), diagnostics.extractDiagnostics())
+        httpClient.upload(JSONUtil.eventsToString(listOf(event)), diagnostics.extractDiagnostics())
 
         val request = runRequest()
         val result = JSONObject(request?.body?.readUtf8())
@@ -133,10 +134,10 @@ class HttpClientTest {
         val response = httpClient.upload(JSONUtil.eventsToString(listOf(event)), diagnostics.extractDiagnostics())
 
         runRequest()
-        assertEquals(200, response.status.code)
+        assertTrue(200 in response.status.range)
 
         runRequest()
-        assertEquals(200, response.status.code)
+        assertTrue(200 in response.status.range)
     }
 
     @Test
@@ -156,8 +157,7 @@ class HttpClientTest {
         val response = httpClient.upload(JSONUtil.eventsToString(listOf(event)))
 
         runRequest()
-        // Error code 503 is converted to a 500 in the http client
-        assertEquals(500, response.status.code)
+        assertTrue(503 in response.status.range)
         val responseBody = response as FailedResponse
         assertEquals("<html>Error occurred</html>", responseBody.error)
     }

--- a/core/src/test/kotlin/com/amplitude/core/utilities/http/AnalyticsResponseTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/utilities/http/AnalyticsResponseTest.kt
@@ -1,0 +1,66 @@
+package com.amplitude.core.utilities.http
+
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AnalyticsResponseTest {
+    @Test
+    fun `test create success response`() {
+        listOf(200, 202, 299).forEach {
+            val response = AnalyticsResponse.create(it, null)
+            assertTrue(response is SuccessResponse)
+            assertEquals(HttpStatus.SUCCESS, response.status)
+        }
+    }
+
+    @Test
+    fun `test create payload too large response`() {
+        val responseBody = JSONObject().apply {
+            put("error", "Payload too large")
+        }.toString()
+
+        val response = AnalyticsResponse.create(413, responseBody)
+        assertTrue(response is PayloadTooLargeResponse)
+        assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, response.status)
+        assertEquals("Payload too large", (response as PayloadTooLargeResponse).error)
+    }
+
+    @Test
+    fun `test create timeout response`() {
+        val response = AnalyticsResponse.create(408, null)
+        assertTrue(response is TimeoutResponse)
+        assertEquals(HttpStatus.TIMEOUT, response.status)
+    }
+
+    @Test
+    fun `test create failed response`() {
+        val responseBody = JSONObject().apply {
+            put("error", "Internal server error")
+        }.toString()
+
+        val response = AnalyticsResponse.create(500, responseBody)
+        assertTrue(response is FailedResponse)
+        assertEquals(HttpStatus.FAILED, response.status)
+        assertEquals("Internal server error", (response as FailedResponse).error)
+    }
+
+    @Test
+    fun `test create failed response with invalid JSON`() {
+        listOf(500, 503, 599).forEach {
+            val response = AnalyticsResponse.create(it, "Invalid JSON")
+            assertTrue(response is FailedResponse)
+            assertEquals(HttpStatus.FAILED, response.status)
+            assertEquals("Invalid JSON", (response as FailedResponse).error)
+        }
+    }
+
+    @Test
+    fun `test create failed response with null body`() {
+        val response = AnalyticsResponse.create(500, null)
+        assertTrue(response is FailedResponse)
+        assertEquals(HttpStatus.FAILED, response.status)
+        assertEquals("", (response as FailedResponse).error)
+    }
+}

--- a/core/src/test/kotlin/com/amplitude/core/utilities/http/ResponseHandlerTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/utilities/http/ResponseHandlerTest.kt
@@ -69,7 +69,7 @@ class ResponseHandlerTest {
             FAILED to true
         )
         statuses.forEach { status ->
-            val analyticsResponse = AnalyticsResponse.create(status.code, responseBody = "{}")
+            val analyticsResponse = AnalyticsResponse.create(status.range.first, responseBody = "{}")
             val shouldRetryUploadOnFailure = fakeResponseHandler.handle(
                 response = analyticsResponse,
                 events = emptyList<AnalyticsResponse>(),
@@ -84,7 +84,7 @@ class ResponseHandlerTest {
 
     @Test
     fun `shouldRetryUploadOnFailure - handleBadRequestResponse`() {
-        val badRequestResponse = AnalyticsResponse.create(BAD_REQUEST.code, responseBody = "{}")
+        val badRequestResponse = AnalyticsResponse.create(BAD_REQUEST.range.first, responseBody = "{}")
 
         fakeResponseHandler.badRequestResult = false
         var shouldRetryUploadOnFailure = fakeResponseHandler.handle(

--- a/core/src/test/kotlin/com/amplitude/core/utilities/http/ResponseHandlerTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/utilities/http/ResponseHandlerTest.kt
@@ -69,7 +69,7 @@ class ResponseHandlerTest {
             FAILED to true
         )
         statuses.forEach { status ->
-            val analyticsResponse = AnalyticsResponse.create(status.range.first, responseBody = "{}")
+            val analyticsResponse = AnalyticsResponse.create(status.statusCode, responseBody = "{}")
             val shouldRetryUploadOnFailure = fakeResponseHandler.handle(
                 response = analyticsResponse,
                 events = emptyList<AnalyticsResponse>(),
@@ -84,7 +84,7 @@ class ResponseHandlerTest {
 
     @Test
     fun `shouldRetryUploadOnFailure - handleBadRequestResponse`() {
-        val badRequestResponse = AnalyticsResponse.create(BAD_REQUEST.range.first, responseBody = "{}")
+        val badRequestResponse = AnalyticsResponse.create(BAD_REQUEST.statusCode, responseBody = "{}")
 
         fakeResponseHandler.badRequestResult = false
         var shouldRetryUploadOnFailure = fakeResponseHandler.handle(


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Support for common success/failure status codes in AnalyticsResponse.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->