### PR TITLE
Fix amplitude host detection in network tracking plugin

### DIFF
--- a/core/src/main/java/com/amplitude/core/network/NetworkTrackingPlugin.kt
+++ b/core/src/main/java/com/amplitude/core/network/NetworkTrackingPlugin.kt
@@ -77,8 +77,8 @@ class NetworkTrackingPlugin(
      * [okhttp3.OkHttpClient] instance is used for both Amplitude and other network requests.
      */
     private fun Request.amplitudeApiRequest(): Boolean {
-        return url.host.endsWith(AMPLITUDE_HOST_DOMAIN) &&
-            body?.contains(NETWORK_TRACKING) == false
+        val containsTrackingEvent = body?.contains(NETWORK_TRACKING) ?: false
+        return url.host.endsWith(AMPLITUDE_HOST_DOMAIN) && !containsTrackingEvent
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix detection logic for Amplitude API requests in `NetworkTrackingPlugin`

## Testing
- `./gradlew test` *(fails: Downloading gradle distribution requires network access)*