### PR TITLE
Fix HttpClient read timeout

### DIFF
--- a/core/src/main/java/com/amplitude/core/utilities/http/HttpClient.kt
+++ b/core/src/main/java/com/amplitude/core/utilities/http/HttpClient.kt
@@ -25,7 +25,7 @@ internal class HttpClient(
         connection.doOutput = true
         connection.doInput = true
         connection.connectTimeout = 15_000 // 15s
-        connection.readTimeout = 20_1000 // 20s
+        connection.readTimeout = 20_000 // 20s
         return connection
     }
 


### PR DESCRIPTION
## Summary
- correct HttpClient's read timeout comment and value

## Testing
- `./gradlew test` *(fails: No route to host while downloading Gradle distribution)*