### PR TITLE
fix: deprecate on enter / exit foreground

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -10,7 +10,6 @@ import com.amplitude.android.plugins.AndroidLifecyclePlugin
 import com.amplitude.android.plugins.AndroidNetworkConnectivityCheckerPlugin
 import com.amplitude.android.storage.AndroidStorageContextV3
 import com.amplitude.android.utilities.ActivityLifecycleObserver
-import com.amplitude.core.Amplitude as CoreAmplitude
 import com.amplitude.core.State
 import com.amplitude.core.platform.plugins.AmplitudeDestination
 import com.amplitude.core.platform.plugins.GetAmpliExtrasPlugin
@@ -22,6 +21,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import java.util.concurrent.Executors
+import com.amplitude.core.Amplitude as CoreAmplitude
 
 open class Amplitude internal constructor(
     configuration: Configuration,

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -10,8 +10,8 @@ import com.amplitude.android.plugins.AndroidLifecyclePlugin
 import com.amplitude.android.plugins.AndroidNetworkConnectivityCheckerPlugin
 import com.amplitude.android.storage.AndroidStorageContextV3
 import com.amplitude.android.utilities.ActivityLifecycleObserver
+import com.amplitude.core.Amplitude as CoreAmplitude
 import com.amplitude.core.State
-import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.plugins.AmplitudeDestination
 import com.amplitude.core.platform.plugins.GetAmpliExtrasPlugin
 import com.amplitude.id.IdentityConfiguration
@@ -22,7 +22,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
 import java.util.concurrent.Executors
-import com.amplitude.core.Amplitude as CoreAmplitude
 
 open class Amplitude internal constructor(
     configuration: Configuration,
@@ -126,22 +125,14 @@ open class Amplitude internal constructor(
         return this
     }
 
+    @Deprecated("This method is deprecated and a no-op.")
     fun onEnterForeground(timestamp: Long) {
-        val dummyEnterForegroundEvent = BaseEvent()
-        dummyEnterForegroundEvent.eventType = DUMMY_ENTER_FOREGROUND_EVENT
-        dummyEnterForegroundEvent.timestamp = timestamp
-        timeline.process(dummyEnterForegroundEvent)
+        // no-op
     }
 
+    @Deprecated("This method is deprecated and a no-op.")
     fun onExitForeground(timestamp: Long) {
-        val dummyExitForegroundEvent = BaseEvent()
-        dummyExitForegroundEvent.eventType = DUMMY_EXIT_FOREGROUND_EVENT
-        dummyExitForegroundEvent.timestamp = timestamp
-        timeline.process(dummyExitForegroundEvent)
-
-        if ((configuration as Configuration).flushEventsOnClose) {
-            flush()
-        }
+        // no-op
     }
 
     private fun registerShutdownHook() {

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -17,12 +17,12 @@ import com.amplitude.android.utilities.ActivityCallbackType
 import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.android.utilities.DefaultEventUtils
 import com.amplitude.core.Amplitude
+import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import com.amplitude.android.Amplitude as AndroidAmplitude
-import com.amplitude.core.events.BaseEvent
 
 class AndroidLifecyclePlugin(
     private val activityLifecycleObserver: ActivityLifecycleObserver

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeRobolectricTests.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeRobolectricTests.kt
@@ -54,14 +54,14 @@ class AmplitudeRobolectricTests {
         event1.timestamp = 1000
         amplitudeInstance.track(event1)
 
-        amplitudeInstance.onEnterForeground(1500)
+        enterForeground(amplitudeInstance, 1500)
 
         val event2 = BaseEvent()
         event2.eventType = "test event 2"
         event2.timestamp = 1700
         amplitudeInstance.track(event2)
 
-        amplitudeInstance.onExitForeground(2000)
+        exitForeground(amplitudeInstance, 2000)
 
         assertTrue { fakeEventPlugin.trackedEvents.isEmpty() }
     }
@@ -80,6 +80,26 @@ class AmplitudeRobolectricTests {
             optOut = optOut ?: false,
             minTimeBetweenSessionsMillis = minTimeBetweenSessionsMillis
                 ?: Configuration.MIN_TIME_BETWEEN_SESSIONS_MILLIS,
+        )
+    }
+
+    // simulates the dummy event for android lifecycle onActivityResumed
+    private fun enterForeground(amplitude: Amplitude, timestamp: Long) {
+        amplitude.timeline.process(
+            BaseEvent().apply {
+                eventType = Amplitude.DUMMY_ENTER_FOREGROUND_EVENT
+                this.timestamp = timestamp
+            }
+        )
+    }
+
+    // simulates the dummy event for android lifecycle onActivityPaused
+    private fun exitForeground(amplitude: Amplitude, timestamp: Long) {
+        amplitude.timeline.process(
+            BaseEvent().apply {
+                eventType = Amplitude.DUMMY_EXIT_FOREGROUND_EVENT
+                this.timestamp = timestamp
+            }
         )
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeSessionTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeSessionTest.kt
@@ -173,7 +173,7 @@ class AmplitudeSessionTest {
 
         amplitude.isBuilt.await()
 
-        amplitude.onEnterForeground(1000)
+        enterForeground(amplitude, 1000)
         amplitude.track(createEvent(1050, "test event 1"))
         amplitude.track(createEvent(2000, "test event 2"))
 
@@ -219,7 +219,7 @@ class AmplitudeSessionTest {
         amplitude.isBuilt.await()
 
         amplitude.track(createEvent(1000, "test event 1"))
-        amplitude.onEnterForeground(1050)
+        enterForeground(amplitude, 1050)
         amplitude.track(createEvent(2000, "test event 2"))
 
         advanceUntilIdle()
@@ -264,7 +264,7 @@ class AmplitudeSessionTest {
         amplitude.isBuilt.await()
 
         amplitude.track(createEvent(1000, "test event 1"))
-        amplitude.onEnterForeground(2000)
+        enterForeground(amplitude, 2000)
         amplitude.track(createEvent(3000, "test event 2"))
 
         advanceUntilIdle()
@@ -318,9 +318,9 @@ class AmplitudeSessionTest {
 
         amplitude.isBuilt.await()
 
-        amplitude.onEnterForeground(1000)
+        enterForeground(amplitude, 1000)
         amplitude.track(createEvent(1500, "test event 1"))
-        amplitude.onExitForeground(2000)
+        exitForeground(amplitude, 2000)
         amplitude.track(createEvent(2050, "test event 2"))
 
         advanceUntilIdle()
@@ -364,9 +364,9 @@ class AmplitudeSessionTest {
 
         amplitude.isBuilt.await()
 
-        amplitude.onEnterForeground(1000)
+        enterForeground(amplitude, 1000)
         amplitude.track(createEvent(1500, "test event 1"))
-        amplitude.onExitForeground(2000)
+        exitForeground(amplitude, 2000)
         amplitude.track(createEvent(3000, "test event 2"))
 
         advanceUntilIdle()
@@ -417,7 +417,7 @@ class AmplitudeSessionTest {
         )
         amplitude1.isBuilt.await()
 
-        amplitude1.onEnterForeground(1000)
+        enterForeground(amplitude1, 1000)
 
         advanceUntilIdle()
         Thread.sleep(100)
@@ -647,6 +647,26 @@ class AmplitudeSessionTest {
         event.eventType = eventType
         event.sessionId = sessionId
         return event
+    }
+
+    // simulates the dummy event for android lifecycle onActivityResumed
+    private fun enterForeground(amplitude: Amplitude, timestamp: Long) {
+        amplitude.timeline.process(
+            BaseEvent().apply {
+                eventType = Amplitude.DUMMY_ENTER_FOREGROUND_EVENT
+                this.timestamp = timestamp
+            }
+        )
+    }
+
+    // simulates the dummy event for android lifecycle onActivityPaused
+    private fun exitForeground(amplitude: Amplitude, timestamp: Long) {
+        amplitude.timeline.process(
+            BaseEvent().apply {
+                eventType = Amplitude.DUMMY_EXIT_FOREGROUND_EVENT
+                this.timestamp = timestamp
+            }
+        )
     }
 }
 

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeTest.kt
@@ -288,7 +288,7 @@ class AmplitudeTest {
         // Fire a foreground event. This is fired using the delayed timeline. The event is
         // actually processed after 500ms
         val thread1 = thread {
-            amplitude.onEnterForeground(1120)
+            enterForeground(amplitude, 1120)
         }
         Thread.sleep(100)
         // Un-mock the object so that there's no delay anymore
@@ -313,5 +313,25 @@ class AmplitudeTest {
 
     companion object {
         private const val INSTANCE_NAME = "testInstance"
+    }
+
+    // simulates the dummy event for android lifecycle onActivityResumed
+    private fun enterForeground(amplitude: Amplitude, timestamp: Long) {
+        amplitude.timeline.process(
+            BaseEvent().apply {
+                eventType = Amplitude.DUMMY_ENTER_FOREGROUND_EVENT
+                this.timestamp = timestamp
+            }
+        )
+    }
+
+    // simulates the dummy event for android lifecycle onActivityPaused
+    private fun exitForeground(amplitude: Amplitude, timestamp: Long) {
+        amplitude.timeline.process(
+            BaseEvent().apply {
+                eventType = Amplitude.DUMMY_EXIT_FOREGROUND_EVENT
+                this.timestamp = timestamp
+            }
+        )
     }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Upon testing, this exposed function can produce these end/start session events if used incorrectly.
This PR is removing the implementation from Amplitude and moving it directly into Timeline.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->