### PR TITLE
Move module deps to version catalog

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,36 +54,37 @@ android {
 
 dependencies {
     api project(':core')
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
-    implementation 'com.amplitude:analytics-connector:1.0.0'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.activity:activity-ktx:1.9.1'
-    compileOnly 'androidx.fragment:fragment-ktx:1.8.2'
-    compileOnly 'androidx.compose.ui:ui:1.6.8'
+    implementation libs.coroutines.core
+    implementation libs.coroutines.android
+    implementation libs.analytics.connector
+    implementation libs.core.ktx
+    implementation libs.activity.ktx
+    compileOnly libs.fragment.ktx
+    compileOnly libs.compose.ui
 
-    testImplementation 'io.mockk:mockk:1.12.4'
+    testImplementation libs.mockk
     testImplementation project(':core')
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit:1.8.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
-    testImplementation("junit:junit:4.13.2")
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.7.2")
-    testImplementation 'org.robolectric:robolectric:4.12.1'
-    testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    testImplementation 'org.json:json:20211205'
-    testImplementation 'com.google.android.gms:play-services-base:18.0.1'
-    testImplementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
-    testImplementation 'com.google.android.gms:play-services-appset:16.0.2'
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.2"
-    testImplementation 'androidx.test:runner:1.4.0'
-    testImplementation "org.mockito:mockito-core:4.3.1"
+    testImplementation libs.coroutines.test
+    testImplementation libs.mockwebserver
+    testImplementation platform(libs.junit.bom)
+    testImplementation libs.junit.jupiter
+    testImplementation libs.kotlin.test.junit
+    testRuntimeOnly libs.junit.jupiter.engine
+    testImplementation libs.junit.jupiter.params
+    testImplementation libs.junit4
+    testRuntimeOnly libs.junit.vintage.engine
+    testImplementation libs.robolectric
+    testImplementation libs.test.core
+    testImplementation libs.test.ext.junit
+    androidTestImplementation libs.test.ext.junit
+    androidTestImplementation libs.espresso.core
+    testImplementation libs.json
+    testImplementation libs.play.services.base
+    testImplementation libs.play.services.ads.identifier
+    testImplementation libs.play.services.appset
+    testImplementation libs.junit.jupiter.api
+    testImplementation libs.test.runner
+    testImplementation libs.mockito.core
 }
 
 tasks.dokkaHtmlPartial.configure {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -26,7 +26,7 @@ test {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation libs.kotlin.stdlib
 
     // MAIN DEPS
     compileOnly libs.json

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,56 @@
 [versions]
+activityKtx = "1.9.1"
+analyticsConnector = "1.0.0"
+composeUi = "1.6.8"
+coreKtx = "1.7.0"
 coroutines = "1.5.2"
 coroutinesTest = "1.6.4"
+espressoCore = "3.4.0"
+fragmentKtx = "1.8.2"
 json = "20211205"
 junit = "5.7.2"
-mockk = "1.12.3"
+junit4 = "4.13.2"
+kotlin = "1.8.0"
+mockito = "4.3.1"
+mockk = "1.12.4"
 mockwebserver = "4.10.0"
 okhttp = "4.12.0"
+playServicesAdsIdentifier = "18.0.1"
+playServicesAppset = "16.0.2"
+playServicesBase = "18.0.1"
+robolectric = "4.12.1"
+testCore = "1.4.0"
+testExtJunit = "1.1.3"
+testRunner = "1.4.0"
 
 [libraries]
+activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
+analytics-connector = { module = "com.amplitude:analytics-connector", version.ref = "analyticsConnector" }
+compose-ui = { module = "androidx.compose.ui:ui", version.ref = "composeUi" }
+core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
+fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtx" }
 json = { module = "org.json:json", version.ref = "json" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter"}
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+play-services-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "playServicesAdsIdentifier" }
+play-services-appset = { module = "com.google.android.gms:play-services-appset", version.ref = "playServicesAppset" }
+play-services-base = { module = "com.google.android.gms:play-services-base", version.ref = "playServicesBase" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+test-core = { module = "androidx.test:core", version.ref = "testCore" }
+test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "testExtJunit" }
+test-runner = { module = "androidx.test:runner", version.ref = "testRunner" }


### PR DESCRIPTION
## Summary
- centralize Android and core module dependencies in libs.versions.toml
- reference the catalog from module build files

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684374adc4308331aabac348b8f0cdd5