### PR TITLE
Update Kotlin to 1.9.23

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,8 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.10.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit:1.8.0'
+    // Align with the Kotlin version used in the root build file
+    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit:1.9.23'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
     testImplementation("junit:junit:4.13.2")

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
-    ext.kotlin_version = "1.8.0"
+    // Use the latest Kotlin version that is still in the 1.x line.
+    ext.kotlin_version = "1.9.23"
     ext.dokka_version = '1.6.10'
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }


### PR DESCRIPTION
## Summary
- use Kotlin `1.9.23` in build scripts
- align android tests with the same Kotlin version

## Testing
- `./gradlew check` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684374d3b65c833190bafe1cb171deda