### PR TITLE
fix: broken sessions forground tracking

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -126,14 +126,12 @@ open class Amplitude internal constructor(
         return this
     }
 
-    @Deprecated("This method is deprecated and a no-op.")
     fun onEnterForeground(timestamp: Long) {
-        // no-op
+        (timeline as Timeline).onEnterForeground(timestamp)
     }
 
-    @Deprecated("This method is deprecated and a no-op.")
     fun onExitForeground(timestamp: Long) {
-        // no-op
+        (timeline as Timeline).onExitForeground(timestamp)
     }
 
     private fun registerShutdownHook() {
@@ -156,6 +154,7 @@ open class Amplitude internal constructor(
          * The event type for end session events.
          */
         const val END_SESSION_EVENT = "session_end"
+
     }
 }
 

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -126,12 +126,12 @@ open class Amplitude internal constructor(
         return this
     }
 
-    @InternalAmplitudeFeature
+    @GuardedAmplitudeFeature
     fun onEnterForeground(timestamp: Long) {
         (timeline as Timeline).onEnterForeground(timestamp)
     }
 
-    @InternalAmplitudeFeature
+    @GuardedAmplitudeFeature
     fun onExitForeground(timestamp: Long) {
         (timeline as Timeline).onExitForeground(timestamp)
     }

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -126,10 +126,12 @@ open class Amplitude internal constructor(
         return this
     }
 
+    @InternalAmplitudeFeature
     fun onEnterForeground(timestamp: Long) {
         (timeline as Timeline).onEnterForeground(timestamp)
     }
 
+    @InternalAmplitudeFeature
     fun onExitForeground(timestamp: Long) {
         (timeline as Timeline).onExitForeground(timestamp)
     }

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -154,7 +154,6 @@ open class Amplitude internal constructor(
          * The event type for end session events.
          */
         const val END_SESSION_EVENT = "session_end"
-
     }
 }
 

--- a/android/src/main/java/com/amplitude/android/GuardedAmplitudeFeature.kt
+++ b/android/src/main/java/com/amplitude/android/GuardedAmplitudeFeature.kt
@@ -1,0 +1,9 @@
+package com.amplitude.android
+
+@RequiresOptIn(
+    message =
+        "This feature is guarded and should only be used by Amplitude SDK developers. " +
+            "It is not intended for public use and may change without notice.",
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class GuardedAmplitudeFeature

--- a/android/src/main/java/com/amplitude/android/InternalAmplitudeFeature.kt
+++ b/android/src/main/java/com/amplitude/android/InternalAmplitudeFeature.kt
@@ -1,8 +1,0 @@
-package com.amplitude.android
-
-@RequiresOptIn(
-    message =
-        "This feature is internal to the Amplitude SDK and is not intended for public use. Use at your own risk",
-)
-@Retention(AnnotationRetention.BINARY)
-annotation class InternalAmplitudeFeature

--- a/android/src/main/java/com/amplitude/android/InternalAmplitudeFeature.kt
+++ b/android/src/main/java/com/amplitude/android/InternalAmplitudeFeature.kt
@@ -1,0 +1,8 @@
+package com.amplitude.android
+
+@RequiresOptIn(
+    message =
+        "This feature is internal to the Amplitude SDK and is not intended for public use. Use at your own risk",
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class InternalAmplitudeFeature

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -73,13 +73,13 @@ class Timeline(
 
     internal fun onEnterForeground(timestamp: Long) {
         amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
-            eventMessageChannel.send(EventQueueMessage.EnterForeground(timestamp))
+            eventMessageChannel.trySend(EventQueueMessage.EnterForeground(timestamp))
         }
     }
 
     internal fun onExitForeground(timestamp: Long) {
         amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
-            eventMessageChannel.send(EventQueueMessage.ExitForeground(timestamp))
+            eventMessageChannel.trySend(EventQueueMessage.ExitForeground(timestamp))
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
 private const val DEFAULT_SESSION_ID = -1L
-private const val DEFAULT = 0L
+private const val DEFAULT_EVENT_ID_OR_TIME = 0L
 
 class Timeline(
     private val initialSessionId: Long? = null,
@@ -29,9 +29,9 @@ class Timeline(
             return _sessionId.get()
         }
 
-    internal var lastEventId: Long = DEFAULT
+    internal var lastEventId: Long = DEFAULT_EVENT_ID_OR_TIME
         private set
-    internal var lastEventTime: Long = DEFAULT
+    internal var lastEventTime: Long = DEFAULT_EVENT_ID_OR_TIME
         private set
 
     internal fun start() {
@@ -43,8 +43,8 @@ class Timeline(
                 if (initialSessionId == null) {
                     _sessionId.set(storage.readLong(PREVIOUS_SESSION_ID, DEFAULT_SESSION_ID))
                 }
-                lastEventId = storage.readLong(LAST_EVENT_ID, DEFAULT)
-                lastEventTime = storage.readLong(LAST_EVENT_TIME, DEFAULT)
+                lastEventId = storage.readLong(LAST_EVENT_ID, DEFAULT_EVENT_ID_OR_TIME)
+                lastEventTime = storage.readLong(LAST_EVENT_TIME, DEFAULT_EVENT_ID_OR_TIME)
 
                 for (message in eventMessageChannel) {
                     processEventMessage(message)
@@ -57,34 +57,51 @@ class Timeline(
         this.eventMessageChannel.cancel()
     }
 
+    /**
+     * Enqueue an event to be processed by the timeline.
+     */
     override fun process(incomingEvent: BaseEvent) {
         if (incomingEvent.timestamp == null) {
             incomingEvent.timestamp = System.currentTimeMillis()
         }
 
-        eventMessageChannel.trySend(EventQueueMessage(incomingEvent))
+        eventMessageChannel.trySend(EventQueueMessage.Event(incomingEvent))
     }
 
     internal fun onEnterForeground(timestamp: Long) {
         amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
-            val localSessionEvents = startNewSessionIfNeeded(timestamp)
-            foreground.set(true)
-
-            // Process any local session events
-            processAndPersistEvents(localSessionEvents)
+            eventMessageChannel.send(EventQueueMessage.EnterForeground(timestamp))
         }
     }
 
     internal fun onExitForeground(timestamp: Long) {
         amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
-            refreshSessionTime(timestamp)
-            foreground.set(false)
+            eventMessageChannel.send(EventQueueMessage.ExitForeground(timestamp))
         }
     }
 
+    /**
+     * Process an event message from the event queue.
+     */
     private suspend fun processEventMessage(message: EventQueueMessage) {
-        val event = message.event
-        val eventTimestamp = event.timestamp!! // Guaranteed non-null by process()
+        when (message) {
+            is EventQueueMessage.EnterForeground -> {
+                foreground.set(true)
+                val sessionEvents = startNewSessionIfNeeded(message.timestamp)
+                processAndPersistEvents(sessionEvents)
+            }
+            is EventQueueMessage.Event -> {
+                processEvent(message.event)
+            }
+            is EventQueueMessage.ExitForeground -> {
+                foreground.set(false)
+                refreshSessionTime(message.timestamp)
+            }
+        }
+    }
+
+    private suspend fun processEvent(event: BaseEvent) {
+        val eventTimestamp = event.timestamp ?: System.currentTimeMillis()
         val eventSessionId = event.sessionId
 
         when (event.eventType) {
@@ -99,16 +116,13 @@ class Timeline(
 
             else -> {
                 if (!foreground.get()) {
-                    val localSessionEvents = startNewSessionIfNeeded(eventTimestamp)
-                    processAndPersistEvents(localSessionEvents)
+                    val sessionEvents = startNewSessionIfNeeded(eventTimestamp)
+                    processAndPersistEvents(sessionEvents)
                 } else {
                     refreshSessionTime(eventTimestamp)
                 }
             }
         }
-
-        // Assign sessionId to the current event if it doesn't have one
-        event.sessionId = event.sessionId ?: this.sessionId
 
         // Process the incoming event
         processAndPersistEvents(listOf(event))
@@ -119,6 +133,9 @@ class Timeline(
 
         val initialLastEventId = lastEventId
         for (event in events) {
+            // Assign sessionId to the current event if it doesn't have one
+            event.sessionId = event.sessionId ?: this.sessionId
+            // Increment and set eventId if it is not set
             event.eventId = event.eventId ?: ++lastEventId
             super.process(event)
         }
@@ -151,7 +168,7 @@ class Timeline(
         if (trackingSessionEvents && inSession()) {
             val sessionEndEvent = BaseEvent()
             sessionEndEvent.eventType = END_SESSION_EVENT
-            sessionEndEvent.timestamp = lastEventTime.takeIf { lastEventTime > DEFAULT }
+            sessionEndEvent.timestamp = lastEventTime.takeIf { lastEventTime > DEFAULT_EVENT_ID_OR_TIME }
             sessionEndEvent.sessionId = sessionId
             sessionEvents.add(sessionEndEvent)
         }
@@ -196,6 +213,8 @@ class Timeline(
     }
 }
 
-data class EventQueueMessage(
-    val event: BaseEvent,
-)
+sealed class EventQueueMessage {
+    data class Event(val event: BaseEvent) : EventQueueMessage()
+    data class EnterForeground(val timestamp: Long) : EventQueueMessage()
+    data class ExitForeground(val timestamp: Long) : EventQueueMessage()
+}

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -215,6 +215,8 @@ class Timeline(
 
 sealed class EventQueueMessage {
     data class Event(val event: BaseEvent) : EventQueueMessage()
+
     data class EnterForeground(val timestamp: Long) : EventQueueMessage()
+
     data class ExitForeground(val timestamp: Long) : EventQueueMessage()
 }

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import com.amplitude.android.Amplitude as AndroidAmplitude
-import com.amplitude.android.Timeline as AndroidTimeline
 
 class AndroidLifecyclePlugin(
     private val activityLifecycleObserver: ActivityLifecycleObserver,
@@ -118,9 +117,7 @@ class AndroidLifecyclePlugin(
     }
 
     override fun onActivityResumed(activity: Activity) {
-        with(androidAmplitude) {
-            (timeline as AndroidTimeline).onEnterForeground(System.currentTimeMillis())
-        }
+        androidAmplitude.onEnterForeground(System.currentTimeMillis())
 
         if (ELEMENT_INTERACTIONS in autocapture) {
             DefaultEventUtils(androidAmplitude).startUserInteractionEventTracking(activity)
@@ -129,7 +126,7 @@ class AndroidLifecyclePlugin(
 
     override fun onActivityPaused(activity: Activity) {
         with(androidAmplitude) {
-            (timeline as AndroidTimeline).onExitForeground(System.currentTimeMillis())
+            onExitForeground(System.currentTimeMillis())
 
             if ((configuration as Configuration).flushEventsOnClose) {
                 flush()

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -12,7 +12,7 @@ import com.amplitude.android.AutocaptureOption.DEEP_LINKS
 import com.amplitude.android.AutocaptureOption.ELEMENT_INTERACTIONS
 import com.amplitude.android.AutocaptureOption.SCREEN_VIEWS
 import com.amplitude.android.Configuration
-import com.amplitude.android.InternalAmplitudeFeature
+import com.amplitude.android.GuardedAmplitudeFeature
 import com.amplitude.android.utilities.ActivityCallbackType
 import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.android.utilities.DefaultEventUtils
@@ -23,7 +23,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import com.amplitude.android.Amplitude as AndroidAmplitude
 
-@OptIn(InternalAmplitudeFeature::class)
+@OptIn(GuardedAmplitudeFeature::class)
 class AndroidLifecyclePlugin(
     private val activityLifecycleObserver: ActivityLifecycleObserver,
 ) : Application.ActivityLifecycleCallbacks, Plugin {

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -12,6 +12,7 @@ import com.amplitude.android.AutocaptureOption.DEEP_LINKS
 import com.amplitude.android.AutocaptureOption.ELEMENT_INTERACTIONS
 import com.amplitude.android.AutocaptureOption.SCREEN_VIEWS
 import com.amplitude.android.Configuration
+import com.amplitude.android.InternalAmplitudeFeature
 import com.amplitude.android.utilities.ActivityCallbackType
 import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.android.utilities.DefaultEventUtils
@@ -22,6 +23,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import com.amplitude.android.Amplitude as AndroidAmplitude
 
+@OptIn(InternalAmplitudeFeature::class)
 class AndroidLifecyclePlugin(
     private val activityLifecycleObserver: ActivityLifecycleObserver,
 ) : Application.ActivityLifecycleCallbacks, Plugin {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
<!-- What does the PR do? -->
This pull request refactors the `Timeline` class to improve the handling of event processing and session management by introducing a `sealed class` for event messages and simplifying related logic. It also updates the `Amplitude` and `AndroidLifecyclePlugin` classes to align with these changes.

### Refactoring of `Timeline` class:

* Replaced the `EventQueueMessage` data class with a `sealed class` to better represent different types of event messages (`Event`, `EnterForeground`, and `ExitForeground`). (`[android/src/main/java/com/amplitude/android/Timeline.ktL199-R222](diffhunk://#diff-56706ffae3ed75480dd3a0d4a2ec464366e74189d50b2b3eb101904e6beeb15eL199-R222)`)
* Updated the `processEventMessage` method to handle different message types using a `when` expression, simplifying the logic for foreground and background transitions. (`[android/src/main/java/com/amplitude/android/Timeline.ktR60-R104](diffhunk://#diff-56706ffae3ed75480dd3a0d4a2ec464366e74189d50b2b3eb101904e6beeb15eR60-R104)`)
* Consolidated session-related logic by moving session ID assignment and event ID incrementation into the `processAndPersistEvents` method. (`[android/src/main/java/com/amplitude/android/Timeline.ktR136-R138](diffhunk://#diff-56706ffae3ed75480dd3a0d4a2ec464366e74189d50b2b3eb101904e6beeb15eR136-R138)`)
* Renamed the `DEFAULT` constant to `DEFAULT_EVENT_ID_OR_TIME` for clarity and updated its usage throughout the class. (`[[1]](diffhunk://#diff-56706ffae3ed75480dd3a0d4a2ec464366e74189d50b2b3eb101904e6beeb15eL18-R18)`, `[[2]](diffhunk://#diff-56706ffae3ed75480dd3a0d4a2ec464366e74189d50b2b3eb101904e6beeb15eL32-R34)`, `[[3]](diffhunk://#diff-56706ffae3ed75480dd3a0d4a2ec464366e74189d50b2b3eb101904e6beeb15eL46-R47)`, `[[4]](diffhunk://#diff-56706ffae3ed75480dd3a0d4a2ec464366e74189d50b2b3eb101904e6beeb15eL154-R171)`)

### Updates to `Amplitude` class:

* Replaced deprecated no-op methods `onEnterForeground` and `onExitForeground` with functional implementations that delegate to the `Timeline` class. (`[android/src/main/java/com/amplitude/android/Amplitude.ktL129-R134](diffhunk://#diff-f0db7176910d8c66beb88e8beb06441160b470c3733061f319a17622f1afcfd6L129-R134)`)

### Updates to `AndroidLifecyclePlugin` class:

* Simplified lifecycle event handling by directly calling `onEnterForeground` and `onExitForeground` on the `Amplitude` instance, removing explicit casting to `Timeline`. (`[[1]](diffhunk://#diff-115c82866176416f03f37c21dea752145c553bba0d00bbc905db9e630af6225bL121-R120)`, `[[2]](diffhunk://#diff-115c82866176416f03f37c21dea752145c553bba0d00bbc905db9e630af6225bL132-R129)`)
* Removed the unused import for `Timeline` to clean up the code. (`[android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.ktL24](diffhunk://#diff-115c82866176416f03f37c21dea752145c553bba0d00bbc905db9e630af6225bL24)`)

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->