### PR TITLE
Debug custom xml attribute read issue

### DIFF
--- a/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
+++ b/android/src/main/java/com/amplitude/android/internal/locators/AndroidViewTargetLocator.kt
@@ -70,59 +70,16 @@ internal class AndroidViewTargetLocator : ViewTargetLocator {
         val ignoreDeadClickKey = "amplitude_ignore_dead_click".hashCode()
         val ignoreFrustrationKey = "amplitude_ignore_frustration".hashCode()
 
-        // Check for programmatically set flags first
+        // Check for programmatically set flags first (includes XML-to-programmatic conversions)
         val programmaticIgnoreRage = getTag(ignoreRageClickKey) as? Boolean ?: false
         val programmaticIgnoreDead = getTag(ignoreDeadClickKey) as? Boolean ?: false
         val programmaticIgnoreAll = getTag(ignoreFrustrationKey) as? Boolean ?: false
 
-        // If programmatic flags are set, use those (takes precedence)
-        if (programmaticIgnoreRage || programmaticIgnoreDead || programmaticIgnoreAll) {
-            return FrustrationSettings(
-                ignoreRageClick = programmaticIgnoreRage || programmaticIgnoreAll,
-                ignoreDeadClick = programmaticIgnoreDead || programmaticIgnoreAll,
-            )
-        }
-
-        // Otherwise, try to read custom XML attributes if available
-        try {
-            val context = context
-
-            // Get the styled attributes for this view using the declare-styleable
-            val typedArray =
-                context.obtainStyledAttributes(
-                    null,
-                    R.styleable.AmplitudeFrustrationAnalytics,
-                    0,
-                    0,
-                )
-
-            val ignoreRageFromXml =
-                typedArray.getBoolean(
-                    R.styleable.AmplitudeFrustrationAnalytics_amplitudeIgnoreRageClick,
-                    false,
-                )
-            val ignoreDeadFromXml =
-                typedArray.getBoolean(
-                    R.styleable.AmplitudeFrustrationAnalytics_amplitudeIgnoreDeadClick,
-                    false,
-                )
-            val ignoreAllFromXml =
-                typedArray.getBoolean(
-                    R.styleable.AmplitudeFrustrationAnalytics_amplitudeIgnoreFrustration,
-                    false,
-                )
-
-            typedArray.recycle()
-
-            // Return XML-based settings
-            return FrustrationSettings(
-                ignoreRageClick = ignoreRageFromXml || ignoreAllFromXml,
-                ignoreDeadClick = ignoreDeadFromXml || ignoreAllFromXml,
-            )
-        } catch (e: Exception) {
-            // Return default (no ignore flags)
-            return FrustrationSettings()
-        }
+        // Return programmatic settings (which now include XML attributes processed during inflation)
+        return FrustrationSettings(
+            ignoreRageClick = programmaticIgnoreRage || programmaticIgnoreAll,
+            ignoreDeadClick = programmaticIgnoreDead || programmaticIgnoreAll,
+        )
     }
 
     private fun View.touchWithinBounds(position: Pair<Float, Float>): Boolean {

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/XmlAdvancedActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/XmlAdvancedActivity.kt
@@ -3,6 +3,7 @@ package com.amplitude.android.sample
 import android.os.Bundle
 import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
+import com.amplitude.android.FrustrationAnalyticsUtils
 import com.amplitude.core.events.Identify
 import com.amplitude.core.events.Revenue
 
@@ -10,6 +11,9 @@ class XmlAdvancedActivity : AppCompatActivity() {
     private val amplitude = MainApplication.amplitude
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Set up automatic XML attribute processing BEFORE setContentView
+        FrustrationAnalyticsUtils.setupAutomaticXmlProcessing(this)
+        
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_advanced)
 

--- a/samples/kotlin-android-app/src/main/res/layout/activity_advanced.xml
+++ b/samples/kotlin-android-app/src/main/res/layout/activity_advanced.xml
@@ -1,32 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".AdvancedActivity">
+    android:orientation="vertical"
+    android:padding="16dp">
 
+    <!-- Test buttons with custom attributes -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <!-- XML Ignore Both Button -->
+        <Button
+            android:id="@+id/xml_ignored_both_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:backgroundTint="#9C27B0"
+            android:text="Ignored (Both XML)"
+            android:textColor="@android:color/white"
+            app:amplitudeIgnoreFrustration="true" />
+
+        <!-- XML Ignore Rage Button -->
+        <Button
+            android:id="@+id/xml_ignored_rage_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:backgroundTint="#FF9800"
+            android:text="XML Ignored (Rage XML)"
+            android:textColor="@android:color/white"
+            android:textSize="12sp"
+            app:amplitudeIgnoreRageClick="true" />
+
+        <!-- XML Ignore Dead Button -->
+        <Button
+            android:id="@+id/xml_ignored_dead_button"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:backgroundTint="#808080"
+            android:stateListAnimator="@null"
+            android:text="XML Ignored (Dead XML)"
+            android:textColor="@android:color/white"
+            android:textSize="12sp"
+            app:amplitudeIgnoreDeadClick="true" />
+
+    </LinearLayout>
+
+    <!-- Regular buttons -->
     <Button
         android:id="@+id/send_advanced_events_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Send Advanced Events"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.5" />
+        android:layout_marginTop="32dp"
+        android:layout_gravity="center"
+        android:text="Send Advanced Events" />
 
     <Button
         android:id="@+id/back_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
+        android:layout_gravity="center"
         android:text="Back"
-        app:backgroundTint="#03A9F4"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/send_advanced_events_button" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        app:backgroundTint="#03A9F4" />
+
+</LinearLayout>


### PR DESCRIPTION
```
### Describe what this PR is addressing
This PR addresses an issue where custom XML attributes for frustration analytics (e.g., `app:amplitudeIgnoreFrustration="true"`) were not being read correctly from Android views, always returning `false` during runtime checks. The problem stemmed from an incorrect usage of `context.obtainStyledAttributes(null, ...)` which prevented the actual XML attributes from being processed.

### Describe the solution
The solution introduces an automatic mechanism to process custom XML attributes during view inflation:
*   **`LayoutInflater.Factory2` Integration**: A new `AmplitudeFrustrationAttributeFactory` is implemented as a `LayoutInflater.Factory2`. This factory intercepts view creation, reads the custom `amplitudeIgnoreFrustration`, `amplitudeIgnoreRageClick`, and `amplitudeIgnoreDeadClick` XML attributes, and then converts them into programmatic `View.setTag()` flags.
*   **Simplified `AndroidViewTargetLocator`**: The `readFrustrationAttributes()` method in `AndroidViewTargetLocator.kt` is simplified to solely rely on these programmatic flags, which are now correctly set during inflation. This removes the previous flawed attempt to read XML attributes directly.
*   **Utility for Setup**: A `FrustrationAnalyticsUtils.setupAutomaticXmlProcessing(activity)` method is provided for easy integration. Developers can call this method in their Activity's `onCreate()` before `setContentView()` to enable automatic processing.
*   **Sample App Update**: The `samples/kotlin-android-app` is updated to demonstrate this automatic processing, including the user's example XML layout.

This approach ensures that XML-declared frustration ignore settings are correctly applied and accessible by the SDK, leveraging Android's view inflation lifecycle.

### Steps to verify the change
1.  Run the `samples/kotlin-android-app` module.
2.  Navigate to `XmlAdvancedActivity`.
3.  Set a breakpoint in `AndroidViewTargetLocator.kt` within the `readFrustrationAttributes()` method.
4.  Observe the `FrustrationSettings` returned for the buttons in the `activity_advanced.xml` layout:
    *   For the "Ignored (Both XML)" button (`xml_ignored_both_button`), `ignoreRageClick` and `ignoreDeadClick` should both be `true`.
    *   For the "XML Ignored (Rage XML)" button (`xml_ignored_rage_button`), `ignoreRageClick` should be `true` and `ignoreDeadClick` should be `false`.
    *   For the "XML Ignored (Dead XML)" button (`xml_ignored_dead_button`), `ignoreDeadClick` should be `true` and `ignoreRageClick` should be `false`.

### Useful links and documentation (optional)
N/A

### Checklist
*   [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
*   [ ] Does your PR have a breaking change?
```

---
<a href="https://cursor.com/background-agent?bcId=bc-33992aab-c143-43f6-8062-42f24fa265cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-33992aab-c143-43f6-8062-42f24fa265cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>