### PR TITLE
fix: async foreground and background

### DIFF
--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -142,7 +142,6 @@ class AndroidLifecyclePlugin(
 
     @OptIn(ExperimentalAmplitudeFeature::class)
     override fun onActivityResumed(activity: Activity) {
-
         if (ELEMENT_INTERACTIONS in autocapture || FRUSTRATION_INTERACTIONS in autocapture) {
             DefaultEventUtils(androidAmplitude).startUserInteractionEventTracking(
                 activity,

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -121,6 +121,8 @@ class AndroidLifecyclePlugin(
         }
         started.add(activity.hashCode())
 
+        androidAmplitude.onEnterForeground(System.currentTimeMillis())
+
         if (APP_LIFECYCLES in autocapture && started.size == 1) {
             DefaultEventUtils(androidAmplitude).trackAppOpenedEvent(
                 packageInfo = packageInfo,
@@ -140,7 +142,6 @@ class AndroidLifecyclePlugin(
 
     @OptIn(ExperimentalAmplitudeFeature::class)
     override fun onActivityResumed(activity: Activity) {
-        androidAmplitude.onEnterForeground(System.currentTimeMillis())
 
         if (ELEMENT_INTERACTIONS in autocapture || FRUSTRATION_INTERACTIONS in autocapture) {
             DefaultEventUtils(androidAmplitude).startUserInteractionEventTracking(
@@ -153,8 +154,6 @@ class AndroidLifecyclePlugin(
     @OptIn(ExperimentalAmplitudeFeature::class)
     override fun onActivityPaused(activity: Activity) {
         with(androidAmplitude) {
-            onExitForeground(System.currentTimeMillis())
-
             if ((configuration as Configuration).flushEventsOnClose) {
                 flush()
             }
@@ -171,6 +170,15 @@ class AndroidLifecyclePlugin(
         if (APP_LIFECYCLES in autocapture && started.isEmpty()) {
             DefaultEventUtils(androidAmplitude).trackAppBackgroundedEvent()
             appInBackground = true
+        }
+
+        if (started.isEmpty()) {
+            with(androidAmplitude) {
+                onExitForeground(System.currentTimeMillis())
+                if ((configuration as Configuration).flushEventsOnClose) {
+                    flush()
+                }
+            }
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -119,9 +119,12 @@ class AndroidLifecyclePlugin(
             // We check for On Create in case if sdk was initialised in Main Activity
             onActivityCreated(activity, activity.intent.extras)
         }
-        started.add(activity.hashCode())
 
-        androidAmplitude.onEnterForeground(System.currentTimeMillis())
+        if (started.isEmpty()) {
+            androidAmplitude.onEnterForeground(System.currentTimeMillis())
+        }
+
+        started.add(activity.hashCode())
 
         if (APP_LIFECYCLES in autocapture && started.size == 1) {
             DefaultEventUtils(androidAmplitude).trackAppOpenedEvent(
@@ -152,12 +155,6 @@ class AndroidLifecyclePlugin(
 
     @OptIn(ExperimentalAmplitudeFeature::class)
     override fun onActivityPaused(activity: Activity) {
-        with(androidAmplitude) {
-            if ((configuration as Configuration).flushEventsOnClose) {
-                flush()
-            }
-        }
-
         if (ELEMENT_INTERACTIONS in autocapture || FRUSTRATION_INTERACTIONS in autocapture) {
             DefaultEventUtils(androidAmplitude).stopUserInteractionEventTracking(activity)
         }

--- a/core/src/main/java/com/amplitude/core/events/Identify.kt
+++ b/core/src/main/java/com/amplitude/core/events/Identify.kt
@@ -262,6 +262,14 @@ open class Identify {
         return this
     }
 
+    fun setOnce(
+        property: String,
+        value: Any,
+    ): Identify {
+        setUserProperty(IdentifyOperation.SET_ONCE, property, value)
+        return this
+    }
+
     fun prepend(
         property: String,
         value: Boolean,

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/TroubleShootingPlugin.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/TroubleShootingPlugin.kt
@@ -36,16 +36,16 @@ class TroubleShootingPlugin : DestinationPlugin() {
     }
 
     override fun track(payload: BaseEvent): BaseEvent {
-        val eventString = buildString {
-            appendLine("Event Type: ${payload.eventType}")
-            appendLine("- User ID: ${payload.userId ?: "N/A"}")
-            appendLine("- Device ID: ${payload.deviceId ?: "N/A"}")
-            val properties = payload.userProperties ?: emptyMap()
-            properties.forEach {
-                appendLine("- - User Property: ${it.key} = ${it.value}")
+        val eventString =
+            buildString {
+                appendLine("Event Type: ${payload.eventType}")
+                appendLine("- User ID: ${payload.userId ?: "N/A"}")
+                appendLine("- Device ID: ${payload.deviceId ?: "N/A"}")
+                val properties = payload.userProperties ?: emptyMap()
+                properties.forEach {
+                    appendLine("- - User Property: ${it.key} = ${it.value}")
+                }
             }
-
-        }
         logger.debug("Processed event: $eventString")
         return payload
     }

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/TroubleShootingPlugin.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/TroubleShootingPlugin.kt
@@ -3,8 +3,10 @@ package com.amplitude.android.sample
 import com.amplitude.common.Logger
 import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.events.GroupIdentifyEvent
+import com.amplitude.core.events.IdentifyEvent
+import com.amplitude.core.events.RevenueEvent
 import com.amplitude.core.platform.DestinationPlugin
-import com.google.gson.Gson
 
 class TroubleShootingPlugin : DestinationPlugin() {
     private lateinit var logger: Logger
@@ -18,10 +20,33 @@ class TroubleShootingPlugin : DestinationPlugin() {
         super.setup(amplitude)
     }
 
+    override fun identify(payload: IdentifyEvent): IdentifyEvent? {
+        track(payload)
+        return super.identify(payload)
+    }
+
+    override fun groupIdentify(payload: GroupIdentifyEvent): GroupIdentifyEvent? {
+        track(payload)
+        return super.groupIdentify(payload)
+    }
+
+    override fun revenue(payload: RevenueEvent): RevenueEvent? {
+        track(payload)
+        return super.revenue(payload)
+    }
+
     override fun track(payload: BaseEvent): BaseEvent {
-        val gson = Gson()
-        val eventJsonStr = gson.toJson(payload)
-        logger.debug("Processed event: $eventJsonStr")
+        val eventString = buildString {
+            appendLine("Event Type: ${payload.eventType}")
+            appendLine("- User ID: ${payload.userId ?: "N/A"}")
+            appendLine("- Device ID: ${payload.deviceId ?: "N/A"}")
+            val properties = payload.userProperties ?: emptyMap()
+            properties.forEach {
+                appendLine("- - User Property: ${it.key} = ${it.value}")
+            }
+
+        }
+        logger.debug("Processed event: $eventString")
         return payload
     }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉
Please fill out the following sections to help us quickly review your pull request.
--->

### Describe what this PR is addressing
<!-- Describe the motivation and context for the change so reviewers can understand the problem you're solving. -->
Duplicate Sessions starts and stops
Async Foreground and background

### Describe the solution
<!-- Describe the changes made in this PR. Include any relevant details about the implementation, design decisions, or trade-offs.
* Why did you choose this way to solve the problem?
* What future impact will this have?
-->
- Moved Foreground and Background from onResume/onPause to onStart/onStop. This will prevent Foreground flag from triggering session start/stop when customer application is changing activities.
- Also we track screen viewed after the foreground is triggered to keep the event in session.
- Calling foreground/background was executed on io dispatcher. Because of this, this command was async and was in race condition with screen viewed. making foreground call not working properly.
Why removing dispatcher is safe: underlying call is just placing a new message in the Channel. Channel is thread safe by design. With this approach calling foreground and screen viewed is done from the same thread and is sync.
- Updated Troubleshooting plugin to support all event types (no gson)

### Steps to verify the change
<!-- Describe how to test the changes made in this PR. Include any relevant details about the testing environment, tools, or frameworks used. -->
Manual testing for now.

### Useful links and documentation (optional)

### Checklist
* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?
