### PR TITLE
feat: add deep link tracking on activity resume for singleTop/singleT…

### DIFF
--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -163,7 +163,13 @@ class AndroidLifecyclePlugin(
         }
     }
 
-    override fun onActivityResumed(activity: Activity) = Unit
+    override fun onActivityResumed(activity: Activity) {
+        // Handle onNewIntent() deep links for singleTop/singleTask activities.
+        // Requires developers to call setIntent(newIntent) in their onNewIntent().
+        if (autocaptureState.deepLinks) {
+            trackDeepLinkIfNew(activity)
+        }
+    }
 
     override fun onActivityPaused(activity: Activity) = Unit
 


### PR DESCRIPTION
### Describe what this PR is addressing

Deep links delivered via `onNewIntent()` to singleTop/singleTask activities were not being tracked.

### Describe the solution

- Add `trackDeepLinkIfNew()` call in `onActivityResumed()` 
- Existing deduplication logic prevents false duplicates on normal resume

**Note:** Requires developers to call `setIntent(newIntent)` in their `onNewIntent()` (standard Android practice).

### Steps to verify the change

- manual test and unit test

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds deep link handling on resume to cover `onNewIntent()` cases for singleTop/singleTask activities.
> 
> - Invoke `trackDeepLinkIfNew()` in `onActivityResumed()` within `AndroidLifecyclePlugin.kt`; relies on developers calling `setIntent(newIntent)` in `onNewIntent()`
> - Maintains existing dedup via `processedDeepLinkIntents` to avoid duplicates across starts/resumes
> - Tests: add scenarios for tracking on resume after `setIntent` (onNewIntent), ensuring no duplicate when resuming without new intent, and verifying other autocapture (e.g., screen views) remains unaffected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 436156ce75da58c82eb98c4fb6c9c5bd85a0fa1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->