### PR TITLE
fix: always register activity lifecycle callbacks for accurate session tracking

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -64,10 +64,8 @@ open class Amplitude internal constructor(
     init {
         registerShutdownHook()
 
-        if (configuration.autocapture.any { it in AutocaptureOption.REQUIRES_ACTIVITY_CALLBACKS }) {
-            with(configuration.context as Application) {
-                registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
-            }
+        with(configuration.context as Application) {
+            registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/AutocaptureOptions.kt
+++ b/android/src/main/java/com/amplitude/android/AutocaptureOptions.kt
@@ -57,19 +57,6 @@ enum class AutocaptureOption {
                 ELEMENT_INTERACTIONS,
                 FRUSTRATION_INTERACTIONS,
             )
-
-        /**
-         * Set of autocapture options that require Android Activity lifecycle callbacks to function properly.
-         *
-         * These options need access to activity lifecycle events and therefore require the ActivityLifecycleObserver to be registered with the Application.
-         */
-        val REQUIRES_ACTIVITY_CALLBACKS =
-            setOf(
-                APP_LIFECYCLES,
-                SCREEN_VIEWS,
-                ELEMENT_INTERACTIONS,
-                DEEP_LINKS,
-            )
     }
 }
 

--- a/android/src/test/kotlin/com/amplitude/android/ConfigurationTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/ConfigurationTest.kt
@@ -138,22 +138,6 @@ class ConfigurationTest {
         Assertions.assertFalse(AutocaptureOption.SCREEN_VIEWS in configuration.autocapture)
     }
 
-    @Test
-    fun autocaptureOption_requiresActivityCallbacks_containsExpectedOptions() {
-        val expectedOptions =
-            setOf(
-                AutocaptureOption.APP_LIFECYCLES,
-                AutocaptureOption.SCREEN_VIEWS,
-                AutocaptureOption.ELEMENT_INTERACTIONS,
-                AutocaptureOption.DEEP_LINKS,
-            )
-
-        Assertions.assertEquals(expectedOptions, AutocaptureOption.REQUIRES_ACTIVITY_CALLBACKS)
-
-        // Verify SESSIONS is NOT included (it doesn't need activity callbacks)
-        Assertions.assertFalse(AutocaptureOption.SESSIONS in AutocaptureOption.REQUIRES_ACTIVITY_CALLBACKS)
-    }
-
     @Suppress("DEPRECATION")
     @Test
     fun configuration_defaultTracking_replaces_autocapture_entirely_configuration() {


### PR DESCRIPTION
### Describe what this PR is addressing

Fixes #354. With default config (`autocapture = setOf(SESSIONS)`), activity lifecycle callbacks were never registered, so `foreground` stayed `false` and sessions reset after `minTimeBetweenSessionsMillis` even while the user was in-app.

### Describe the solution

Always register activity lifecycle callbacks. Autocapture events are already individually guarded in `AndroidLifecyclePlugin`, so this only makes foreground detection always-on. Removes the now-dead `REQUIRES_ACTIVITY_CALLBACKS` constant and its test.

### Steps to verify the change

UT and manual

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change limited to always-on lifecycle callback registration; main risk is minor overhead or unintended lifecycle side effects, but no auth/data-flow logic changes.
> 
> **Overview**
> Always registers `ActivityLifecycleObserver` in `Amplitude` initialization, instead of doing so only when certain `autocapture` options are enabled, ensuring foreground/session state stays accurate even with session-only tracking.
> 
> Removes the now-unused `AutocaptureOption.REQUIRES_ACTIVITY_CALLBACKS` constant and deletes its unit test coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11510165a631c21a9259cd7be0d606d4fd0fad11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->