### PR TITLE
fix: move network tracking plugin to android

### DIFF
--- a/android/api/android.api
+++ b/android/api/android.api
@@ -652,6 +652,52 @@ public final class com/amplitude/android/migration/RemnantDataMigration {
 public final class com/amplitude/android/migration/RemnantDataMigration$Companion {
 }
 
+public final class com/amplitude/android/network/NetworkTrackingOptions {
+	public static final field Companion Lcom/amplitude/android/network/NetworkTrackingOptions$Companion;
+	public fun <init> (Ljava/util/List;Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/util/List;Ljava/util/List;Z)Lcom/amplitude/android/network/NetworkTrackingOptions;
+	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptureRules ()Ljava/util/List;
+	public final fun getIgnoreAmplitudeRequests ()Z
+	public final fun getIgnoreHosts ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;
+	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHosts ()Ljava/util/List;
+	public final fun getStatusCodeRange ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/android/network/NetworkTrackingOptions$Companion {
+	public final fun getDEFAULT ()Lcom/amplitude/android/network/NetworkTrackingOptions;
+}
+
+public final class com/amplitude/android/network/NetworkTrackingPlugin : com/amplitude/core/platform/Plugin, okhttp3/Interceptor {
+	public field amplitude Lcom/amplitude/core/Amplitude;
+	public fun <init> ()V
+	public fun <init> (Lcom/amplitude/android/network/NetworkTrackingOptions;)V
+	public synthetic fun <init> (Lcom/amplitude/android/network/NetworkTrackingOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getAmplitude ()Lcom/amplitude/core/Amplitude;
+	public fun getType ()Lcom/amplitude/core/platform/Plugin$Type;
+	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
+	public fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
+}
+
 public class com/amplitude/android/plugins/AndroidContextPlugin : com/amplitude/core/platform/Plugin {
 	public static final field Companion Lcom/amplitude/android/plugins/AndroidContextPlugin$Companion;
 	public static final field PLATFORM Ljava/lang/String;

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     implementation(libs.core.ktx)
     implementation(libs.activity.ktx)
     implementation(libs.curtains)
+    compileOnly(libs.okhttp)
     compileOnly(libs.fragment.ktx)
     compileOnly(libs.compose.ui)
 

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
@@ -1,17 +1,10 @@
-package com.amplitude.core.network
+package com.amplitude.android.network
 
-import com.amplitude.core.network.NetworkTrackingOptions.CaptureRule
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import kotlin.text.RegexOption.IGNORE_CASE
 
 private const val STAR_WILDCARD = "*"
 
-@Deprecated(
-    message = "Moved to the android module.",
-    replaceWith = ReplaceWith(
-        "NetworkTrackingOptions",
-        "com.amplitude.android.network.NetworkTrackingOptions",
-    ),
-)
 data class NetworkTrackingOptions(
     val captureRules: List<CaptureRule>,
     val ignoreHosts: List<String> = emptyList(),
@@ -36,7 +29,7 @@ data class NetworkTrackingOptions(
     ) {
         private val hostMatcher = HostMatcher(hosts)
 
-        fun matches(host: String): Boolean {
+        internal fun matches(host: String): Boolean {
             return hostMatcher.matches(host)
         }
     }
@@ -52,12 +45,12 @@ data class NetworkTrackingOptions(
 
     private val ignoreHostMatcher = HostMatcher(ignoreHosts)
 
-    fun shouldIgnore(host: String): Boolean {
+    internal fun shouldIgnore(host: String): Boolean {
         return ignoreHostMatcher.matches(host)
     }
 }
 
-private class HostMatcher(hosts: List<String>) {
+internal class HostMatcher(hosts: List<String>) {
     private val hostRegexes: List<Regex> by lazy {
         hosts.filter { it.contains(STAR_WILDCARD) }
             .map { host ->
@@ -93,7 +86,7 @@ private class HostMatcher(hosts: List<String>) {
  * @param host The host of the request URL.
  * @param responseCode The status code of the response, or null if it's an error.
  */
-fun List<CaptureRule>.matches(
+internal fun List<CaptureRule>.matches(
     host: String,
     responseCode: Int,
 ): Boolean {

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -1,4 +1,4 @@
-package com.amplitude.core.network
+package com.amplitude.android.network
 
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_COMPLETION_TIME
@@ -29,13 +29,6 @@ import okio.IOException
 private const val AMPLITUDE_HOST_DOMAIN = "amplitude.com"
 private const val LOCAL_ERROR_STATUS_CODE = 0
 
-@Deprecated(
-    message = "Moved to the android module.",
-    replaceWith = ReplaceWith(
-        "NetworkTrackingPlugin",
-        "com.amplitude.android.network.NetworkTrackingPlugin",
-    ),
-)
 class NetworkTrackingPlugin(
     private val options: NetworkTrackingOptions = NetworkTrackingOptions.DEFAULT,
 ) : Interceptor, Plugin {

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
@@ -1,6 +1,6 @@
-package com.amplitude.core.network
+package com.amplitude.android.network
 
-import com.amplitude.core.network.NetworkTrackingOptions.CaptureRule
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -1,5 +1,6 @@
 package com.amplitude.android.network
 
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_COMPLETION_TIME
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_DURATION
@@ -14,7 +15,6 @@ import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL_FRAGMEN
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL_QUERY
 import com.amplitude.core.Constants.EventTypes.NETWORK_TRACKING
 import com.amplitude.core.events.BaseEvent
-import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -1,4 +1,4 @@
-package com.amplitude.core.network
+package com.amplitude.android.network
 
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_COMPLETION_TIME
@@ -14,7 +14,7 @@ import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL_FRAGMEN
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL_QUERY
 import com.amplitude.core.Constants.EventTypes.NETWORK_TRACKING
 import com.amplitude.core.events.BaseEvent
-import com.amplitude.core.network.NetworkTrackingOptions.CaptureRule
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk

--- a/core/src/main/java/com/amplitude/core/network/NetworkTrackingOptions.kt
+++ b/core/src/main/java/com/amplitude/core/network/NetworkTrackingOptions.kt
@@ -7,10 +7,11 @@ private const val STAR_WILDCARD = "*"
 
 @Deprecated(
     message = "Moved to the android module.",
-    replaceWith = ReplaceWith(
-        "NetworkTrackingOptions",
-        "com.amplitude.android.network.NetworkTrackingOptions",
-    ),
+    replaceWith =
+        ReplaceWith(
+            "NetworkTrackingOptions",
+            "com.amplitude.android.network.NetworkTrackingOptions",
+        ),
 )
 data class NetworkTrackingOptions(
     val captureRules: List<CaptureRule>,

--- a/core/src/main/java/com/amplitude/core/network/NetworkTrackingPlugin.kt
+++ b/core/src/main/java/com/amplitude/core/network/NetworkTrackingPlugin.kt
@@ -31,10 +31,11 @@ private const val LOCAL_ERROR_STATUS_CODE = 0
 
 @Deprecated(
     message = "Moved to the android module.",
-    replaceWith = ReplaceWith(
-        "NetworkTrackingPlugin",
-        "com.amplitude.android.network.NetworkTrackingPlugin",
-    ),
+    replaceWith =
+        ReplaceWith(
+            "NetworkTrackingPlugin",
+            "com.amplitude.android.network.NetworkTrackingPlugin",
+        ),
 )
 class NetworkTrackingPlugin(
     private val options: NetworkTrackingOptions = NetworkTrackingOptions.DEFAULT,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉
Please fill out the following sections to help us quickly review your pull request.
--->

### Describe what this PR is addressing
<!-- Describe the motivation and context for the change so reviewers can understand the problem you're solving. -->

NetworkTrackingPlugin won't be shared across other platform SDKs. It belongs in :android, not :core. 

### Describe the solution
<!-- Describe the changes made in this PR. Include any relevant details about the implementation, design decisions, or trade-offs.
* Why did you choose this way to solve the problem?
* What future impact will this have?
-->
  - Copied NetworkTrackingPlugin and NetworkTrackingOptions to com.amplitude.android.network
  - Deprecated the :core versions with `@Deprecated` + ReplaceWith                   
  - Made helpers internal now that tests are co-located in :android

### Steps to verify the change
<!-- Describe how to test the changes made in this PR. Include any relevant details about the testing environment, tools, or frameworks used. -->

### Useful links and documentation (optional)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the public API surface and recommended import path for `NetworkTrackingPlugin`/`NetworkTrackingOptions`, which can impact downstream consumers despite behavior remaining largely unchanged.
> 
> **Overview**
> Moves network tracking support into the `:android` module by adding `com.amplitude.android.network.NetworkTrackingPlugin` and `NetworkTrackingOptions` (now part of the Android public API) and updating/relocating the unit tests accordingly.
> 
> Keeps the existing `:core` implementations but marks them `@Deprecated` with `ReplaceWith` to steer callers to the Android versions, and adds an Android `compileOnly` dependency on `okhttp` to support the interceptor API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a0a51e27036acbaf4fc8e8d6e745c7db0e1c266. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->