### PR TITLE
feat: add header body capture for network tracking

### DIFF
--- a/android/api/android.api
+++ b/android/api/android.api
@@ -656,68 +656,34 @@ public final class com/amplitude/android/network/NetworkTrackingOptions {
 	public static final field Companion Lcom/amplitude/android/network/NetworkTrackingOptions$Companion;
 	public fun <init> (Ljava/util/List;Ljava/util/List;ZZZ)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Z
-	public final fun component4 ()Z
-	public final fun component5 ()Z
-	public final fun copy (Ljava/util/List;Ljava/util/List;ZZZ)Lcom/amplitude/android/network/NetworkTrackingOptions;
-	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions;Ljava/util/List;Ljava/util/List;ZZZILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCaptureRules ()Ljava/util/List;
 	public final fun getEnableRemoteConfig ()Z
 	public final fun getEnabled ()Z
 	public final fun getIgnoreAmplitudeRequests ()Z
 	public final fun getIgnoreHosts ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureBody {
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
-	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowlist ()Ljava/util/List;
 	public final fun getBlocklist ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureHeader {
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;Z)V
 	public synthetic fun <init> (Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Z
-	public final fun copy (Ljava/util/List;Z)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
-	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Ljava/util/List;ZILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowlist ()Ljava/util/List;
 	public final fun getCaptureSafeHeaders ()Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule {
 	public static final field Companion Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/util/List;
-	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
-	public final fun component6 ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
-	public final fun component7 ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
-	public final fun component8 ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
-	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;
-	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;ILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;
-	public fun equals (Ljava/lang/Object;)Z
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getHosts ()Ljava/util/List;
 	public final fun getMethods ()Ljava/util/List;
 	public final fun getRequestBody ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
@@ -726,8 +692,6 @@ public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureR
 	public final fun getResponseHeaders ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
 	public final fun getStatusCodeRange ()Ljava/util/List;
 	public final fun getUrls ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule$Companion {

--- a/android/api/android.api
+++ b/android/api/android.api
@@ -654,15 +654,19 @@ public final class com/amplitude/android/migration/RemnantDataMigration$Companio
 
 public final class com/amplitude/android/network/NetworkTrackingOptions {
 	public static final field Companion Lcom/amplitude/android/network/NetworkTrackingOptions$Companion;
-	public fun <init> (Ljava/util/List;Ljava/util/List;Z)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;ZZZ)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Z
-	public final fun copy (Ljava/util/List;Ljava/util/List;Z)Lcom/amplitude/android/network/NetworkTrackingOptions;
-	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions;
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun copy (Ljava/util/List;Ljava/util/List;ZZZ)Lcom/amplitude/android/network/NetworkTrackingOptions;
+	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions;Ljava/util/List;Ljava/util/List;ZZZILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCaptureRules ()Ljava/util/List;
+	public final fun getEnableRemoteConfig ()Z
+	public final fun getEnabled ()Z
 	public final fun getIgnoreAmplitudeRequests ()Z
 	public final fun getIgnoreHosts ()Ljava/util/List;
 	public fun hashCode ()I
@@ -699,6 +703,7 @@ public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureH
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule {
+	public static final field Companion Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -723,6 +728,9 @@ public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureR
 	public final fun getUrls ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule$Companion {
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$Companion {
@@ -764,6 +772,7 @@ public final class com/amplitude/android/network/NetworkTrackingPlugin : com/amp
 	public fun getType ()Lcom/amplitude/core/platform/Plugin$Type;
 	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
 	public fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
+	public fun setup (Lcom/amplitude/core/Amplitude;)V
 }
 
 public final class com/amplitude/android/network/NetworkTrackingPlugin$Companion {

--- a/android/api/android.api
+++ b/android/api/android.api
@@ -667,7 +667,7 @@ public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureB
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAllowlist ()Ljava/util/List;
-	public final fun getBlocklist ()Ljava/util/List;
+	public final fun getExcludelist ()Ljava/util/List;
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureHeader {
@@ -679,7 +679,6 @@ public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureH
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule {
-	public static final field Companion Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule$Companion;
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;)V
@@ -692,9 +691,6 @@ public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureR
 	public final fun getResponseHeaders ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
 	public final fun getStatusCodeRange ()Ljava/util/List;
 	public final fun getUrls ()Ljava/util/List;
-}
-
-public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule$Companion {
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$Companion {

--- a/android/api/android.api
+++ b/android/api/android.api
@@ -669,16 +669,58 @@ public final class com/amplitude/android/network/NetworkTrackingOptions {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule {
+public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureBody {
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;
-	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
+	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowlist ()Ljava/util/List;
+	public final fun getBlocklist ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureHeader {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Z)V
+	public synthetic fun <init> (Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/util/List;Z)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
+	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Ljava/util/List;ZILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowlist ()Ljava/util/List;
+	public final fun getCaptureSafeHeaders ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
+	public final fun component6 ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
+	public final fun component7 ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
+	public final fun component8 ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;
+	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;ILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureRule;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHosts ()Ljava/util/List;
+	public final fun getMethods ()Ljava/util/List;
+	public final fun getRequestBody ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
+	public final fun getRequestHeaders ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
+	public final fun getResponseBody ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;
+	public final fun getResponseHeaders ()Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;
 	public final fun getStatusCodeRange ()Ljava/util/List;
+	public final fun getUrls ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -687,7 +729,33 @@ public final class com/amplitude/android/network/NetworkTrackingOptions$Companio
 	public final fun getDEFAULT ()Lcom/amplitude/android/network/NetworkTrackingOptions;
 }
 
+public abstract class com/amplitude/android/network/NetworkTrackingOptions$URLPattern {
+}
+
+public final class com/amplitude/android/network/NetworkTrackingOptions$URLPattern$Exact : com/amplitude/android/network/NetworkTrackingOptions$URLPattern {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/amplitude/android/network/NetworkTrackingOptions$URLPattern$Exact;
+	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$URLPattern$Exact;Ljava/lang/String;ILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$URLPattern$Exact;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/android/network/NetworkTrackingOptions$URLPattern$Regex : com/amplitude/android/network/NetworkTrackingOptions$URLPattern {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/amplitude/android/network/NetworkTrackingOptions$URLPattern$Regex;
+	public static synthetic fun copy$default (Lcom/amplitude/android/network/NetworkTrackingOptions$URLPattern$Regex;Ljava/lang/String;ILjava/lang/Object;)Lcom/amplitude/android/network/NetworkTrackingOptions$URLPattern$Regex;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPattern ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/amplitude/android/network/NetworkTrackingPlugin : com/amplitude/core/platform/Plugin, okhttp3/Interceptor {
+	public static final field Companion Lcom/amplitude/android/network/NetworkTrackingPlugin$Companion;
 	public field amplitude Lcom/amplitude/core/Amplitude;
 	public fun <init> ()V
 	public fun <init> (Lcom/amplitude/android/network/NetworkTrackingOptions;)V
@@ -696,6 +764,9 @@ public final class com/amplitude/android/network/NetworkTrackingPlugin : com/amp
 	public fun getType ()Lcom/amplitude/core/platform/Plugin$Type;
 	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
 	public fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
+}
+
+public final class com/amplitude/android/network/NetworkTrackingPlugin$Companion {
 }
 
 public class com/amplitude/android/plugins/AndroidContextPlugin : com/amplitude/core/platform/Plugin {

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
@@ -68,13 +68,16 @@ internal val BLOCK_HEADERS: Set<String> =
         "proxy-authorization",
     )
 
-data class NetworkTrackingOptions(
-    val captureRules: List<CaptureRule>,
-    val ignoreHosts: List<String> = emptyList(),
+class NetworkTrackingOptions(
+    captureRules: List<CaptureRule>,
+    ignoreHosts: List<String> = emptyList(),
     val ignoreAmplitudeRequests: Boolean = true,
     val enabled: Boolean = true,
     val enableRemoteConfig: Boolean = true,
 ) {
+    val captureRules: List<CaptureRule> = captureRules.toList()
+    val ignoreHosts: List<String> = ignoreHosts.toList()
+
     companion object {
         val DEFAULT by lazy {
             NetworkTrackingOptions(
@@ -88,10 +91,12 @@ data class NetworkTrackingOptions(
         }
     }
 
-    data class CaptureHeader(
-        val allowlist: List<String> = emptyList(),
+    class CaptureHeader(
+        allowlist: List<String> = emptyList(),
         val captureSafeHeaders: Boolean = true,
     ) {
+        val allowlist: List<String> = allowlist.toList()
+
         internal fun filterHeaders(headers: Map<String, String>): Map<String, String>? {
             val combinedAllowSet =
                 buildSet {
@@ -105,17 +110,19 @@ data class NetworkTrackingOptions(
         }
     }
 
-    data class CaptureBody(
-        val allowlist: List<String>,
-        val blocklist: List<String> = emptyList(),
+    class CaptureBody(
+        allowlist: List<String>,
+        blocklist: List<String> = emptyList(),
     ) {
+        val allowlist: List<String> = allowlist.toList()
+        val blocklist: List<String> = blocklist.toList()
+
         internal fun filterBodyBytes(bodyBytes: ByteArray?): String? {
             if (bodyBytes == null || bodyBytes.isEmpty()) return null
             return try {
                 val bodyString = bodyBytes.toString(Charsets.UTF_8)
-                val parsed = JSONTokener(bodyString).nextValue()
                 val json: Any =
-                    when (parsed) {
+                    when (val parsed = JSONTokener(bodyString).nextValue()) {
                         is JSONObject -> jsonObjectToMap(parsed)
                         is JSONArray -> jsonArrayToList(parsed)
                         else -> return null
@@ -139,16 +146,60 @@ data class NetworkTrackingOptions(
         data class Regex(val pattern: String) : URLPattern()
     }
 
-    data class CaptureRule(
-        val hosts: List<String> = emptyList(),
-        val urls: List<URLPattern> = emptyList(),
-        val methods: List<String> = emptyList(),
-        val statusCodeRange: List<Int> = (500..599).toList(),
-        val requestHeaders: CaptureHeader? = null,
-        val responseHeaders: CaptureHeader? = null,
-        val requestBody: CaptureBody? = null,
-        val responseBody: CaptureBody? = null,
+    class CaptureRule internal constructor(
+        hosts: List<String>,
+        urls: List<URLPattern>,
+        methods: List<String>,
+        statusCodeRange: List<Int>,
+        val requestHeaders: CaptureHeader?,
+        val responseHeaders: CaptureHeader?,
+        val requestBody: CaptureBody?,
+        val responseBody: CaptureBody?,
     ) {
+        val hosts: List<String> = hosts.toList()
+        val urls: List<URLPattern> = urls.toList()
+        val methods: List<String> = methods.toList()
+        val statusCodeRange: List<Int> = statusCodeRange.toList()
+
+        /**
+         * Creates a rule that matches requests by host patterns.
+         */
+        constructor(
+            hosts: List<String>,
+            statusCodeRange: List<Int> = (500..599).toList(),
+        ) : this(
+            hosts = hosts,
+            urls = emptyList(),
+            methods = emptyList(),
+            statusCodeRange = statusCodeRange,
+            requestHeaders = null,
+            responseHeaders = null,
+            requestBody = null,
+            responseBody = null,
+        )
+
+        /**
+         * Creates a rule that matches requests by URL patterns (exact or regex).
+         */
+        constructor(
+            urls: List<URLPattern>,
+            methods: List<String> = emptyList(),
+            statusCodeRange: List<Int> = (500..599).toList(),
+            requestHeaders: CaptureHeader? = null,
+            responseHeaders: CaptureHeader? = null,
+            requestBody: CaptureBody? = null,
+            responseBody: CaptureBody? = null,
+        ) : this(
+            hosts = emptyList(),
+            urls = urls,
+            methods = methods,
+            statusCodeRange = statusCodeRange,
+            requestHeaders = requestHeaders,
+            responseHeaders = responseHeaders,
+            requestBody = requestBody,
+            responseBody = responseBody,
+        )
+
         private val hostMatcher = HostMatcher(hosts)
         private val urlMatchers: List<Pair<URLPattern, Regex?>> =
             urls.map { pattern ->
@@ -163,7 +214,6 @@ data class NetworkTrackingOptions(
             url: String,
             method: String?,
         ): Boolean {
-            // If URLs are configured, match by URL patterns only
             if (urls.isNotEmpty()) {
                 if (!matchesUrl(url)) return false
             } else if (hosts.isNotEmpty()) {
@@ -172,7 +222,6 @@ data class NetworkTrackingOptions(
                 return false
             }
 
-            // Check method matching
             if (methods.isNotEmpty() && !methods.contains("*")) {
                 val upperMethod = method?.uppercase() ?: return false
                 if (methods.none { it.equals(upperMethod, ignoreCase = true) }) return false

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
@@ -9,62 +9,64 @@ import kotlin.text.RegexOption.IGNORE_CASE
 
 private const val STAR_WILDCARD = "*"
 
-internal val SAFE_HEADERS: Set<String> = setOf(
-    "access-control-allow-origin",
-    "access-control-allow-credentials",
-    "access-control-expose-headers",
-    "access-control-max-age",
-    "access-control-allow-methods",
-    "access-control-allow-headers",
-    "accept-patch",
-    "accept-ranges",
-    "age",
-    "allow",
-    "alt-svc",
-    "cache-control",
-    "connection",
-    "content-disposition",
-    "content-encoding",
-    "content-language",
-    "content-length",
-    "content-location",
-    "content-md5",
-    "content-range",
-    "content-type",
-    "date",
-    "delta-base",
-    "etag",
-    "expires",
-    "im",
-    "last-modified",
-    "link",
-    "location",
-    "permanent",
-    "p3p",
-    "pragma",
-    "proxy-authenticate",
-    "public-key-pins",
-    "retry-after",
-    "server",
-    "status",
-    "strict-transport-security",
-    "trailer",
-    "transfer-encoding",
-    "tk",
-    "upgrade",
-    "vary",
-    "via",
-    "warning",
-    "www-authenticate",
-    "x-b3-traceid",
-    "x-frame-options",
-)
+internal val SAFE_HEADERS: Set<String> =
+    setOf(
+        "access-control-allow-origin",
+        "access-control-allow-credentials",
+        "access-control-expose-headers",
+        "access-control-max-age",
+        "access-control-allow-methods",
+        "access-control-allow-headers",
+        "accept-patch",
+        "accept-ranges",
+        "age",
+        "allow",
+        "alt-svc",
+        "cache-control",
+        "connection",
+        "content-disposition",
+        "content-encoding",
+        "content-language",
+        "content-length",
+        "content-location",
+        "content-md5",
+        "content-range",
+        "content-type",
+        "date",
+        "delta-base",
+        "etag",
+        "expires",
+        "im",
+        "last-modified",
+        "link",
+        "location",
+        "permanent",
+        "p3p",
+        "pragma",
+        "proxy-authenticate",
+        "public-key-pins",
+        "retry-after",
+        "server",
+        "status",
+        "strict-transport-security",
+        "trailer",
+        "transfer-encoding",
+        "tk",
+        "upgrade",
+        "vary",
+        "via",
+        "warning",
+        "www-authenticate",
+        "x-b3-traceid",
+        "x-frame-options",
+    )
 
-internal val BLOCK_HEADERS: Set<String> = setOf(
-    "authorization",
-    "cookie",
-    "proxy-authorization",
-)
+internal val BLOCK_HEADERS: Set<String> =
+    setOf(
+        "authorization",
+        "cookie",
+        "proxy-authorization",
+    )
 
 data class NetworkTrackingOptions(
     val captureRules: List<CaptureRule>,
@@ -91,11 +93,12 @@ data class NetworkTrackingOptions(
         val captureSafeHeaders: Boolean = true,
     ) {
         internal fun filterHeaders(headers: Map<String, String>): Map<String, String>? {
-            val combinedAllowSet = buildSet {
-                addAll(allowlist.map { it.lowercase() })
-                if (captureSafeHeaders) addAll(SAFE_HEADERS)
-                removeAll(BLOCK_HEADERS)
-            }
+            val combinedAllowSet =
+                buildSet {
+                    addAll(allowlist.map { it.lowercase() })
+                    if (captureSafeHeaders) addAll(SAFE_HEADERS)
+                    removeAll(BLOCK_HEADERS)
+                }
             if (combinedAllowSet.isEmpty()) return null
             val result = headers.filter { (key, _) -> combinedAllowSet.contains(key.lowercase()) }
             return result.ifEmpty { null }
@@ -111,11 +114,12 @@ data class NetworkTrackingOptions(
             return try {
                 val bodyString = bodyBytes.toString(Charsets.UTF_8)
                 val parsed = JSONTokener(bodyString).nextValue()
-                val json: Any = when (parsed) {
-                    is JSONObject -> jsonObjectToMap(parsed)
-                    is JSONArray -> jsonArrayToList(parsed)
-                    else -> return null
-                }
+                val json: Any =
+                    when (parsed) {
+                        is JSONObject -> jsonObjectToMap(parsed)
+                        is JSONArray -> jsonArrayToList(parsed)
+                        else -> return null
+                    }
                 val filter = ObjectFilter(allowlist, blocklist)
                 val filtered = filter.filtered(json) ?: return null
                 when (filtered) {
@@ -131,6 +135,7 @@ data class NetworkTrackingOptions(
 
     sealed class URLPattern {
         data class Exact(val url: String) : URLPattern()
+
         data class Regex(val pattern: String) : URLPattern()
     }
 
@@ -153,7 +158,11 @@ data class NetworkTrackingOptions(
                 }
             }
 
-        internal fun matchesRequest(host: String, url: String, method: String?): Boolean {
+        internal fun matchesRequest(
+            host: String,
+            url: String,
+            method: String?,
+        ): Boolean {
             // If URLs are configured, match by URL patterns only
             if (urls.isNotEmpty()) {
                 if (!matchesUrl(url)) return false

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
@@ -98,7 +98,6 @@ class NetworkTrackingOptions(
     ) {
         val allowlist: List<String> = allowlist.toList()
 
-        @Suppress("UNCHECKED_CAST")
         internal fun filterHeaders(headers: Headers): Map<String, Any>? {
             val combinedAllowSet =
                 buildSet {
@@ -115,7 +114,10 @@ class NetworkTrackingOptions(
                 when (val existing = result[name]) {
                     null -> result[name] = value
                     is String -> result[name] = mutableListOf(existing, value)
-                    is MutableList<*> -> (existing as MutableList<String>).add(value)
+                    is MutableList<*> -> {
+                        @Suppress("UNCHECKED_CAST")
+                        (existing as MutableList<String>).add(value)
+                    }
                 }
             }
             return result.ifEmpty { null }
@@ -124,10 +126,11 @@ class NetworkTrackingOptions(
 
     class CaptureBody(
         allowlist: List<String>,
-        blocklist: List<String> = emptyList(),
+        excludelist: List<String> = emptyList(),
     ) {
         val allowlist: List<String> = allowlist.toList()
-        val blocklist: List<String> = blocklist.toList()
+        val excludelist: List<String> = excludelist.toList()
+        private val objectFilter = ObjectFilter(this.allowlist, this.excludelist)
 
         internal fun filterBodyBytes(bodyBytes: ByteArray?): String? {
             if (bodyBytes == null || bodyBytes.isEmpty()) return null
@@ -139,8 +142,7 @@ class NetworkTrackingOptions(
                         is JSONArray -> jsonArrayToList(parsed)
                         else -> return null
                     }
-                val filter = ObjectFilter(allowlist, blocklist)
-                val filtered = filter.filtered(json) ?: return null
+                val filtered = objectFilter.filtered(json) ?: return null
                 when (filtered) {
                     is Map<*, *> -> JSONObject(filtered).toString()
                     is List<*> -> JSONArray(filtered).toString()
@@ -248,71 +250,6 @@ class NetworkTrackingOptions(
                     is URLPattern.Exact -> pattern.url == url
                     is URLPattern.Regex -> regex?.containsMatchIn(url) == true
                 }
-            }
-        }
-
-        companion object {
-            @Suppress("UNCHECKED_CAST")
-            internal fun fromRemoteConfig(configs: List<Map<String, Any?>>): List<CaptureRule>? {
-                if (configs.isEmpty()) return null
-                return try {
-                    configs.map { map ->
-                        CaptureRule(
-                            hosts = (map["hosts"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
-                            urls = parseUrlPatterns(map),
-                            methods = (map["methods"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
-                            statusCodeRange = parseStatusCodeRange(map["statusCodeRange"] as? String ?: "500-599"),
-                            requestHeaders = parseCaptureHeader(map["requestHeaders"] as? Map<String, Any?>),
-                            responseHeaders = parseCaptureHeader(map["responseHeaders"] as? Map<String, Any?>),
-                            requestBody = parseCaptureBody(map["requestBody"] as? Map<String, Any?>),
-                            responseBody = parseCaptureBody(map["responseBody"] as? Map<String, Any?>),
-                        )
-                    }
-                } catch (_: Exception) {
-                    null
-                }
-            }
-
-            private fun parseUrlPatterns(map: Map<String, Any?>): List<URLPattern> {
-                val patterns = mutableListOf<URLPattern>()
-                (map["urls"] as? List<*>)?.filterIsInstance<String>()?.forEach {
-                    patterns.add(URLPattern.Exact(it))
-                }
-                (map["urlsRegex"] as? List<*>)?.filterIsInstance<String>()?.forEach {
-                    patterns.add(URLPattern.Regex(it))
-                }
-                return patterns
-            }
-
-            private fun parseStatusCodeRange(rangeString: String): List<Int> {
-                val codes = mutableListOf<Int>()
-                for (part in rangeString.split(",")) {
-                    val trimmed = part.trim()
-                    if (trimmed.contains("-")) {
-                        val (lo, hi) = trimmed.split("-", limit = 2).map { it.trim().toInt() }
-                        codes.addAll(lo..hi)
-                    } else {
-                        codes.add(trimmed.toInt())
-                    }
-                }
-                return codes
-            }
-
-            private fun parseCaptureHeader(map: Map<String, Any?>?): CaptureHeader? {
-                if (map == null) return null
-                return CaptureHeader(
-                    allowlist = (map["allowlist"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
-                    captureSafeHeaders = map["captureSafeHeaders"] as? Boolean ?: true,
-                )
-            }
-
-            private fun parseCaptureBody(map: Map<String, Any?>?): CaptureBody? {
-                if (map == null) return null
-                val allowlist = (map["allowlist"] as? List<*>)?.filterIsInstance<String>() ?: return null
-                return CaptureBody(
-                    allowlist = allowlist,
-                    blocklist = (map["excludelist"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
-                )
             }
         }
     }

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
@@ -70,6 +70,8 @@ data class NetworkTrackingOptions(
     val captureRules: List<CaptureRule>,
     val ignoreHosts: List<String> = emptyList(),
     val ignoreAmplitudeRequests: Boolean = true,
+    val enabled: Boolean = true,
+    val enableRemoteConfig: Boolean = true,
 ) {
     companion object {
         val DEFAULT by lazy {
@@ -176,6 +178,71 @@ data class NetworkTrackingOptions(
                     is URLPattern.Exact -> pattern.url == url
                     is URLPattern.Regex -> regex?.containsMatchIn(url) == true
                 }
+            }
+        }
+
+        companion object {
+            @Suppress("UNCHECKED_CAST")
+            internal fun fromRemoteConfig(configs: List<Map<String, Any?>>): List<CaptureRule>? {
+                if (configs.isEmpty()) return null
+                return try {
+                    configs.map { map ->
+                        CaptureRule(
+                            hosts = (map["hosts"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+                            urls = parseUrlPatterns(map),
+                            methods = (map["methods"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+                            statusCodeRange = parseStatusCodeRange(map["statusCodeRange"] as? String ?: "500-599"),
+                            requestHeaders = parseCaptureHeader(map["requestHeaders"] as? Map<String, Any?>),
+                            responseHeaders = parseCaptureHeader(map["responseHeaders"] as? Map<String, Any?>),
+                            requestBody = parseCaptureBody(map["requestBody"] as? Map<String, Any?>),
+                            responseBody = parseCaptureBody(map["responseBody"] as? Map<String, Any?>),
+                        )
+                    }
+                } catch (_: Exception) {
+                    null
+                }
+            }
+
+            private fun parseUrlPatterns(map: Map<String, Any?>): List<URLPattern> {
+                val patterns = mutableListOf<URLPattern>()
+                (map["urls"] as? List<*>)?.filterIsInstance<String>()?.forEach {
+                    patterns.add(URLPattern.Exact(it))
+                }
+                (map["urlsRegex"] as? List<*>)?.filterIsInstance<String>()?.forEach {
+                    patterns.add(URLPattern.Regex(it))
+                }
+                return patterns
+            }
+
+            private fun parseStatusCodeRange(rangeString: String): List<Int> {
+                val codes = mutableListOf<Int>()
+                for (part in rangeString.split(",")) {
+                    val trimmed = part.trim()
+                    if (trimmed.contains("-")) {
+                        val (lo, hi) = trimmed.split("-", limit = 2).map { it.trim().toInt() }
+                        codes.addAll(lo..hi)
+                    } else {
+                        codes.add(trimmed.toInt())
+                    }
+                }
+                return codes
+            }
+
+            private fun parseCaptureHeader(map: Map<String, Any?>?): CaptureHeader? {
+                if (map == null) return null
+                return CaptureHeader(
+                    allowlist = (map["allowlist"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+                    captureSafeHeaders = map["captureSafeHeaders"] as? Boolean ?: true,
+                )
+            }
+
+            private fun parseCaptureBody(map: Map<String, Any?>?): CaptureBody? {
+                if (map == null) return null
+                val allowlist = (map["allowlist"] as? List<*>)?.filterIsInstance<String>() ?: return null
+                return CaptureBody(
+                    allowlist = allowlist,
+                    blocklist = (map["excludelist"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+                )
             }
         }
     }

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
@@ -2,6 +2,7 @@ package com.amplitude.android.network
 
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import com.amplitude.android.utilities.ObjectFilter
+import okhttp3.Headers
 import org.json.JSONArray
 import org.json.JSONObject
 import org.json.JSONTokener
@@ -97,7 +98,8 @@ class NetworkTrackingOptions(
     ) {
         val allowlist: List<String> = allowlist.toList()
 
-        internal fun filterHeaders(headers: Map<String, String>): Map<String, String>? {
+        @Suppress("UNCHECKED_CAST")
+        internal fun filterHeaders(headers: Headers): Map<String, Any>? {
             val combinedAllowSet =
                 buildSet {
                     addAll(allowlist.map { it.lowercase() })
@@ -105,7 +107,17 @@ class NetworkTrackingOptions(
                     removeAll(BLOCK_HEADERS)
                 }
             if (combinedAllowSet.isEmpty()) return null
-            val result = headers.filter { (key, _) -> combinedAllowSet.contains(key.lowercase()) }
+            val result = linkedMapOf<String, Any>()
+            for (i in 0 until headers.size) {
+                val name = headers.name(i)
+                if (!combinedAllowSet.contains(name.lowercase())) continue
+                val value = headers.value(i)
+                when (val existing = result[name]) {
+                    null -> result[name] = value
+                    is String -> result[name] = mutableListOf(existing, value)
+                    is MutableList<*> -> (existing as MutableList<String>).add(value)
+                }
+            }
             return result.ifEmpty { null }
         }
     }

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
@@ -1,9 +1,70 @@
 package com.amplitude.android.network
 
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
+import com.amplitude.android.utilities.ObjectFilter
+import org.json.JSONArray
+import org.json.JSONObject
+import org.json.JSONTokener
 import kotlin.text.RegexOption.IGNORE_CASE
 
 private const val STAR_WILDCARD = "*"
+
+internal val SAFE_HEADERS: Set<String> = setOf(
+    "access-control-allow-origin",
+    "access-control-allow-credentials",
+    "access-control-expose-headers",
+    "access-control-max-age",
+    "access-control-allow-methods",
+    "access-control-allow-headers",
+    "accept-patch",
+    "accept-ranges",
+    "age",
+    "allow",
+    "alt-svc",
+    "cache-control",
+    "connection",
+    "content-disposition",
+    "content-encoding",
+    "content-language",
+    "content-length",
+    "content-location",
+    "content-md5",
+    "content-range",
+    "content-type",
+    "date",
+    "delta-base",
+    "etag",
+    "expires",
+    "im",
+    "last-modified",
+    "link",
+    "location",
+    "permanent",
+    "p3p",
+    "pragma",
+    "proxy-authenticate",
+    "public-key-pins",
+    "retry-after",
+    "server",
+    "status",
+    "strict-transport-security",
+    "trailer",
+    "transfer-encoding",
+    "tk",
+    "upgrade",
+    "vary",
+    "via",
+    "warning",
+    "www-authenticate",
+    "x-b3-traceid",
+    "x-frame-options",
+)
+
+internal val BLOCK_HEADERS: Set<String> = setOf(
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+)
 
 data class NetworkTrackingOptions(
     val captureRules: List<CaptureRule>,
@@ -23,20 +84,105 @@ data class NetworkTrackingOptions(
         }
     }
 
+    data class CaptureHeader(
+        val allowlist: List<String> = emptyList(),
+        val captureSafeHeaders: Boolean = true,
+    ) {
+        internal fun filterHeaders(headers: Map<String, String>): Map<String, String>? {
+            val combinedAllowSet = buildSet {
+                addAll(allowlist.map { it.lowercase() })
+                if (captureSafeHeaders) addAll(SAFE_HEADERS)
+                removeAll(BLOCK_HEADERS)
+            }
+            if (combinedAllowSet.isEmpty()) return null
+            val result = headers.filter { (key, _) -> combinedAllowSet.contains(key.lowercase()) }
+            return result.ifEmpty { null }
+        }
+    }
+
+    data class CaptureBody(
+        val allowlist: List<String>,
+        val blocklist: List<String> = emptyList(),
+    ) {
+        internal fun filterBodyBytes(bodyBytes: ByteArray?): String? {
+            if (bodyBytes == null || bodyBytes.isEmpty()) return null
+            return try {
+                val bodyString = bodyBytes.toString(Charsets.UTF_8)
+                val parsed = JSONTokener(bodyString).nextValue()
+                val json: Any = when (parsed) {
+                    is JSONObject -> jsonObjectToMap(parsed)
+                    is JSONArray -> jsonArrayToList(parsed)
+                    else -> return null
+                }
+                val filter = ObjectFilter(allowlist, blocklist)
+                val filtered = filter.filtered(json) ?: return null
+                when (filtered) {
+                    is Map<*, *> -> JSONObject(filtered).toString()
+                    is List<*> -> JSONArray(filtered).toString()
+                    else -> null
+                }
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+
+    sealed class URLPattern {
+        data class Exact(val url: String) : URLPattern()
+        data class Regex(val pattern: String) : URLPattern()
+    }
+
     data class CaptureRule(
-        val hosts: List<String>,
+        val hosts: List<String> = emptyList(),
+        val urls: List<URLPattern> = emptyList(),
+        val methods: List<String> = emptyList(),
         val statusCodeRange: List<Int> = (500..599).toList(),
+        val requestHeaders: CaptureHeader? = null,
+        val responseHeaders: CaptureHeader? = null,
+        val requestBody: CaptureBody? = null,
+        val responseBody: CaptureBody? = null,
     ) {
         private val hostMatcher = HostMatcher(hosts)
+        private val urlMatchers: List<Pair<URLPattern, Regex?>> =
+            urls.map { pattern ->
+                when (pattern) {
+                    is URLPattern.Exact -> pattern to null
+                    is URLPattern.Regex -> pattern to pattern.pattern.toRegex()
+                }
+            }
 
-        internal fun matches(host: String): Boolean {
-            return hostMatcher.matches(host)
+        internal fun matchesRequest(host: String, url: String, method: String?): Boolean {
+            // If URLs are configured, match by URL patterns only
+            if (urls.isNotEmpty()) {
+                if (!matchesUrl(url)) return false
+            } else if (hosts.isNotEmpty()) {
+                if (!hostMatcher.matches(host)) return false
+            } else {
+                return false
+            }
+
+            // Check method matching
+            if (methods.isNotEmpty() && !methods.contains("*")) {
+                val upperMethod = method?.uppercase() ?: return false
+                if (methods.none { it.equals(upperMethod, ignoreCase = true) }) return false
+            }
+
+            return true
+        }
+
+        private fun matchesUrl(url: String): Boolean {
+            return urlMatchers.any { (pattern, regex) ->
+                when (pattern) {
+                    is URLPattern.Exact -> pattern.url == url
+                    is URLPattern.Regex -> regex?.containsMatchIn(url) == true
+                }
+            }
         }
     }
 
     init {
-        require(captureRules.all { it.hosts.isNotEmpty() }) {
-            "Capture rules must have a non-empty host list."
+        require(captureRules.all { it.hosts.isNotEmpty() || it.urls.isNotEmpty() }) {
+            "Capture rules must have a non-empty host list or URL list."
         }
         require(captureRules.all { it.statusCodeRange.isNotEmpty() }) {
             "Capture rules must have a non-empty status code range."
@@ -46,8 +192,39 @@ data class NetworkTrackingOptions(
     private val ignoreHostMatcher = HostMatcher(ignoreHosts)
 
     internal fun shouldIgnore(host: String): Boolean {
+        if (ignoreAmplitudeRequests && host.isAmplitudeHost()) return true
         return ignoreHostMatcher.matches(host)
     }
+}
+
+private fun jsonObjectToMap(obj: JSONObject): Map<String, Any?> {
+    val map = mutableMapOf<String, Any?>()
+    for (key in obj.keys()) {
+        map[key] = convertJsonValue(obj.get(key))
+    }
+    return map
+}
+
+private fun jsonArrayToList(arr: JSONArray): List<Any?> {
+    val list = mutableListOf<Any?>()
+    for (i in 0 until arr.length()) {
+        list.add(convertJsonValue(arr.get(i)))
+    }
+    return list
+}
+
+private fun convertJsonValue(value: Any?): Any? {
+    return when (value) {
+        is JSONObject -> jsonObjectToMap(value)
+        is JSONArray -> jsonArrayToList(value)
+        JSONObject.NULL -> null
+        else -> value
+    }
+}
+
+internal fun String.isAmplitudeHost(): Boolean {
+    val lower = lowercase()
+    return lower == "amplitude.com" || lower.endsWith(".amplitude.com")
 }
 
 internal class HostMatcher(hosts: List<String>) {
@@ -56,12 +233,8 @@ internal class HostMatcher(hosts: List<String>) {
             .map { host ->
                 val regexString =
                     if (host == STAR_WILDCARD) {
-                        // Single wildcard matches everything
                         ".*"
                     } else {
-                        // For domain or multiple wildcards, e.g. "*.example.com", "*.sub.*.example.com"
-                        // it matches "api.example.com" but not "api.test.example.com"
-                        // it matches "api.sub.domain.example.com" but not "api.test.sub.domain.example.com"
                         host
                             .replace(".", "\\.")
                             .replace(STAR_WILDCARD, "[^.]+")
@@ -80,16 +253,12 @@ internal class HostMatcher(hosts: List<String>) {
     }
 }
 
-/**
- * Checks if the request matches any of the capture rules.
- *
- * @param host The host of the request URL.
- * @param responseCode The status code of the response, or null if it's an error.
- */
-internal fun List<CaptureRule>.matches(
+internal fun List<CaptureRule>.findMatchingRule(
     host: String,
+    url: String,
+    method: String?,
     responseCode: Int,
-): Boolean {
-    val ruleWithMatchingHost = lastOrNull { it.matches(host) } ?: return false
-    return responseCode in ruleWithMatchingHost.statusCodeRange
+): CaptureRule? {
+    val matchingRule = lastOrNull { it.matchesRequest(host, url, method) } ?: return null
+    return if (responseCode in matchingRule.statusCodeRange) matchingRule else null
 }

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptionsParser.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptionsParser.kt
@@ -1,0 +1,74 @@
+package com.amplitude.android.network
+
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
+import com.amplitude.android.network.NetworkTrackingOptions.URLPattern
+
+/**
+ * Parses [CaptureRule] lists from remote config maps.
+ *
+ * Uses all-or-nothing semantics: if any rule fails to parse, the entire
+ * override is rejected and `null` is returned.
+ */
+@Suppress("UNCHECKED_CAST")
+internal fun parseCaptureRulesFromRemoteConfig(configs: List<Map<String, Any?>>): List<CaptureRule>? {
+    if (configs.isEmpty()) return null
+    return try {
+        configs.map { map ->
+            CaptureRule(
+                hosts = (map["hosts"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+                urls = parseUrlPatterns(map),
+                methods = (map["methods"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+                statusCodeRange = parseStatusCodeRange(map["statusCodeRange"] as? String ?: "500-599"),
+                requestHeaders = parseCaptureHeader(map["requestHeaders"] as? Map<String, Any?>),
+                responseHeaders = parseCaptureHeader(map["responseHeaders"] as? Map<String, Any?>),
+                requestBody = parseCaptureBody(map["requestBody"] as? Map<String, Any?>),
+                responseBody = parseCaptureBody(map["responseBody"] as? Map<String, Any?>),
+            )
+        }
+    } catch (_: Exception) {
+        null
+    }
+}
+
+private fun parseUrlPatterns(map: Map<String, Any?>): List<URLPattern> {
+    val patterns = mutableListOf<URLPattern>()
+    (map["urls"] as? List<*>)?.filterIsInstance<String>()?.forEach {
+        patterns.add(URLPattern.Exact(it))
+    }
+    (map["urlsRegex"] as? List<*>)?.filterIsInstance<String>()?.forEach {
+        patterns.add(URLPattern.Regex(it))
+    }
+    return patterns
+}
+
+internal fun parseStatusCodeRange(rangeString: String): List<Int> {
+    val codes = mutableListOf<Int>()
+    for (part in rangeString.split(",")) {
+        val trimmed = part.trim()
+        if (trimmed.contains("-")) {
+            val (lo, hi) = trimmed.split("-", limit = 2).map { it.trim().toInt() }
+            codes.addAll(lo..hi)
+        } else {
+            codes.add(trimmed.toInt())
+        }
+    }
+    return codes
+}
+
+private fun parseCaptureHeader(map: Map<String, Any?>?): CaptureHeader? {
+    if (map == null) return null
+    return CaptureHeader(
+        allowlist = (map["allowlist"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+        captureSafeHeaders = map["captureSafeHeaders"] as? Boolean ?: true,
+    )
+}
+
+private fun parseCaptureBody(map: Map<String, Any?>?): CaptureBody? {
+    if (map == null) return null
+    return CaptureBody(
+        allowlist = (map["allowlist"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+        excludelist = (map["excludelist"] as? List<*>)?.filterIsInstance<String>() ?: emptyList(),
+    )
+}

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -24,7 +24,6 @@ import com.amplitude.core.platform.Plugin.Type.Utility
 import com.amplitude.core.remoteconfig.ConfigMap
 import com.amplitude.core.remoteconfig.RemoteConfigClient
 import com.amplitude.core.remoteconfig.RemoteConfigClient.Key
-import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
@@ -170,10 +169,10 @@ class NetworkTrackingPlugin(
         val maskedHttpUrl = request.url.mask()
 
         // Filter headers
-        val requestHeaders = matchedRule.requestHeaders?.filterHeaders(request.headers.toMap())
+        val requestHeaders = matchedRule.requestHeaders?.filterHeaders(request.headers)
         val responseHeaders =
             matchedRule.responseHeaders?.let { captureHeader ->
-                response?.headers?.let { captureHeader.filterHeaders(it.toMap()) }
+                response?.headers?.let { captureHeader.filterHeaders(it) }
             }
 
         // Filter request body — skip one-shot, duplex, and non-JSON bodies
@@ -269,5 +268,3 @@ private fun Response.isJsonContentType(): Boolean {
     val contentType = body?.contentType() ?: return true // unknown type — attempt capture
     return contentType.type == "application" && contentType.subtype.contains("json")
 }
-
-private fun Headers.toMap(): Map<String, String> = (0 until size).associate { name(it) to value(it) }

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -1,12 +1,17 @@
 package com.amplitude.android.network
 
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_COMPLETION_TIME
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_DURATION
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_ERROR_MESSAGE
+import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_REQUEST_BODY
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_REQUEST_BODY_SIZE
+import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_REQUEST_HEADERS
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_REQUEST_METHOD
+import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_RESPONSE_BODY
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_RESPONSE_BODY_SIZE
+import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_RESPONSE_HEADERS
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_START_TIME
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_STATUS_CODE
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL
@@ -16,6 +21,7 @@ import com.amplitude.core.Constants.EventTypes.NETWORK_TRACKING
 import com.amplitude.core.platform.Plugin
 import com.amplitude.core.platform.Plugin.Type
 import com.amplitude.core.platform.Plugin.Type.Utility
+import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
@@ -25,9 +31,6 @@ import okhttp3.Response
 import okio.Buffer
 import okio.ByteString.Companion.toByteString
 import okio.IOException
-
-private const val AMPLITUDE_HOST_DOMAIN = "amplitude.com"
-private const val LOCAL_ERROR_STATUS_CODE = 0
 
 class NetworkTrackingPlugin(
     private val options: NetworkTrackingOptions = NetworkTrackingOptions.DEFAULT,
@@ -41,45 +44,38 @@ class NetworkTrackingPlugin(
 
         try {
             val response = chain.proceed(request)
-
-            if (shouldCapture(request, response.code)) {
+            val matchedRule = matchedRule(request, response.code)
+            if (matchedRule != null) {
                 val completionTime = System.currentTimeMillis()
-                trackEvent(request, response, startTime, completionTime)
+                trackEvent(request, response, startTime, completionTime, matchedRule = matchedRule)
             }
-
             return response
         } catch (error: IOException) {
-            if (shouldCapture(request, LOCAL_ERROR_STATUS_CODE)) {
+            val matchedRule = matchedRule(request, LOCAL_ERROR_STATUS_CODE)
+            if (matchedRule != null) {
                 val completionTime = System.currentTimeMillis()
-                trackEvent(request, null, startTime, completionTime, error)
+                trackEvent(request, null, startTime, completionTime, error, matchedRule = matchedRule)
             }
-
             throw error
         }
     }
 
-    private fun shouldCapture(
+    private fun matchedRule(
         request: Request,
         responseCode: Int,
-    ): Boolean =
-        with(options) {
-            val host = request.url.host
-            return when {
-                shouldIgnore(host) -> false
-                ignoreAmplitudeRequests && request.amplitudeApiRequest() -> false
-                captureRules.matches(host, responseCode) || request.amplitudeApiRequest() -> true
-                else -> false
-            }
-        }
-
-    /**
-     * Checks if the request is an Amplitude request, and not a [NETWORK_TRACKING] event as we don't
-     * want to track our own network tracking events to be tracked again for cases where the same
-     * [okhttp3.OkHttpClient] instance is used for both Amplitude and other network requests.
-     */
-    private fun Request.amplitudeApiRequest(): Boolean {
-        return url.host.endsWith(AMPLITUDE_HOST_DOMAIN) &&
-            body?.contains(NETWORK_TRACKING) == false
+    ): CaptureRule? {
+        val host = request.url.host
+        if (options.shouldIgnore(host)) return null
+        // Recursion guard: only scan body for amplitude hosts to avoid consuming one-shot
+        // bodies on normal requests. This prevents the SDK's own network tracking event
+        // uploads from being re-tracked when the same OkHttpClient is shared.
+        if (host.isAmplitudeHost() && request.body?.contains(NETWORK_TRACKING) == true) return null
+        return options.captureRules.findMatchingRule(
+            host,
+            request.url.toString(),
+            request.method,
+            responseCode,
+        )
     }
 
     /**
@@ -98,8 +94,48 @@ class NetworkTrackingPlugin(
         startTime: Long,
         completionTime: Long,
         error: IOException? = null,
+        matchedRule: CaptureRule,
     ) {
         val maskedHttpUrl = request.url.mask()
+
+        // Filter headers
+        val requestHeaders = matchedRule.requestHeaders?.filterHeaders(request.headers.toMap())
+        val responseHeaders = matchedRule.responseHeaders?.let { captureHeader ->
+            response?.headers?.let { captureHeader.filterHeaders(it.toMap()) }
+        }
+
+        // Filter request body — skip one-shot, duplex, and non-JSON bodies
+        val requestBodyString = matchedRule.requestBody?.let { captureBody ->
+            val body = request.body ?: return@let null
+            if (body.isOneShot() || body.isDuplex()) return@let null
+
+            val contentType = body.contentType()
+            if (contentType != null && !(contentType.type == "application" && contentType.subtype.contains("json"))) {
+                return@let null
+            }
+
+            try {
+                val buffer = Buffer()
+                body.writeTo(buffer)
+                captureBody.filterBodyBytes(buffer.readByteArray())
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        // Filter response body — bounded peek, JSON content type only
+        val responseBodyString = matchedRule.responseBody?.let { captureBody ->
+            val resp = response ?: return@let null
+            if (!resp.isJsonContentType()) return@let null
+
+            try {
+                val peekedBody = resp.peekBody(MAX_BODY_PEEK_BYTES)
+                captureBody.filterBodyBytes(peekedBody.bytes())
+            } catch (_: Exception) {
+                null
+            }
+        }
+
         amplitude.track(
             NETWORK_TRACKING,
             eventProperties =
@@ -115,24 +151,14 @@ class NetworkTrackingPlugin(
                     NETWORK_TRACKING_DURATION to completionTime - startTime,
                     NETWORK_TRACKING_REQUEST_BODY_SIZE to request.body?.contentLength(),
                     NETWORK_TRACKING_RESPONSE_BODY_SIZE to response?.body?.contentLength(),
+                    NETWORK_TRACKING_REQUEST_HEADERS to requestHeaders,
+                    NETWORK_TRACKING_RESPONSE_HEADERS to responseHeaders,
+                    NETWORK_TRACKING_REQUEST_BODY to requestBodyString,
+                    NETWORK_TRACKING_RESPONSE_BODY to responseBodyString,
                 ),
         )
     }
 
-    /**
-     * Masks sensitive information in the URL by replacing values of sensitive query parameters and
-     * credentials with "[mask]". The following are considered sensitive:
-     * - Username and password in URL credentials
-     * - Query parameter values where the parameter name matches: username, password, email, phone
-     *
-     * Example:
-     * Original URL: https://user:pass@example.com/path?email=test@email.com&id=123#password-reset
-     * Masked URL: https://mask:mask@example.com/path?email=[mask]&id=123#password-reset
-     *
-     * Note: The fragment portion of the URL is preserved and not masked.
-     *
-     * @return A new [HttpUrl] with sensitive information masked
-     */
     private fun HttpUrl.mask(): HttpUrl {
         val sensitiveKeys = setOf("username", "password", "email", "phone")
         val query =
@@ -158,4 +184,17 @@ class NetworkTrackingPlugin(
             .build()
             .toString()
     }
+
+    companion object {
+        private const val LOCAL_ERROR_STATUS_CODE = 0
+        private const val MAX_BODY_PEEK_BYTES = 1L * 1024 * 1024 // 1 MB
+    }
 }
+
+private fun Response.isJsonContentType(): Boolean {
+    val contentType = body?.contentType() ?: return true // unknown type — attempt capture
+    return contentType.type == "application" && contentType.subtype.contains("json")
+}
+
+private fun Headers.toMap(): Map<String, String> =
+    (0 until size).associate { name(it) to value(it) }

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -92,19 +92,25 @@ class NetworkTrackingPlugin(
         var captureRules = originalOptions.captureRules
         (networkConfig["captureRules"] as? List<*>)?.let { rawRules ->
             val maps = rawRules.filterIsInstance<Map<String, Any?>>()
-            val rules = CaptureRule.fromRemoteConfig(maps)
+            val rules = parseCaptureRulesFromRemoteConfig(maps)
             if (rules != null) captureRules = rules
         }
 
-        // Single atomic write — all fields in one snapshot
+        // Single atomic write — all fields in one snapshot.
+        // Wrap in try-catch: malformed remote config (e.g. rules with empty hosts+urls)
+        // would fail the require checks in NetworkTrackingOptions.init.
         currentOptions =
-            NetworkTrackingOptions(
-                captureRules = captureRules,
-                ignoreHosts = ignoreHosts,
-                ignoreAmplitudeRequests = ignoreAmplitudeRequests,
-                enabled = resolvedEnabled,
-                enableRemoteConfig = originalOptions.enableRemoteConfig,
-            )
+            try {
+                NetworkTrackingOptions(
+                    captureRules = captureRules,
+                    ignoreHosts = ignoreHosts,
+                    ignoreAmplitudeRequests = ignoreAmplitudeRequests,
+                    enabled = resolvedEnabled,
+                    enableRemoteConfig = originalOptions.enableRemoteConfig,
+                )
+            } catch (_: IllegalArgumentException) {
+                originalOptions
+            }
     }
 
     override fun intercept(chain: Chain): Response {

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -56,9 +56,10 @@ class NetworkTrackingPlugin(
         val androidConfig = androidAmplitude.configuration as? com.amplitude.android.Configuration ?: return
 
         if (androidConfig.enableAutocaptureRemoteConfig && originalOptions.enableRemoteConfig) {
-            remoteConfigCallback = RemoteConfigClient.RemoteConfigCallback { config, _, _ ->
-                handleRemoteConfig(config)
-            }
+            remoteConfigCallback =
+                RemoteConfigClient.RemoteConfigCallback { config, _, _ ->
+                    handleRemoteConfig(config)
+                }
             androidAmplitude.remoteConfigClient.subscribe(Key.ANALYTICS_SDK, remoteConfigCallback!!)
         }
     }
@@ -158,41 +159,44 @@ class NetworkTrackingPlugin(
 
         // Filter headers
         val requestHeaders = matchedRule.requestHeaders?.filterHeaders(request.headers.toMap())
-        val responseHeaders = matchedRule.responseHeaders?.let { captureHeader ->
-            response?.headers?.let { captureHeader.filterHeaders(it.toMap()) }
-        }
+        val responseHeaders =
+            matchedRule.responseHeaders?.let { captureHeader ->
+                response?.headers?.let { captureHeader.filterHeaders(it.toMap()) }
+            }
 
         // Filter request body — skip one-shot, duplex, and non-JSON bodies
-        val requestBodyString = matchedRule.requestBody?.let { captureBody ->
-            val body = request.body ?: return@let null
-            if (body.isOneShot() || body.isDuplex()) return@let null
+        val requestBodyString =
+            matchedRule.requestBody?.let { captureBody ->
+                val body = request.body ?: return@let null
+                if (body.isOneShot() || body.isDuplex()) return@let null
 
-            val contentType = body.contentType()
-            if (contentType != null && !(contentType.type == "application" && contentType.subtype.contains("json"))) {
-                return@let null
-            }
+                val contentType = body.contentType()
+                if (contentType != null && !(contentType.type == "application" && contentType.subtype.contains("json"))) {
+                    return@let null
+                }
 
-            try {
-                val buffer = Buffer()
-                body.writeTo(buffer)
-                captureBody.filterBodyBytes(buffer.readByteArray())
-            } catch (_: Exception) {
-                null
+                try {
+                    val buffer = Buffer()
+                    body.writeTo(buffer)
+                    captureBody.filterBodyBytes(buffer.readByteArray())
+                } catch (_: Exception) {
+                    null
+                }
             }
-        }
 
         // Filter response body — bounded peek, JSON content type only
-        val responseBodyString = matchedRule.responseBody?.let { captureBody ->
-            val resp = response ?: return@let null
-            if (!resp.isJsonContentType()) return@let null
+        val responseBodyString =
+            matchedRule.responseBody?.let { captureBody ->
+                val resp = response ?: return@let null
+                if (!resp.isJsonContentType()) return@let null
 
-            try {
-                val peekedBody = resp.peekBody(MAX_BODY_PEEK_BYTES)
-                captureBody.filterBodyBytes(peekedBody.bytes())
-            } catch (_: Exception) {
-                null
+                try {
+                    val peekedBody = resp.peekBody(MAX_BODY_PEEK_BYTES)
+                    captureBody.filterBodyBytes(peekedBody.bytes())
+                } catch (_: Exception) {
+                    null
+                }
             }
-        }
 
         amplitude.track(
             NETWORK_TRACKING,
@@ -254,5 +258,4 @@ private fun Response.isJsonContentType(): Boolean {
     return contentType.type == "application" && contentType.subtype.contains("json")
 }
 
-private fun Headers.toMap(): Map<String, String> =
-    (0 until size).associate { name(it) to value(it) }
+private fun Headers.toMap(): Map<String, String> = (0 until size).associate { name(it) to value(it) }

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -77,23 +77,35 @@ class NetworkTrackingPlugin(
 
         // Fresh overlay on local options each time. Start from originalOptions so
         // fields absent from remote fall back to local, not to a previous remote value.
-        var updated = originalOptions
         var resolvedEnabled = originalOptions.enabled
         (networkConfig["enabled"] as? Boolean)?.let { resolvedEnabled = it }
+
+        var ignoreHosts = originalOptions.ignoreHosts
         (networkConfig["ignoreHosts"] as? List<*>)?.filterIsInstance<String>()?.let {
-            updated = updated.copy(ignoreHosts = it)
+            ignoreHosts = it
         }
+
+        var ignoreAmplitudeRequests = originalOptions.ignoreAmplitudeRequests
         (networkConfig["ignoreAmplitudeRequests"] as? Boolean)?.let {
-            updated = updated.copy(ignoreAmplitudeRequests = it)
+            ignoreAmplitudeRequests = it
         }
+
+        var captureRules = originalOptions.captureRules
         (networkConfig["captureRules"] as? List<*>)?.let { rawRules ->
             val maps = rawRules.filterIsInstance<Map<String, Any?>>()
             val rules = CaptureRule.fromRemoteConfig(maps)
-            if (rules != null) updated = updated.copy(captureRules = rules)
+            if (rules != null) captureRules = rules
         }
 
-        // Single atomic write — enabled + options in one snapshot
-        currentOptions = updated.copy(enabled = resolvedEnabled)
+        // Single atomic write — all fields in one snapshot
+        currentOptions =
+            NetworkTrackingOptions(
+                captureRules = captureRules,
+                ignoreHosts = ignoreHosts,
+                ignoreAmplitudeRequests = ignoreAmplitudeRequests,
+                enabled = resolvedEnabled,
+                enableRemoteConfig = originalOptions.enableRemoteConfig,
+            )
     }
 
     override fun intercept(chain: Chain): Response {

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -21,6 +21,9 @@ import com.amplitude.core.Constants.EventTypes.NETWORK_TRACKING
 import com.amplitude.core.platform.Plugin
 import com.amplitude.core.platform.Plugin.Type
 import com.amplitude.core.platform.Plugin.Type.Utility
+import com.amplitude.core.remoteconfig.ConfigMap
+import com.amplitude.core.remoteconfig.RemoteConfigClient
+import com.amplitude.core.remoteconfig.RemoteConfigClient.Key
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
@@ -33,10 +36,64 @@ import okio.ByteString.Companion.toByteString
 import okio.IOException
 
 class NetworkTrackingPlugin(
-    private val options: NetworkTrackingOptions = NetworkTrackingOptions.DEFAULT,
+    options: NetworkTrackingOptions = NetworkTrackingOptions.DEFAULT,
 ) : Interceptor, Plugin {
     override val type: Type = Utility
     override lateinit var amplitude: Amplitude
+
+    private val originalOptions: NetworkTrackingOptions = options
+
+    @Volatile
+    internal var currentOptions: NetworkTrackingOptions = options
+
+    // Strong reference to prevent GC — RemoteConfigClient uses WeakReference
+    private var remoteConfigCallback: RemoteConfigClient.RemoteConfigCallback? = null
+
+    override fun setup(amplitude: Amplitude) {
+        super.setup(amplitude)
+
+        val androidAmplitude = amplitude as? com.amplitude.android.Amplitude ?: return
+        val androidConfig = androidAmplitude.configuration as? com.amplitude.android.Configuration ?: return
+
+        if (androidConfig.enableAutocaptureRemoteConfig && originalOptions.enableRemoteConfig) {
+            remoteConfigCallback = RemoteConfigClient.RemoteConfigCallback { config, _, _ ->
+                handleRemoteConfig(config)
+            }
+            androidAmplitude.remoteConfigClient.subscribe(Key.ANALYTICS_SDK, remoteConfigCallback!!)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun handleRemoteConfig(config: ConfigMap) {
+        val autocaptureConfig = config["autocapture"] as? ConfigMap
+        val networkConfig = autocaptureConfig?.get("networkTracking") as? ConfigMap
+
+        if (networkConfig == null) {
+            // No networkTracking section — reset to local config
+            currentOptions = originalOptions
+            return
+        }
+
+        // Fresh overlay on local options each time. Start from originalOptions so
+        // fields absent from remote fall back to local, not to a previous remote value.
+        var updated = originalOptions
+        var resolvedEnabled = originalOptions.enabled
+        (networkConfig["enabled"] as? Boolean)?.let { resolvedEnabled = it }
+        (networkConfig["ignoreHosts"] as? List<*>)?.filterIsInstance<String>()?.let {
+            updated = updated.copy(ignoreHosts = it)
+        }
+        (networkConfig["ignoreAmplitudeRequests"] as? Boolean)?.let {
+            updated = updated.copy(ignoreAmplitudeRequests = it)
+        }
+        (networkConfig["captureRules"] as? List<*>)?.let { rawRules ->
+            val maps = rawRules.filterIsInstance<Map<String, Any?>>()
+            val rules = CaptureRule.fromRemoteConfig(maps)
+            if (rules != null) updated = updated.copy(captureRules = rules)
+        }
+
+        // Single atomic write — enabled + options in one snapshot
+        currentOptions = updated.copy(enabled = resolvedEnabled)
+    }
 
     override fun intercept(chain: Chain): Response {
         val request = chain.request()
@@ -64,13 +121,14 @@ class NetworkTrackingPlugin(
         request: Request,
         responseCode: Int,
     ): CaptureRule? {
+        val opts = currentOptions // single read — enabled + options in one atomic snapshot
+        if (!opts.enabled) return null
         val host = request.url.host
-        if (options.shouldIgnore(host)) return null
+        if (opts.shouldIgnore(host)) return null
         // Recursion guard: only scan body for amplitude hosts to avoid consuming one-shot
-        // bodies on normal requests. This prevents the SDK's own network tracking event
-        // uploads from being re-tracked when the same OkHttpClient is shared.
+        // bodies on normal requests.
         if (host.isAmplitudeHost() && request.body?.contains(NETWORK_TRACKING) == true) return null
-        return options.captureRules.findMatchingRule(
+        return opts.captureRules.findMatchingRule(
             host,
             request.url.toString(),
             request.method,

--- a/android/src/main/java/com/amplitude/android/utilities/ObjectFilter.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/ObjectFilter.kt
@@ -62,14 +62,6 @@ internal class ObjectFilter(
             return if (isAllowed(at)) value else null
         }
 
-        // Return entire container for exact non-wildcard matches
-        if (allowKeyPaths.any { pattern ->
-                pattern.none { it == "*" || it == "**" } && matches(at, pattern) && !isBlocked(at)
-            }
-        ) {
-            return value
-        }
-
         // Return empty containers that match patterns
         if (isAllowed(at)) {
             if (value is Map<*, *> && value.isEmpty()) return value

--- a/android/src/main/java/com/amplitude/android/utilities/ObjectFilter.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/ObjectFilter.kt
@@ -102,7 +102,13 @@ internal class ObjectFilter(
         path: List<String>,
         pattern: List<String>,
     ): Boolean {
-        if (pattern.size <= path.size) return pattern.contains("**")
+        if (pattern.size <= path.size) {
+            for (i in pattern.indices) {
+                if (pattern[i] == "**") return true
+                if (pattern[i] != path[i] && pattern[i] != "*") return false
+            }
+            return false
+        }
         for (i in path.indices) {
             if (pattern[i] == "**") return true
             if (pattern[i] != path[i] && pattern[i] != "*") return false

--- a/android/src/main/java/com/amplitude/android/utilities/ObjectFilter.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/ObjectFilter.kt
@@ -1,0 +1,153 @@
+package com.amplitude.android.utilities
+
+internal class ObjectFilter(
+    allowList: List<String> = emptyList(),
+    blockList: List<String> = emptyList(),
+) {
+    private val allowKeyPaths: List<List<String>> = allowList.mapNotNull { parseKeyPath(it) }
+    private val blockKeyPaths: List<List<String>> = blockList.mapNotNull { parseKeyPath(it) }
+
+    fun filtered(obj: Any?): Any? {
+        if (obj == null || allowKeyPaths.isEmpty()) return null
+        return when (obj) {
+            is Map<*, *> -> filterMap(obj.filterIsStringKey(), emptyList())
+            is List<*> -> filterList(obj, emptyList())
+            else -> null
+        }
+    }
+
+    private fun filterMap(map: Map<String, Any?>, path: List<String>): Map<String, Any?>? {
+        val result = mutableMapOf<String, Any?>()
+        for ((key, value) in map) {
+            val newPath = path + key
+            if (isBlocked(newPath) || !canInclude(newPath)) continue
+
+            val filtered = processValue(value, newPath)
+            if (filtered != null) {
+                result[key] = filtered
+            } else if (shouldPreserveEmpty(newPath, value)) {
+                result[key] = emptyContainer(value)
+            }
+        }
+        return result.ifEmpty { null }
+    }
+
+    private fun filterList(list: List<*>, path: List<String>): List<Any?>? {
+        val result = mutableListOf<Any?>()
+        for ((index, value) in list.withIndex()) {
+            val newPath = path + index.toString()
+            if (isBlocked(newPath) || !canInclude(newPath)) continue
+
+            val filtered = processValue(value, newPath)
+            if (filtered != null) {
+                result.add(filtered)
+            } else if (shouldPreserveEmpty(newPath, value)) {
+                result.add(emptyContainer(value))
+            }
+        }
+        return result.ifEmpty { null }
+    }
+
+    private fun processValue(value: Any?, at: List<String>): Any? {
+        if (value !is Map<*, *> && value !is List<*>) {
+            return if (isAllowed(at)) value else null
+        }
+
+        // Return entire container for exact non-wildcard matches
+        if (allowKeyPaths.any { pattern ->
+                pattern.none { it == "*" || it == "**" } && matches(at, pattern) && !isBlocked(at)
+            }
+        ) {
+            return value
+        }
+
+        // Return empty containers that match patterns
+        if (isAllowed(at)) {
+            if (value is Map<*, *> && value.isEmpty()) return value
+            if (value is List<*> && value.isEmpty()) return value
+        }
+
+        // Recursively filter containers
+        return when (value) {
+            is Map<*, *> -> filterMap(value.filterIsStringKey(), at)
+            is List<*> -> filterList(value, at)
+            else -> null
+        }
+    }
+
+    private fun shouldPreserveEmpty(path: List<String>, value: Any?): Boolean {
+        if (value !is Map<*, *> && value !is List<*>) return false
+        return allowKeyPaths.any { pattern ->
+            pattern.size == path.size &&
+                pattern.last() == "*" &&
+                matches(path.dropLast(1), pattern.dropLast(1))
+        }
+    }
+
+    private fun emptyContainer(value: Any?): Any {
+        return if (value is List<*>) emptyList<Any?>() else emptyMap<String, Any?>()
+    }
+
+    private fun canInclude(path: List<String>): Boolean {
+        return allowKeyPaths.any { pattern ->
+            matches(path, pattern) || canMatchDescendants(path, pattern)
+        }
+    }
+
+    private fun canMatchDescendants(path: List<String>, pattern: List<String>): Boolean {
+        if (pattern.size <= path.size) return pattern.contains("**")
+        for (i in path.indices) {
+            if (pattern[i] == "**") return true
+            if (pattern[i] != path[i] && pattern[i] != "*") return false
+        }
+        return true
+    }
+
+    private fun isAllowed(path: List<String>): Boolean {
+        return allowKeyPaths.any { matches(path, it) } && !isBlocked(path)
+    }
+
+    private fun isBlocked(path: List<String>): Boolean {
+        return blockKeyPaths.any { matches(path, it) }
+    }
+
+    internal fun matches(path: List<String>, pattern: List<String>): Boolean {
+        if (path.isEmpty() && pattern.isEmpty()) return true
+        if (pattern == listOf("**")) return true
+        return matchImpl(path, pattern, 0, 0)
+    }
+
+    private fun matchImpl(path: List<String>, pattern: List<String>, pIdx: Int, patIdx: Int): Boolean {
+        if (pIdx == path.size && patIdx == pattern.size) return true
+        if (patIdx == pattern.size) return false
+
+        val current = pattern[patIdx]
+
+        if (current == "**") {
+            if (patIdx == pattern.size - 1) return true
+            if (matchImpl(path, pattern, pIdx, patIdx + 1)) return true
+            for (i in pIdx until path.size) {
+                if (matchImpl(path, pattern, i + 1, patIdx + 1)) return true
+            }
+            return false
+        }
+
+        if (pIdx == path.size) return false
+
+        return (current == "*" || current == path[pIdx]) &&
+            matchImpl(path, pattern, pIdx + 1, patIdx + 1)
+    }
+
+    companion object {
+        private fun parseKeyPath(path: String): List<String>? {
+            if (path.isEmpty()) return null
+            val components = path.split("/").filter { it.isNotEmpty() }
+            return components.ifEmpty { null }
+        }
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun Map<*, *>.filterIsStringKey(): Map<String, Any?> {
+    return this.filterKeys { it is String } as Map<String, Any?>
+}

--- a/android/src/main/java/com/amplitude/android/utilities/ObjectFilter.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/ObjectFilter.kt
@@ -16,7 +16,10 @@ internal class ObjectFilter(
         }
     }
 
-    private fun filterMap(map: Map<String, Any?>, path: List<String>): Map<String, Any?>? {
+    private fun filterMap(
+        map: Map<String, Any?>,
+        path: List<String>,
+    ): Map<String, Any?>? {
         val result = mutableMapOf<String, Any?>()
         for ((key, value) in map) {
             val newPath = path + key
@@ -32,7 +35,10 @@ internal class ObjectFilter(
         return result.ifEmpty { null }
     }
 
-    private fun filterList(list: List<*>, path: List<String>): List<Any?>? {
+    private fun filterList(
+        list: List<*>,
+        path: List<String>,
+    ): List<Any?>? {
         val result = mutableListOf<Any?>()
         for ((index, value) in list.withIndex()) {
             val newPath = path + index.toString()
@@ -48,7 +54,10 @@ internal class ObjectFilter(
         return result.ifEmpty { null }
     }
 
-    private fun processValue(value: Any?, at: List<String>): Any? {
+    private fun processValue(
+        value: Any?,
+        at: List<String>,
+    ): Any? {
         if (value !is Map<*, *> && value !is List<*>) {
             return if (isAllowed(at)) value else null
         }
@@ -75,7 +84,10 @@ internal class ObjectFilter(
         }
     }
 
-    private fun shouldPreserveEmpty(path: List<String>, value: Any?): Boolean {
+    private fun shouldPreserveEmpty(
+        path: List<String>,
+        value: Any?,
+    ): Boolean {
         if (value !is Map<*, *> && value !is List<*>) return false
         return allowKeyPaths.any { pattern ->
             pattern.size == path.size &&
@@ -94,7 +106,10 @@ internal class ObjectFilter(
         }
     }
 
-    private fun canMatchDescendants(path: List<String>, pattern: List<String>): Boolean {
+    private fun canMatchDescendants(
+        path: List<String>,
+        pattern: List<String>,
+    ): Boolean {
         if (pattern.size <= path.size) return pattern.contains("**")
         for (i in path.indices) {
             if (pattern[i] == "**") return true
@@ -111,13 +126,21 @@ internal class ObjectFilter(
         return blockKeyPaths.any { matches(path, it) }
     }
 
-    internal fun matches(path: List<String>, pattern: List<String>): Boolean {
+    internal fun matches(
+        path: List<String>,
+        pattern: List<String>,
+    ): Boolean {
         if (path.isEmpty() && pattern.isEmpty()) return true
         if (pattern == listOf("**")) return true
         return matchImpl(path, pattern, 0, 0)
     }
 
-    private fun matchImpl(path: List<String>, pattern: List<String>, pIdx: Int, patIdx: Int): Boolean {
+    private fun matchImpl(
+        path: List<String>,
+        pattern: List<String>,
+        pIdx: Int,
+        patIdx: Int,
+    ): Boolean {
         if (pIdx == path.size && patIdx == pattern.size) return true
         if (patIdx == pattern.size) return false
 

--- a/android/src/test/kotlin/com/amplitude/android/migration/DatabaseStorageTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/migration/DatabaseStorageTest.kt
@@ -8,6 +8,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.spyk
+import io.mockk.unmockkConstructor
 import io.mockk.verify
 import org.json.JSONObject
 import org.junit.jupiter.api.Assertions
@@ -76,6 +77,8 @@ class DatabaseStorageTest {
         Assertions.assertEquals(events.size, 2)
         Assertions.assertEquals((events[0]).get("event_id"), 1)
         Assertions.assertEquals((events[1]).get("event_id"), 2)
+
+        unmockkConstructor(JSONObject::class)
     }
 
     @Test

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsParserTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsParserTest.kt
@@ -1,0 +1,103 @@
+package com.amplitude.android.network
+
+import com.amplitude.android.network.NetworkTrackingOptions.URLPattern
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class NetworkTrackingOptionsParserTest {
+    @Test
+    fun `full rule`() {
+        val configs =
+            listOf(
+                mapOf(
+                    "hosts" to listOf("api.example.com"),
+                    "urls" to listOf("https://exact.com/path"),
+                    "urlsRegex" to listOf(".*\\.example\\.com/api/.*"),
+                    "methods" to listOf("GET", "POST"),
+                    "statusCodeRange" to "200-299,500-599",
+                    "requestHeaders" to mapOf("allowlist" to listOf("x-custom"), "captureSafeHeaders" to false),
+                    "responseHeaders" to mapOf("allowlist" to listOf("x-resp"), "captureSafeHeaders" to true),
+                    "requestBody" to mapOf("allowlist" to listOf("user/*"), "excludelist" to listOf("user/password")),
+                    "responseBody" to mapOf("allowlist" to listOf("**")),
+                ),
+            )
+        val rules = parseCaptureRulesFromRemoteConfig(configs)
+        assertNotNull(rules)
+        assertEquals(1, rules!!.size)
+        val rule = rules[0]
+        assertEquals(listOf("api.example.com"), rule.hosts)
+        assertEquals(2, rule.urls.size)
+        assertTrue(rule.urls[0] is URLPattern.Exact)
+        assertTrue(rule.urls[1] is URLPattern.Regex)
+        assertEquals(listOf("GET", "POST"), rule.methods)
+        assertTrue(200 in rule.statusCodeRange)
+        assertTrue(500 in rule.statusCodeRange)
+        assertFalse(300 in rule.statusCodeRange)
+
+        assertNotNull(rule.requestHeaders)
+        assertEquals(listOf("x-custom"), rule.requestHeaders!!.allowlist)
+        assertFalse(rule.requestHeaders!!.captureSafeHeaders)
+
+        assertNotNull(rule.responseHeaders)
+        assertTrue(rule.responseHeaders!!.captureSafeHeaders)
+
+        assertNotNull(rule.requestBody)
+        assertEquals(listOf("user/*"), rule.requestBody!!.allowlist)
+        assertEquals(listOf("user/password"), rule.requestBody!!.excludelist)
+
+        assertNotNull(rule.responseBody)
+        assertEquals(listOf("**"), rule.responseBody!!.allowlist)
+    }
+
+    @Test
+    fun `minimal rule`() {
+        val configs = listOf(mapOf("hosts" to listOf("*")))
+        val rules = parseCaptureRulesFromRemoteConfig(configs)
+        assertNotNull(rules)
+        assertEquals(listOf("*"), rules!![0].hosts)
+        assertEquals((500..599).toList(), rules[0].statusCodeRange)
+        assertNull(rules[0].requestHeaders)
+        assertNull(rules[0].requestBody)
+    }
+
+    @Test
+    fun `empty list returns null`() {
+        assertNull(parseCaptureRulesFromRemoteConfig(emptyList()))
+    }
+
+    @Test
+    fun `invalid status range rejects all rules`() {
+        val configs =
+            listOf(
+                mapOf("hosts" to listOf("a.com"), "statusCodeRange" to "200-299"),
+                mapOf("hosts" to listOf("b.com"), "statusCodeRange" to "not-a-number"),
+            )
+        assertNull(parseCaptureRulesFromRemoteConfig(configs))
+    }
+
+    @Test
+    fun `body without allowlist has empty allowlist`() {
+        val configs =
+            listOf(
+                mapOf(
+                    "hosts" to listOf("*"),
+                    "requestBody" to mapOf("excludelist" to listOf("secret")),
+                ),
+            )
+        val rules = parseCaptureRulesFromRemoteConfig(configs)
+        assertNotNull(rules)
+        assertNotNull(rules!![0].requestBody)
+        assertTrue(rules[0].requestBody!!.allowlist.isEmpty())
+        assertEquals(listOf("secret"), rules[0].requestBody!!.excludelist)
+    }
+
+    @Test
+    fun `parseStatusCodeRange single values and ranges`() {
+        val codes = parseStatusCodeRange("0,200-202,404,500-501")
+        assertEquals(listOf(0, 200, 201, 202, 404, 500, 501), codes)
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
@@ -1,47 +1,40 @@
 package com.amplitude.android.network
 
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
+import com.amplitude.android.network.NetworkTrackingOptions.URLPattern
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class NetworkTrackingOptionsTest {
+    private fun List<CaptureRule>.matches(host: String, responseCode: Int): Boolean =
+        findMatchingRule(host, "https://$host/test", "GET", responseCode) != null
+
     @Test
-    fun `capture rules must have non-empty host list`() {
-        val exception =
-            assertThrows<IllegalArgumentException> {
-                NetworkTrackingOptions(
-                    captureRules =
-                        listOf(
-                            CaptureRule(
-                                hosts = emptyList(),
-                                statusCodeRange = (500..599).toList(),
-                            ),
-                        ),
-                    ignoreAmplitudeRequests = false,
-                )
-            }
-        assertEquals("Capture rules must have a non-empty host list.", exception.message)
+    fun `capture rules must have non-empty host or url list`() {
+        assertThrows<IllegalArgumentException> {
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(statusCodeRange = (500..599).toList())),
+                ignoreAmplitudeRequests = false,
+            )
+        }
     }
 
     @Test
     fun `capture rules must have non-empty status code range`() {
-        val exception =
-            assertThrows<IllegalArgumentException> {
-                NetworkTrackingOptions(
-                    listOf(
-                        CaptureRule(
-                            hosts = listOf("api.example.com"),
-                            statusCodeRange = emptyList(),
-                        ),
-                    ),
-                    ignoreAmplitudeRequests = false,
-                )
-            }
-        assertEquals("Capture rules must have a non-empty status code range.", exception.message)
+        assertThrows<IllegalArgumentException> {
+            NetworkTrackingOptions(
+                listOf(CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = emptyList())),
+                ignoreAmplitudeRequests = false,
+            )
+        }
     }
 
     @Test
@@ -58,182 +51,181 @@ class NetworkTrackingOptionsTest {
 
     @Test
     fun `basic wildcard host matching`() {
-        val options =
-            NetworkTrackingOptions(
-                captureRules =
-                    listOf(
-                        CaptureRule(
-                            hosts = listOf("*"),
-                            statusCodeRange = (200..299).toList(),
-                        ),
-                    ),
-                ignoreHosts = emptyList(),
-                ignoreAmplitudeRequests = false,
-            )
-
-        val matchingHosts =
-            listOf(
-                "https://api.example.com",
-                "https://test.amplitude.com",
-                "https://random-api.com",
-            ).urlsToHosts()
-        matchingHosts.map { host ->
-            assertTrue(options.captureRules.matches(host, 200)) {
-                "expected $host to match"
-            }
-        }
+        val options = NetworkTrackingOptions(
+            captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+            ignoreAmplitudeRequests = false,
+        )
+        listOf("https://api.example.com", "https://test.amplitude.com", "https://random-api.com")
+            .urlsToHosts()
+            .forEach { assertTrue(options.captureRules.matches(it, 200)) { "expected $it to match" } }
     }
 
     @Test
     fun `domain wildcard host matching`() {
-        val options =
-            NetworkTrackingOptions(
-                captureRules =
-                    listOf(
-                        CaptureRule(
-                            hosts = listOf("*.example.com", "*.subdomain.test.com", "exact-match.com"),
-                            statusCodeRange = (200..299).toList(),
-                        ),
-                    ),
-                ignoreAmplitudeRequests = false,
-            )
-
-        val matchingHosts =
-            listOf(
-                "https://api.example.com/test",
-                "https://another.subdomain.test.com/api",
-                "https://exact-match.com/test",
-            ).urlsToHosts()
-        matchingHosts.forEach { host ->
-            assertTrue(options.captureRules.matches(host, 200)) {
-                "expected $host to match"
-            }
-        }
-
-        val nonMatchingHosts =
-            listOf(
-                "https://notexample.com/test",
-                "https://testing.other.com/test",
-            ).urlsToHosts()
-        nonMatchingHosts.forEach { host ->
-            assertFalse(options.captureRules.matches(host, 200))
-        }
+        val options = NetworkTrackingOptions(
+            captureRules = listOf(CaptureRule(hosts = listOf("*.example.com", "*.subdomain.test.com", "exact-match.com"), statusCodeRange = (200..299).toList())),
+            ignoreAmplitudeRequests = false,
+        )
+        listOf("https://api.example.com/test", "https://another.subdomain.test.com/api", "https://exact-match.com/test")
+            .urlsToHosts().forEach { assertTrue(options.captureRules.matches(it, 200)) }
+        listOf("https://notexample.com/test", "https://testing.other.com/test")
+            .urlsToHosts().forEach { assertFalse(options.captureRules.matches(it, 200)) }
     }
 
     @Test
     fun `specific host matching`() {
-        val options =
-            NetworkTrackingOptions(
-                captureRules =
-                    listOf(
-                        CaptureRule(
-                            hosts = listOf("api.example.com"),
-                            statusCodeRange = (200..299).toList(),
-                        ),
-                    ),
-                ignoreAmplitudeRequests = true,
-            )
-
-        // matching host request
-        val matchingHosts =
-            listOf(
-                "https://api.example.com/test",
-                "https://api.example.com/test/123",
-                "https://api.example.com/test?param=value",
-            ).urlsToHosts()
-        matchingHosts.forEach { host ->
-            assertTrue(options.captureRules.matches(host, 200))
-        }
-
-        // non-matching host requests
-        val nonMatchingHosts =
-            listOf(
-                "https://other.example.com",
-                "https://test.amplitude.com",
-                "https://api.different.com",
-            ).urlsToHosts()
-        nonMatchingHosts.forEach { host ->
-            assertFalse(options.captureRules.matches(host, 200))
-        }
+        val options = NetworkTrackingOptions(
+            captureRules = listOf(CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = (200..299).toList())),
+            ignoreAmplitudeRequests = true,
+        )
+        listOf("https://api.example.com/test", "https://api.example.com/test/123").urlsToHosts()
+            .forEach { assertTrue(options.captureRules.matches(it, 200)) }
+        listOf("https://other.example.com", "https://api.different.com").urlsToHosts()
+            .forEach { assertFalse(options.captureRules.matches(it, 200)) }
     }
 
     @Test
-    fun `should ignore hosts with exact and wildcard patterns`() {
-        val options =
-            NetworkTrackingOptions(
-                captureRules = listOf(CaptureRule(hosts = listOf("*"))),
-                ignoreHosts = listOf("exact.ignore.com", "*.wildcard.ignore.com"),
-            )
-
+    fun `should ignore hosts`() {
+        val options = NetworkTrackingOptions(
+            captureRules = listOf(CaptureRule(hosts = listOf("*"))),
+            ignoreHosts = listOf("exact.ignore.com", "*.wildcard.ignore.com"),
+        )
         assertTrue(options.shouldIgnore("exact.ignore.com"))
         assertTrue(options.shouldIgnore("test.wildcard.ignore.com"))
         assertFalse(options.shouldIgnore("not.ignored.com"))
     }
 
     @Test
-    fun `multiple capture rules with last matching rule precedence`() {
-        val options =
-            NetworkTrackingOptions(
-                captureRules =
-                    listOf(
-                        CaptureRule(
-                            hosts = listOf("*.example.com"),
-                            statusCodeRange = (200..299).toList(),
-                        ),
-                        CaptureRule(
-                            hosts = listOf("api.example.com"),
-                            statusCodeRange = (500..599).toList(),
-                        ),
-                    ),
-            )
+    fun `should ignore amplitude hosts`() {
+        val options = NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), ignoreAmplitudeRequests = true)
+        assertTrue(options.shouldIgnore("amplitude.com"))
+        assertTrue(options.shouldIgnore("api2.amplitude.com"))
+        assertTrue(options.shouldIgnore("api.eu.amplitude.com"))
+        assertFalse(options.shouldIgnore("notamplitude.com"))
+    }
 
+    @Test
+    fun `should not ignore amplitude hosts when disabled`() {
+        val options = NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), ignoreAmplitudeRequests = false)
+        assertFalse(options.shouldIgnore("api2.amplitude.com"))
+    }
+
+    @Test
+    fun `multiple capture rules with last matching rule precedence`() {
+        val options = NetworkTrackingOptions(captureRules = listOf(
+            CaptureRule(hosts = listOf("*.example.com"), statusCodeRange = (200..299).toList()),
+            CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = (500..599).toList()),
+        ))
         assertTrue(options.captureRules.matches("api.example.com", 500))
         assertFalse(options.captureRules.matches("api.example.com", 200))
     }
 
     @Test
     fun `non-contiguous status code ranges`() {
-        val options =
-            NetworkTrackingOptions(
-                captureRules =
-                    listOf(
-                        CaptureRule(
-                            hosts = listOf("api.example.com"),
-                            statusCodeRange = listOf(404, 200, 500),
-                        ),
-                    ),
-            )
-
+        val options = NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = listOf(404, 200, 500))))
         assertTrue(options.captureRules.matches("api.example.com", 200))
         assertTrue(options.captureRules.matches("api.example.com", 404))
-        assertTrue(options.captureRules.matches("api.example.com", 500))
         assertFalse(options.captureRules.matches("api.example.com", 300))
     }
 
     @Test
     fun `host matcher edge cases`() {
-        val options =
-            NetworkTrackingOptions(
-                captureRules =
-                    listOf(
-                        CaptureRule(
-                            hosts =
-                                listOf(
-                                    "*.sub.*.example.com",
-                                    "TEST.EXAMPLE.COM",
-                                    "special-chars.example.com",
-                                ),
-                            statusCodeRange = (200..599).toList(),
-                        ),
-                    ),
-            )
-
+        val options = NetworkTrackingOptions(captureRules = listOf(
+            CaptureRule(hosts = listOf("*.sub.*.example.com", "TEST.EXAMPLE.COM", "special-chars.example.com"), statusCodeRange = (200..599).toList()),
+        ))
         assertTrue(options.captureRules.matches("test.sub.domain.example.com", 200))
         assertTrue(options.captureRules.matches("test.example.com", 200))
         assertTrue(options.captureRules.matches("special-chars.example.com", 200))
     }
 
-    private fun List<String>.urlsToHosts(): List<String> {
-        return map { url -> url.toHttpUrl().host }
+    @Test fun `URL pattern exact matching`() {
+        val rule = CaptureRule(urls = listOf(URLPattern.Exact("https://api.example.com/v1/users")), statusCodeRange = (200..299).toList())
+        assertTrue(rule.matchesRequest("api.example.com", "https://api.example.com/v1/users", "GET"))
+        assertFalse(rule.matchesRequest("api.example.com", "https://api.example.com/v1/products", "GET"))
     }
+
+    @Test fun `URL pattern regex matching`() {
+        val rule = CaptureRule(urls = listOf(URLPattern.Regex("https://api\\.example\\.com/v[0-9]+/.*")), statusCodeRange = (200..299).toList())
+        assertTrue(rule.matchesRequest("api.example.com", "https://api.example.com/v1/users", "GET"))
+        assertFalse(rule.matchesRequest("api.example.com", "https://other.com/v1/users", "GET"))
+    }
+
+    @Test fun `invalid regex rejected at construction`() {
+        assertThrows<java.util.regex.PatternSyntaxException> {
+            CaptureRule(urls = listOf(URLPattern.Regex("[invalid")), statusCodeRange = (200..299).toList())
+        }
+    }
+
+    @Test fun `method matching`() {
+        val rule = CaptureRule(hosts = listOf("e.com"), methods = listOf("GET", "POST"), statusCodeRange = (200..299).toList())
+        assertTrue(rule.matchesRequest("e.com", "https://e.com/t", "GET"))
+        assertTrue(rule.matchesRequest("e.com", "https://e.com/t", "post"))
+        assertFalse(rule.matchesRequest("e.com", "https://e.com/t", "DELETE"))
+    }
+
+    @Test fun `empty methods matches all`() {
+        val rule = CaptureRule(hosts = listOf("e.com"), statusCodeRange = (200..299).toList())
+        assertTrue(rule.matchesRequest("e.com", "https://e.com/t", "DELETE"))
+    }
+
+    @Test fun `findMatchingRule returns rule with config`() {
+        val ch = CaptureHeader(allowlist = listOf("ct"), captureSafeHeaders = false)
+        val cb = CaptureBody(allowlist = listOf("user/name"))
+        val rules = listOf(CaptureRule(hosts = listOf("e.com"), statusCodeRange = (200..299).toList(), requestHeaders = ch, requestBody = cb))
+        val m = rules.findMatchingRule("e.com", "https://e.com/t", "GET", 200)
+        assertNotNull(m)
+        assertEquals(ch, m!!.requestHeaders)
+        assertEquals(cb, m.requestBody)
+    }
+
+    // --- Header filtering ---
+
+    @Test fun `filter headers with safe headers`() {
+        val ch = CaptureHeader(captureSafeHeaders = true)
+        val r = ch.filterHeaders(mapOf("Content-Type" to "json", "Authorization" to "Bearer x", "Cache-Control" to "no-cache"))
+        assertNotNull(r)
+        assertEquals("json", r!!["Content-Type"])
+        assertEquals("no-cache", r["Cache-Control"])
+        assertNull(r["Authorization"])
+    }
+
+    @Test fun `filter headers blocked even if in allowlist`() {
+        val ch = CaptureHeader(allowlist = listOf("authorization", "cookie"), captureSafeHeaders = false)
+        assertNull(ch.filterHeaders(mapOf("Authorization" to "x", "Cookie" to "y")))
+    }
+
+    @Test fun `filter headers case insensitive`() {
+        val ch = CaptureHeader(allowlist = listOf("X-CUSTOM"), captureSafeHeaders = false)
+        val r = ch.filterHeaders(mapOf("x-custom" to "v"))
+        assertEquals("v", r!!["x-custom"])
+    }
+
+    // --- Body filtering ---
+
+    @Test fun `filter body bytes JSON object`() {
+        val cb = CaptureBody(allowlist = listOf("user/name"))
+        val r = cb.filterBodyBytes("""{"user":{"name":"John","password":"secret"}}""".toByteArray())
+        assertNotNull(r)
+        assertTrue(r!!.contains("John"))
+        assertFalse(r.contains("secret"))
+    }
+
+    @Test fun `filter body bytes non-JSON returns null`() {
+        assertNull(CaptureBody(allowlist = listOf("k")).filterBodyBytes("not json".toByteArray()))
+    }
+
+    @Test fun `filter body bytes null returns null`() {
+        assertNull(CaptureBody(allowlist = listOf("k")).filterBodyBytes(null))
+    }
+
+    @Test fun `filter body bytes with blocklist`() {
+        val cb = CaptureBody(allowlist = listOf("user/**"), blocklist = listOf("user/password"))
+        val r = cb.filterBodyBytes("""{"user":{"name":"John","password":"secret","email":"j@e.com"}}""".toByteArray())
+        assertNotNull(r)
+        assertTrue(r!!.contains("John"))
+        assertTrue(r.contains("j@e.com"))
+        assertFalse(r.contains("secret"))
+    }
+
+    private fun List<String>.urlsToHosts(): List<String> = map { it.toHttpUrl().host }
 }

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
@@ -281,7 +281,7 @@ class NetworkTrackingOptionsTest {
     }
 
     @Test fun `filter body bytes with blocklist`() {
-        val cb = CaptureBody(allowlist = listOf("user/**"), blocklist = listOf("user/password"))
+        val cb = CaptureBody(allowlist = listOf("user/**"), excludelist = listOf("user/password"))
         val r = cb.filterBodyBytes("""{"user":{"name":"John","password":"secret","email":"j@e.com"}}""".toByteArray())
         assertNotNull(r)
         assertTrue(r!!.contains("John"))

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
@@ -23,7 +23,7 @@ class NetworkTrackingOptionsTest {
     fun `capture rules must have non-empty host or url list`() {
         assertThrows<IllegalArgumentException> {
             NetworkTrackingOptions(
-                captureRules = listOf(CaptureRule(statusCodeRange = (500..599).toList())),
+                captureRules = listOf(CaptureRule(hosts = emptyList(), statusCodeRange = (500..599).toList())),
                 ignoreAmplitudeRequests = false,
             )
         }
@@ -184,14 +184,23 @@ class NetworkTrackingOptionsTest {
     }
 
     @Test fun `method matching`() {
-        val rule = CaptureRule(hosts = listOf("e.com"), methods = listOf("GET", "POST"), statusCodeRange = (200..299).toList())
+        val rule =
+            CaptureRule(
+                urls = listOf(URLPattern.Exact("https://e.com/t")),
+                methods = listOf("GET", "POST"),
+                statusCodeRange = (200..299).toList(),
+            )
         assertTrue(rule.matchesRequest("e.com", "https://e.com/t", "GET"))
         assertTrue(rule.matchesRequest("e.com", "https://e.com/t", "post"))
         assertFalse(rule.matchesRequest("e.com", "https://e.com/t", "DELETE"))
     }
 
     @Test fun `empty methods matches all`() {
-        val rule = CaptureRule(hosts = listOf("e.com"), statusCodeRange = (200..299).toList())
+        val rule =
+            CaptureRule(
+                urls = listOf(URLPattern.Exact("https://e.com/t")),
+                statusCodeRange = (200..299).toList(),
+            )
         assertTrue(rule.matchesRequest("e.com", "https://e.com/t", "DELETE"))
     }
 
@@ -199,7 +208,14 @@ class NetworkTrackingOptionsTest {
         val ch = CaptureHeader(allowlist = listOf("ct"), captureSafeHeaders = false)
         val cb = CaptureBody(allowlist = listOf("user/name"))
         val rules =
-            listOf(CaptureRule(hosts = listOf("e.com"), statusCodeRange = (200..299).toList(), requestHeaders = ch, requestBody = cb))
+            listOf(
+                CaptureRule(
+                    urls = listOf(URLPattern.Regex(".*e\\.com.*")),
+                    statusCodeRange = (200..299).toList(),
+                    requestHeaders = ch,
+                    requestBody = cb,
+                ),
+            )
         val m = rules.findMatchingRule("e.com", "https://e.com/t", "GET", 200)
         assertNotNull(m)
         assertEquals(ch, m!!.requestHeaders)

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
@@ -4,6 +4,7 @@ import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import com.amplitude.android.network.NetworkTrackingOptions.URLPattern
+import okhttp3.Headers.Companion.headersOf
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -226,7 +227,8 @@ class NetworkTrackingOptionsTest {
 
     @Test fun `filter headers with safe headers`() {
         val ch = CaptureHeader(captureSafeHeaders = true)
-        val r = ch.filterHeaders(mapOf("Content-Type" to "json", "Authorization" to "Bearer x", "Cache-Control" to "no-cache"))
+        val headers = headersOf("Content-Type", "json", "Authorization", "Bearer x", "Cache-Control", "no-cache")
+        val r = ch.filterHeaders(headers)
         assertNotNull(r)
         assertEquals("json", r!!["Content-Type"])
         assertEquals("no-cache", r["Cache-Control"])
@@ -235,13 +237,29 @@ class NetworkTrackingOptionsTest {
 
     @Test fun `filter headers blocked even if in allowlist`() {
         val ch = CaptureHeader(allowlist = listOf("authorization", "cookie"), captureSafeHeaders = false)
-        assertNull(ch.filterHeaders(mapOf("Authorization" to "x", "Cookie" to "y")))
+        assertNull(ch.filterHeaders(headersOf("Authorization", "x", "Cookie", "y")))
     }
 
     @Test fun `filter headers case insensitive`() {
         val ch = CaptureHeader(allowlist = listOf("X-CUSTOM"), captureSafeHeaders = false)
-        val r = ch.filterHeaders(mapOf("x-custom" to "v"))
+        val r = ch.filterHeaders(headersOf("x-custom", "v"))
         assertEquals("v", r!!["x-custom"])
+    }
+
+    @Test fun `filter headers preserves multi-valued headers`() {
+        val ch = CaptureHeader(allowlist = listOf("x-multi"), captureSafeHeaders = false)
+        val headers = headersOf("X-Multi", "a", "X-Multi", "b", "X-Multi", "c")
+        val r = ch.filterHeaders(headers)
+        assertNotNull(r)
+        assertEquals(listOf("a", "b", "c"), r!!["X-Multi"])
+    }
+
+    @Test fun `filter headers single-valued header is String not List`() {
+        val ch = CaptureHeader(allowlist = listOf("x-single"), captureSafeHeaders = false)
+        val r = ch.filterHeaders(headersOf("X-Single", "only"))
+        assertNotNull(r)
+        assertTrue(r!!["X-Single"] is String)
+        assertEquals("only", r["X-Single"])
     }
 
     // --- Body filtering ---

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingOptionsTest.kt
@@ -14,8 +14,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class NetworkTrackingOptionsTest {
-    private fun List<CaptureRule>.matches(host: String, responseCode: Int): Boolean =
-        findMatchingRule(host, "https://$host/test", "GET", responseCode) != null
+    private fun List<CaptureRule>.matches(
+        host: String,
+        responseCode: Int,
+    ): Boolean = findMatchingRule(host, "https://$host/test", "GET", responseCode) != null
 
     @Test
     fun `capture rules must have non-empty host or url list`() {
@@ -51,10 +53,11 @@ class NetworkTrackingOptionsTest {
 
     @Test
     fun `basic wildcard host matching`() {
-        val options = NetworkTrackingOptions(
-            captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
-            ignoreAmplitudeRequests = false,
-        )
+        val options =
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                ignoreAmplitudeRequests = false,
+            )
         listOf("https://api.example.com", "https://test.amplitude.com", "https://random-api.com")
             .urlsToHosts()
             .forEach { assertTrue(options.captureRules.matches(it, 200)) { "expected $it to match" } }
@@ -62,10 +65,17 @@ class NetworkTrackingOptionsTest {
 
     @Test
     fun `domain wildcard host matching`() {
-        val options = NetworkTrackingOptions(
-            captureRules = listOf(CaptureRule(hosts = listOf("*.example.com", "*.subdomain.test.com", "exact-match.com"), statusCodeRange = (200..299).toList())),
-            ignoreAmplitudeRequests = false,
-        )
+        val options =
+            NetworkTrackingOptions(
+                captureRules =
+                    listOf(
+                        CaptureRule(
+                            hosts = listOf("*.example.com", "*.subdomain.test.com", "exact-match.com"),
+                            statusCodeRange = (200..299).toList(),
+                        ),
+                    ),
+                ignoreAmplitudeRequests = false,
+            )
         listOf("https://api.example.com/test", "https://another.subdomain.test.com/api", "https://exact-match.com/test")
             .urlsToHosts().forEach { assertTrue(options.captureRules.matches(it, 200)) }
         listOf("https://notexample.com/test", "https://testing.other.com/test")
@@ -74,10 +84,11 @@ class NetworkTrackingOptionsTest {
 
     @Test
     fun `specific host matching`() {
-        val options = NetworkTrackingOptions(
-            captureRules = listOf(CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = (200..299).toList())),
-            ignoreAmplitudeRequests = true,
-        )
+        val options =
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = (200..299).toList())),
+                ignoreAmplitudeRequests = true,
+            )
         listOf("https://api.example.com/test", "https://api.example.com/test/123").urlsToHosts()
             .forEach { assertTrue(options.captureRules.matches(it, 200)) }
         listOf("https://other.example.com", "https://api.different.com").urlsToHosts()
@@ -86,10 +97,11 @@ class NetworkTrackingOptionsTest {
 
     @Test
     fun `should ignore hosts`() {
-        val options = NetworkTrackingOptions(
-            captureRules = listOf(CaptureRule(hosts = listOf("*"))),
-            ignoreHosts = listOf("exact.ignore.com", "*.wildcard.ignore.com"),
-        )
+        val options =
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(hosts = listOf("*"))),
+                ignoreHosts = listOf("exact.ignore.com", "*.wildcard.ignore.com"),
+            )
         assertTrue(options.shouldIgnore("exact.ignore.com"))
         assertTrue(options.shouldIgnore("test.wildcard.ignore.com"))
         assertFalse(options.shouldIgnore("not.ignored.com"))
@@ -112,17 +124,24 @@ class NetworkTrackingOptionsTest {
 
     @Test
     fun `multiple capture rules with last matching rule precedence`() {
-        val options = NetworkTrackingOptions(captureRules = listOf(
-            CaptureRule(hosts = listOf("*.example.com"), statusCodeRange = (200..299).toList()),
-            CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = (500..599).toList()),
-        ))
+        val options =
+            NetworkTrackingOptions(
+                captureRules =
+                    listOf(
+                        CaptureRule(hosts = listOf("*.example.com"), statusCodeRange = (200..299).toList()),
+                        CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = (500..599).toList()),
+                    ),
+            )
         assertTrue(options.captureRules.matches("api.example.com", 500))
         assertFalse(options.captureRules.matches("api.example.com", 200))
     }
 
     @Test
     fun `non-contiguous status code ranges`() {
-        val options = NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = listOf(404, 200, 500))))
+        val options =
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(hosts = listOf("api.example.com"), statusCodeRange = listOf(404, 200, 500))),
+            )
         assertTrue(options.captureRules.matches("api.example.com", 200))
         assertTrue(options.captureRules.matches("api.example.com", 404))
         assertFalse(options.captureRules.matches("api.example.com", 300))
@@ -130,9 +149,16 @@ class NetworkTrackingOptionsTest {
 
     @Test
     fun `host matcher edge cases`() {
-        val options = NetworkTrackingOptions(captureRules = listOf(
-            CaptureRule(hosts = listOf("*.sub.*.example.com", "TEST.EXAMPLE.COM", "special-chars.example.com"), statusCodeRange = (200..599).toList()),
-        ))
+        val options =
+            NetworkTrackingOptions(
+                captureRules =
+                    listOf(
+                        CaptureRule(
+                            hosts = listOf("*.sub.*.example.com", "TEST.EXAMPLE.COM", "special-chars.example.com"),
+                            statusCodeRange = (200..599).toList(),
+                        ),
+                    ),
+            )
         assertTrue(options.captureRules.matches("test.sub.domain.example.com", 200))
         assertTrue(options.captureRules.matches("test.example.com", 200))
         assertTrue(options.captureRules.matches("special-chars.example.com", 200))
@@ -145,7 +171,8 @@ class NetworkTrackingOptionsTest {
     }
 
     @Test fun `URL pattern regex matching`() {
-        val rule = CaptureRule(urls = listOf(URLPattern.Regex("https://api\\.example\\.com/v[0-9]+/.*")), statusCodeRange = (200..299).toList())
+        val rule =
+            CaptureRule(urls = listOf(URLPattern.Regex("https://api\\.example\\.com/v[0-9]+/.*")), statusCodeRange = (200..299).toList())
         assertTrue(rule.matchesRequest("api.example.com", "https://api.example.com/v1/users", "GET"))
         assertFalse(rule.matchesRequest("api.example.com", "https://other.com/v1/users", "GET"))
     }
@@ -171,7 +198,8 @@ class NetworkTrackingOptionsTest {
     @Test fun `findMatchingRule returns rule with config`() {
         val ch = CaptureHeader(allowlist = listOf("ct"), captureSafeHeaders = false)
         val cb = CaptureBody(allowlist = listOf("user/name"))
-        val rules = listOf(CaptureRule(hosts = listOf("e.com"), statusCodeRange = (200..299).toList(), requestHeaders = ch, requestBody = cb))
+        val rules =
+            listOf(CaptureRule(hosts = listOf("e.com"), statusCodeRange = (200..299).toList(), requestHeaders = ch, requestBody = cb))
         val m = rules.findMatchingRule("e.com", "https://e.com/t", "GET", 200)
         assertNotNull(m)
         assertEquals(ch, m!!.requestHeaders)

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -5,9 +5,13 @@ import com.amplitude.core.Amplitude
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_COMPLETION_TIME
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_DURATION
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_ERROR_MESSAGE
+import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_REQUEST_BODY
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_REQUEST_BODY_SIZE
+import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_REQUEST_HEADERS
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_REQUEST_METHOD
+import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_RESPONSE_BODY
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_RESPONSE_BODY_SIZE
+import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_RESPONSE_HEADERS
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_START_TIME
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_STATUS_CODE
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL
@@ -15,6 +19,8 @@ import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL_FRAGMEN
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL_QUERY
 import com.amplitude.core.Constants.EventTypes.NETWORK_TRACKING
 import com.amplitude.core.events.BaseEvent
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
@@ -29,8 +35,10 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import okio.IOException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class NetworkTrackingPluginTest {
@@ -208,9 +216,10 @@ class NetworkTrackingPluginTest {
     }
 
     @Test
-    fun `amplitude request ignored`() {
+    fun `amplitude request ignored when ignoreAmplitudeRequests is true`() {
         val plugin =
             networkTrackingPlugin(
+                hosts = listOf("*"),
                 statusCodeRange = (200..299).toList(),
                 ignoreAmplitudeRequests = true,
             )
@@ -222,15 +231,24 @@ class NetworkTrackingPluginTest {
             ),
         )
 
+        // Also verify EU endpoint is ignored
+        plugin.intercept(
+            mockInterceptorChain(
+                statusCode = 200,
+                url = "https://api.eu.amplitude.com/test",
+            ),
+        )
+
         verify(exactly = 0) {
             mockAmplitude.track(any<BaseEvent>(), any())
         }
     }
 
     @Test
-    fun `amplitude request NOT ignored`() {
+    fun `amplitude request NOT ignored when ignoreAmplitudeRequests is false`() {
         val plugin =
             networkTrackingPlugin(
+                hosts = listOf("*"),
                 statusCodeRange = (200..299).toList(),
                 ignoreAmplitudeRequests = false,
             )
@@ -239,10 +257,11 @@ class NetworkTrackingPluginTest {
             mockInterceptorChain(
                 statusCode = 200,
                 url = "https://api.amplitude.com/test",
+                requestBodyString = "{\"event_type\":\"other_event\"}",
             ),
         )
 
-        verify {
+        verify(exactly = 1) {
             mockAmplitude.track(
                 eq(NETWORK_TRACKING),
                 withArg { eventProperties ->
@@ -251,7 +270,6 @@ class NetworkTrackingPluginTest {
                         eventProperties[NETWORK_TRACKING_URL],
                     )
                     assertEquals(200, eventProperties[NETWORK_TRACKING_STATUS_CODE])
-                    assertEquals(true, eventProperties[NETWORK_TRACKING_DURATION] != null)
                 },
             )
         }
@@ -388,7 +406,7 @@ class NetworkTrackingPluginTest {
                     assertNotNull(eventProperties[NETWORK_TRACKING_DURATION])
                     assertEquals(28L, eventProperties[NETWORK_TRACKING_REQUEST_BODY_SIZE])
                     assertEquals(2L, eventProperties[NETWORK_TRACKING_RESPONSE_BODY_SIZE])
-                    assertEquals(11, eventProperties.size)
+                    assertEquals(15, eventProperties.size)
                 },
             )
         }
@@ -477,54 +495,38 @@ class NetworkTrackingPluginTest {
     }
 
     @Test
-    fun `only capture amplitude API requests`() {
+    fun `network tracking events to amplitude host are NOT captured - recursion guard`() {
         val plugin =
             networkTrackingPlugin(
+                hosts = listOf("*"),
                 statusCodeRange = (200..299).toList(),
                 ignoreAmplitudeRequests = false,
             )
 
+        // Recursion guard only applies to amplitude hosts
         plugin.intercept(
             mockInterceptorChain(
                 statusCode = 200,
-                url = "https://test.amplitude.com/api",
-                requestBodyString = "{\"event_type\":\"other_event\"}",
-            ),
-        )
-
-        plugin.intercept(
-            mockInterceptorChain(
-                statusCode = 200,
-                url = "https://test.amplitude.com/api",
+                url = "https://api2.amplitude.com/2/httpapi",
                 requestBodyString = "{\"event_type\":\"$NETWORK_TRACKING\"}",
             ),
         )
 
-        // we're expecting only the API event to be tracked,
-        // as we want to skip our own network tracking events
-        verify(exactly = 1) {
-            mockAmplitude.track(
-                eq(NETWORK_TRACKING),
-                withArg { eventProperties ->
-                    assertEquals(
-                        "https://test.amplitude.com/api",
-                        eventProperties[NETWORK_TRACKING_URL],
-                    )
-                    assertEquals(200, eventProperties[NETWORK_TRACKING_STATUS_CODE])
-                    assertEquals(true, eventProperties[NETWORK_TRACKING_DURATION] != null)
-                },
-            )
+        verify(exactly = 0) {
+            mockAmplitude.track(any<BaseEvent>(), any())
         }
     }
 
     @Test
-    fun `network tracking events are NOT captured`() {
+    fun `network tracking event type in body on non-amplitude host is captured normally`() {
         val plugin =
             networkTrackingPlugin(
+                hosts = listOf("*"),
                 statusCodeRange = (200..299).toList(),
                 ignoreAmplitudeRequests = false,
             )
 
+        // Non-amplitude host: body is NOT scanned, so the event IS captured
         plugin.intercept(
             mockInterceptorChain(
                 statusCode = 200,
@@ -533,16 +535,11 @@ class NetworkTrackingPluginTest {
             ),
         )
 
-        verify(exactly = 0) {
+        verify(exactly = 1) {
             mockAmplitude.track(
                 eq(NETWORK_TRACKING),
                 withArg { eventProperties ->
-                    assertEquals(
-                        "https://api.example.com/test",
-                        eventProperties[NETWORK_TRACKING_URL],
-                    )
-                    assertEquals(200, eventProperties[NETWORK_TRACKING_STATUS_CODE])
-                    assertEquals(true, eventProperties[NETWORK_TRACKING_DURATION] != null)
+                    assertEquals("https://api.example.com/test", eventProperties[NETWORK_TRACKING_URL])
                 },
             )
         }
@@ -643,29 +640,183 @@ class NetworkTrackingPluginTest {
         }
     }
 
+    // --- Header and Body Capture Tests ---
+
+    @Test
+    fun `capture request and response headers`() {
+        val captureHeader = CaptureHeader(
+            allowlist = listOf("x-custom"),
+            captureSafeHeaders = true,
+        )
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(
+                captureRules = listOf(
+                    CaptureRule(
+                        hosts = listOf("example.com"),
+                        statusCodeRange = (200..299).toList(),
+                        requestHeaders = captureHeader,
+                        responseHeaders = captureHeader,
+                    ),
+                ),
+                ignoreAmplitudeRequests = false,
+            ),
+        ).apply { amplitude = mockAmplitude }
+
+        plugin.intercept(
+            mockInterceptorChain(
+                statusCode = 200,
+                requestHeaders = mapOf("X-Custom" to "req-value", "Content-Type" to "application/json", "Authorization" to "Bearer token"),
+                responseHeaders = mapOf("X-Custom" to "resp-value", "Cache-Control" to "no-cache", "Cookie" to "session=abc"),
+            ),
+        )
+
+        verify {
+            mockAmplitude.track(
+                eq(NETWORK_TRACKING),
+                withArg { eventProperties ->
+                    @Suppress("UNCHECKED_CAST")
+                    val reqHeaders = eventProperties[NETWORK_TRACKING_REQUEST_HEADERS] as Map<String, String>
+                    assertEquals("req-value", reqHeaders["X-Custom"])
+                    assertEquals("application/json", reqHeaders["Content-Type"])
+                    assertFalse(reqHeaders.containsKey("Authorization")) // blocked
+
+                    @Suppress("UNCHECKED_CAST")
+                    val respHeaders = eventProperties[NETWORK_TRACKING_RESPONSE_HEADERS] as Map<String, String>
+                    assertEquals("resp-value", respHeaders["X-Custom"])
+                    assertEquals("no-cache", respHeaders["Cache-Control"])
+                    assertFalse(respHeaders.containsKey("Cookie")) // blocked
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `capture request and response body`() {
+        val captureBody = CaptureBody(allowlist = listOf("user/name"))
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(
+                captureRules = listOf(
+                    CaptureRule(
+                        hosts = listOf("example.com"),
+                        statusCodeRange = (200..299).toList(),
+                        requestBody = captureBody,
+                        responseBody = captureBody,
+                    ),
+                ),
+                ignoreAmplitudeRequests = false,
+            ),
+        ).apply { amplitude = mockAmplitude }
+
+        plugin.intercept(
+            mockInterceptorChain(
+                statusCode = 200,
+                requestBodyString = """{"user":{"name":"John","password":"secret"}}""",
+                responseBodyString = """{"user":{"name":"Jane","email":"jane@example.com"}}""",
+            ),
+        )
+
+        verify {
+            mockAmplitude.track(
+                eq(NETWORK_TRACKING),
+                withArg { eventProperties ->
+                    val reqBody = eventProperties[NETWORK_TRACKING_REQUEST_BODY] as String
+                    assertTrue(reqBody.contains("John"))
+                    assertFalse(reqBody.contains("secret"))
+
+                    val respBody = eventProperties[NETWORK_TRACKING_RESPONSE_BODY] as String
+                    assertTrue(respBody.contains("Jane"))
+                    assertFalse(respBody.contains("jane@example.com"))
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `no header body config - same 11 properties`() {
+        val plugin =
+            networkTrackingPlugin(
+                statusCodeRange = (200..299).toList(),
+                ignoreAmplitudeRequests = false,
+            )
+
+        plugin.intercept(mockInterceptorChain(200))
+
+        verify {
+            mockAmplitude.track(
+                eq(NETWORK_TRACKING),
+                withArg { eventProperties ->
+                    assertEquals(15, eventProperties.size)
+                    assertNull(eventProperties[NETWORK_TRACKING_REQUEST_HEADERS])
+                    assertNull(eventProperties[NETWORK_TRACKING_RESPONSE_HEADERS])
+                    assertNull(eventProperties[NETWORK_TRACKING_REQUEST_BODY])
+                    assertNull(eventProperties[NETWORK_TRACKING_RESPONSE_BODY])
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `non-JSON body - body property absent`() {
+        val captureBody = CaptureBody(allowlist = listOf("key"))
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(
+                captureRules = listOf(
+                    CaptureRule(
+                        hosts = listOf("example.com"),
+                        statusCodeRange = (200..299).toList(),
+                        requestBody = captureBody,
+                        responseBody = captureBody,
+                    ),
+                ),
+                ignoreAmplitudeRequests = false,
+            ),
+        ).apply { amplitude = mockAmplitude }
+
+        plugin.intercept(
+            mockInterceptorChain(
+                statusCode = 200,
+                requestBodyString = "not json content",
+                responseBodyString = "also not json",
+            ),
+        )
+
+        verify {
+            mockAmplitude.track(
+                eq(NETWORK_TRACKING),
+                withArg { eventProperties ->
+                    assertNull(eventProperties[NETWORK_TRACKING_REQUEST_BODY])
+                    assertNull(eventProperties[NETWORK_TRACKING_RESPONSE_BODY])
+                },
+            )
+        }
+    }
+
     private fun mockInterceptorChain(
         statusCode: Int,
         exception: IOException? = null,
         url: String = "https://example.com/test",
         requestBodyString: String = "{}",
+        responseBodyString: String = "{}",
+        requestHeaders: Map<String, String> = emptyMap(),
+        responseHeaders: Map<String, String> = emptyMap(),
     ): Chain {
         val requestBody = requestBodyString.toRequestBody("application/json".toMediaType())
-        val mockRequest =
-            Builder()
-                .post(requestBody)
-                .url(url)
-                .build()
+        val requestBuilder = Builder()
+            .post(requestBody)
+            .url(url)
+        requestHeaders.forEach { (key, value) -> requestBuilder.addHeader(key, value) }
+        val mockRequest = requestBuilder.build()
 
         val statusMessage = if (statusCode in 200..299) "OK" else "Error"
-        val emptyResponseBody = "{}".toResponseBody("application/json".toMediaType())
-        val mockResponse =
-            Response.Builder()
-                .request(mockRequest)
-                .protocol(HTTP_1_1)
-                .body(emptyResponseBody)
-                .code(statusCode)
-                .message(statusMessage)
-                .build()
+        val mockResponseBody = responseBodyString.toResponseBody("application/json".toMediaType())
+        val responseBuilder = Response.Builder()
+            .request(mockRequest)
+            .protocol(HTTP_1_1)
+            .body(mockResponseBody)
+            .code(statusCode)
+            .message(statusMessage)
+        responseHeaders.forEach { (key, value) -> responseBuilder.addHeader(key, value) }
+        val mockResponse = responseBuilder.build()
 
         val mockChain =
             mockk<Chain> {

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -1094,4 +1094,39 @@ class NetworkTrackingPluginTest {
         assertEquals(localRules.first().hosts, opts.captureRules.first().hosts)
         assertEquals(listOf("other.com"), opts.ignoreHosts)
     }
+
+    @Test
+    fun `malformed remote config falls back to local options`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                    ignoreAmplitudeRequests = false,
+                ),
+            )
+        val amplitude = mockAndroidAmplitude(remoteConfig)
+        plugin.setup(amplitude)
+        plugin.amplitude = amplitude
+
+        // Remote config sends a rule with empty hosts and urls — would fail require() check
+        remoteConfig.emit(
+            mapOf(
+                "autocapture" to
+                    mapOf(
+                        "networkTracking" to
+                            mapOf(
+                                "captureRules" to
+                                    listOf(
+                                        mapOf("statusCodeRange" to "200-299"),
+                                    ),
+                            ),
+                    ),
+            ),
+        )
+
+        // Should fall back to local options, not crash
+        plugin.intercept(mockInterceptorChain(200))
+        verify(exactly = 1) { amplitude.track(eq(NETWORK_TRACKING), any()) }
+    }
 }

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -681,13 +681,13 @@ class NetworkTrackingPluginTest {
                 eq(NETWORK_TRACKING),
                 withArg { eventProperties ->
                     @Suppress("UNCHECKED_CAST")
-                    val reqHeaders = eventProperties[NETWORK_TRACKING_REQUEST_HEADERS] as Map<String, String>
+                    val reqHeaders = eventProperties[NETWORK_TRACKING_REQUEST_HEADERS] as Map<String, Any>
                     assertEquals("req-value", reqHeaders["X-Custom"])
                     assertEquals("application/json", reqHeaders["Content-Type"])
                     assertFalse(reqHeaders.containsKey("Authorization")) // blocked
 
                     @Suppress("UNCHECKED_CAST")
-                    val respHeaders = eventProperties[NETWORK_TRACKING_RESPONSE_HEADERS] as Map<String, String>
+                    val respHeaders = eventProperties[NETWORK_TRACKING_RESPONSE_HEADERS] as Map<String, Any>
                     assertEquals("resp-value", respHeaders["X-Custom"])
                     assertEquals("no-cache", respHeaders["Cache-Control"])
                     assertFalse(respHeaders.containsKey("Cookie")) // blocked

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -19,6 +19,8 @@ import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL_FRAGMEN
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_URL_QUERY
 import com.amplitude.core.Constants.EventTypes.NETWORK_TRACKING
 import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.remoteconfig.ConfigMap
+import com.amplitude.core.remoteconfig.RemoteConfigClient
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
 import io.mockk.confirmVerified
@@ -828,5 +830,238 @@ class NetworkTrackingPluginTest {
                 }
             }
         return mockChain
+    }
+
+    // --- Remote Config Tests ---
+
+    private class TestRemoteConfigClient : RemoteConfigClient {
+        val callbacks = mutableListOf<RemoteConfigClient.RemoteConfigCallback>()
+
+        override fun subscribe(key: RemoteConfigClient.Key, callback: RemoteConfigClient.RemoteConfigCallback) {
+            if (key == RemoteConfigClient.Key.ANALYTICS_SDK) callbacks.add(callback)
+        }
+
+        override fun updateConfigs() {}
+
+        fun emit(config: ConfigMap) {
+            callbacks.forEach { it.onUpdate(config, RemoteConfigClient.Source.REMOTE, System.currentTimeMillis()) }
+        }
+    }
+
+    private fun mockAndroidAmplitude(
+        remoteConfigClient: RemoteConfigClient,
+        enableAutocaptureRemoteConfig: Boolean = true,
+    ): com.amplitude.android.Amplitude {
+        val mockConfig = mockk<com.amplitude.android.Configuration>(relaxed = true)
+        every { mockConfig.enableAutocaptureRemoteConfig } returns enableAutocaptureRemoteConfig
+        val amplitude = mockk<com.amplitude.android.Amplitude>(relaxed = true)
+        every { amplitude.configuration } returns mockConfig
+        every { amplitude.remoteConfigClient } returns remoteConfigClient
+        return amplitude
+    }
+
+    private fun networkTrackingConfig(vararg entries: Pair<String, Any?>): ConfigMap {
+        return mapOf("autocapture" to mapOf("networkTracking" to mapOf(*entries)))
+    }
+
+    @Test
+    fun `setup subscribes to remote config when both flags true`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = true),
+        )
+        plugin.setup(mockAndroidAmplitude(remoteConfig, enableAutocaptureRemoteConfig = true))
+
+        assertEquals(1, remoteConfig.callbacks.size)
+    }
+
+    @Test
+    fun `setup does NOT subscribe when enableAutocaptureRemoteConfig is false`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = true),
+        )
+        plugin.setup(mockAndroidAmplitude(remoteConfig, enableAutocaptureRemoteConfig = false))
+
+        assertEquals(0, remoteConfig.callbacks.size)
+    }
+
+    @Test
+    fun `setup does NOT subscribe when enableRemoteConfig option is false`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = false),
+        )
+        plugin.setup(mockAndroidAmplitude(remoteConfig, enableAutocaptureRemoteConfig = true))
+
+        assertEquals(0, remoteConfig.callbacks.size)
+    }
+
+    @Test
+    fun `setup with core Amplitude skips subscription`() {
+        val coreAmplitude = mockk<Amplitude>(relaxed = true)
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = true),
+        )
+        // Should not crash — setup returns early when amplitude is not android.Amplitude
+        plugin.setup(coreAmplitude)
+    }
+
+    @Test
+    fun `remote config disables tracking`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                enabled = true,
+            ),
+        )
+        val amplitude = mockAndroidAmplitude(remoteConfig)
+        plugin.setup(amplitude)
+        plugin.amplitude = amplitude
+
+        // Disable via remote config
+        remoteConfig.emit(networkTrackingConfig("enabled" to false))
+
+        plugin.intercept(mockInterceptorChain(200))
+
+        verify(exactly = 0) { amplitude.track(any<BaseEvent>(), any()) }
+    }
+
+    @Test
+    fun `remote config re-enables tracking`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                enabled = false, // initially disabled
+            ),
+        )
+        val amplitude = mockAndroidAmplitude(remoteConfig)
+        plugin.setup(amplitude)
+        plugin.amplitude = amplitude
+
+        // Enable via remote config
+        remoteConfig.emit(networkTrackingConfig("enabled" to true))
+
+        plugin.intercept(mockInterceptorChain(200))
+
+        verify(exactly = 1) { amplitude.track(eq(NETWORK_TRACKING), any()) }
+    }
+
+    @Test
+    fun `remote config updates ignoreHosts`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                ignoreHosts = emptyList(),
+                ignoreAmplitudeRequests = false,
+            ),
+        )
+        val amplitude = mockAndroidAmplitude(remoteConfig)
+        plugin.setup(amplitude)
+        plugin.amplitude = amplitude
+
+        // Add ignore host via remote config
+        remoteConfig.emit(networkTrackingConfig("ignoreHosts" to listOf("example.com")))
+
+        plugin.intercept(mockInterceptorChain(200, url = "https://example.com/test"))
+
+        verify(exactly = 0) { amplitude.track(any<BaseEvent>(), any()) }
+    }
+
+    @Test
+    fun `remote config updates captureRules`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (500..599).toList())),
+                ignoreAmplitudeRequests = false,
+            ),
+        )
+        val amplitude = mockAndroidAmplitude(remoteConfig)
+        plugin.setup(amplitude)
+        plugin.amplitude = amplitude
+
+        // Override rules to capture 200s instead
+        remoteConfig.emit(
+            mapOf(
+                "autocapture" to mapOf(
+                    "networkTracking" to mapOf(
+                        "captureRules" to listOf(
+                            mapOf("hosts" to listOf("*"), "statusCodeRange" to "200-299"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        plugin.intercept(mockInterceptorChain(200))
+        verify(exactly = 1) { amplitude.track(eq(NETWORK_TRACKING), any()) }
+    }
+
+    @Test
+    fun `missing networkTracking section resets to local config`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(
+                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                enabled = true,
+                ignoreAmplitudeRequests = false,
+            ),
+        )
+        val amplitude = mockAndroidAmplitude(remoteConfig)
+        plugin.setup(amplitude)
+        plugin.amplitude = amplitude
+
+        // First: disable via remote config
+        remoteConfig.emit(networkTrackingConfig("enabled" to false))
+        plugin.intercept(mockInterceptorChain(200))
+        verify(exactly = 0) { amplitude.track(any<BaseEvent>(), any()) }
+
+        // Then: emit config without networkTracking section → should reset to local (enabled=true)
+        remoteConfig.emit(mapOf("autocapture" to mapOf("sessions" to true)))
+
+        plugin.intercept(mockInterceptorChain(200))
+        verify(exactly = 1) { amplitude.track(eq(NETWORK_TRACKING), any()) }
+    }
+
+    @Test
+    fun `partial remote config uses fresh overlay on local`() {
+        val remoteConfig = TestRemoteConfigClient()
+        val localRules = listOf(CaptureRule(hosts = listOf("local.com"), statusCodeRange = (200..299).toList()))
+        val plugin = NetworkTrackingPlugin(
+            NetworkTrackingOptions(
+                captureRules = localRules,
+                ignoreHosts = listOf("local-ignore.com"),
+                ignoreAmplitudeRequests = false,
+            ),
+        )
+        val amplitude = mockAndroidAmplitude(remoteConfig)
+        plugin.setup(amplitude)
+        plugin.amplitude = amplitude
+
+        // First remote config: override ignoreHosts and add captureRules
+        remoteConfig.emit(
+            mapOf(
+                "autocapture" to mapOf(
+                    "networkTracking" to mapOf(
+                        "ignoreHosts" to listOf("remote-ignore.com"),
+                        "captureRules" to listOf(
+                            mapOf("hosts" to listOf("*"), "statusCodeRange" to "200-299"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        // Second remote config: only set ignoreHosts — captureRules should fall back to LOCAL, not previous remote
+        remoteConfig.emit(networkTrackingConfig("ignoreHosts" to listOf("other.com")))
+
+        // local.com should match (local rules restored), not "*" from previous remote
+        val opts = plugin.currentOptions
+        assertEquals(localRules.first().hosts, opts.captureRules.first().hosts)
+        assertEquals(listOf("other.com"), opts.ignoreHosts)
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -1,5 +1,7 @@
 package com.amplitude.android.network
 
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_COMPLETION_TIME
@@ -21,8 +23,6 @@ import com.amplitude.core.Constants.EventTypes.NETWORK_TRACKING
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.remoteconfig.ConfigMap
 import com.amplitude.core.remoteconfig.RemoteConfigClient
-import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody
-import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
@@ -646,23 +646,26 @@ class NetworkTrackingPluginTest {
 
     @Test
     fun `capture request and response headers`() {
-        val captureHeader = CaptureHeader(
-            allowlist = listOf("x-custom"),
-            captureSafeHeaders = true,
-        )
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(
-                captureRules = listOf(
-                    CaptureRule(
-                        hosts = listOf("example.com"),
-                        statusCodeRange = (200..299).toList(),
-                        requestHeaders = captureHeader,
-                        responseHeaders = captureHeader,
-                    ),
+        val captureHeader =
+            CaptureHeader(
+                allowlist = listOf("x-custom"),
+                captureSafeHeaders = true,
+            )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules =
+                        listOf(
+                            CaptureRule(
+                                hosts = listOf("example.com"),
+                                statusCodeRange = (200..299).toList(),
+                                requestHeaders = captureHeader,
+                                responseHeaders = captureHeader,
+                            ),
+                        ),
+                    ignoreAmplitudeRequests = false,
                 ),
-                ignoreAmplitudeRequests = false,
-            ),
-        ).apply { amplitude = mockAmplitude }
+            ).apply { amplitude = mockAmplitude }
 
         plugin.intercept(
             mockInterceptorChain(
@@ -695,19 +698,21 @@ class NetworkTrackingPluginTest {
     @Test
     fun `capture request and response body`() {
         val captureBody = CaptureBody(allowlist = listOf("user/name"))
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(
-                captureRules = listOf(
-                    CaptureRule(
-                        hosts = listOf("example.com"),
-                        statusCodeRange = (200..299).toList(),
-                        requestBody = captureBody,
-                        responseBody = captureBody,
-                    ),
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules =
+                        listOf(
+                            CaptureRule(
+                                hosts = listOf("example.com"),
+                                statusCodeRange = (200..299).toList(),
+                                requestBody = captureBody,
+                                responseBody = captureBody,
+                            ),
+                        ),
+                    ignoreAmplitudeRequests = false,
                 ),
-                ignoreAmplitudeRequests = false,
-            ),
-        ).apply { amplitude = mockAmplitude }
+            ).apply { amplitude = mockAmplitude }
 
         plugin.intercept(
             mockInterceptorChain(
@@ -760,19 +765,21 @@ class NetworkTrackingPluginTest {
     @Test
     fun `non-JSON body - body property absent`() {
         val captureBody = CaptureBody(allowlist = listOf("key"))
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(
-                captureRules = listOf(
-                    CaptureRule(
-                        hosts = listOf("example.com"),
-                        statusCodeRange = (200..299).toList(),
-                        requestBody = captureBody,
-                        responseBody = captureBody,
-                    ),
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules =
+                        listOf(
+                            CaptureRule(
+                                hosts = listOf("example.com"),
+                                statusCodeRange = (200..299).toList(),
+                                requestBody = captureBody,
+                                responseBody = captureBody,
+                            ),
+                        ),
+                    ignoreAmplitudeRequests = false,
                 ),
-                ignoreAmplitudeRequests = false,
-            ),
-        ).apply { amplitude = mockAmplitude }
+            ).apply { amplitude = mockAmplitude }
 
         plugin.intercept(
             mockInterceptorChain(
@@ -803,20 +810,22 @@ class NetworkTrackingPluginTest {
         responseHeaders: Map<String, String> = emptyMap(),
     ): Chain {
         val requestBody = requestBodyString.toRequestBody("application/json".toMediaType())
-        val requestBuilder = Builder()
-            .post(requestBody)
-            .url(url)
+        val requestBuilder =
+            Builder()
+                .post(requestBody)
+                .url(url)
         requestHeaders.forEach { (key, value) -> requestBuilder.addHeader(key, value) }
         val mockRequest = requestBuilder.build()
 
         val statusMessage = if (statusCode in 200..299) "OK" else "Error"
         val mockResponseBody = responseBodyString.toResponseBody("application/json".toMediaType())
-        val responseBuilder = Response.Builder()
-            .request(mockRequest)
-            .protocol(HTTP_1_1)
-            .body(mockResponseBody)
-            .code(statusCode)
-            .message(statusMessage)
+        val responseBuilder =
+            Response.Builder()
+                .request(mockRequest)
+                .protocol(HTTP_1_1)
+                .body(mockResponseBody)
+                .code(statusCode)
+                .message(statusMessage)
         responseHeaders.forEach { (key, value) -> responseBuilder.addHeader(key, value) }
         val mockResponse = responseBuilder.build()
 
@@ -837,7 +846,10 @@ class NetworkTrackingPluginTest {
     private class TestRemoteConfigClient : RemoteConfigClient {
         val callbacks = mutableListOf<RemoteConfigClient.RemoteConfigCallback>()
 
-        override fun subscribe(key: RemoteConfigClient.Key, callback: RemoteConfigClient.RemoteConfigCallback) {
+        override fun subscribe(
+            key: RemoteConfigClient.Key,
+            callback: RemoteConfigClient.RemoteConfigCallback,
+        ) {
             if (key == RemoteConfigClient.Key.ANALYTICS_SDK) callbacks.add(callback)
         }
 
@@ -867,9 +879,10 @@ class NetworkTrackingPluginTest {
     @Test
     fun `setup subscribes to remote config when both flags true`() {
         val remoteConfig = TestRemoteConfigClient()
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = true),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = true),
+            )
         plugin.setup(mockAndroidAmplitude(remoteConfig, enableAutocaptureRemoteConfig = true))
 
         assertEquals(1, remoteConfig.callbacks.size)
@@ -878,9 +891,10 @@ class NetworkTrackingPluginTest {
     @Test
     fun `setup does NOT subscribe when enableAutocaptureRemoteConfig is false`() {
         val remoteConfig = TestRemoteConfigClient()
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = true),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = true),
+            )
         plugin.setup(mockAndroidAmplitude(remoteConfig, enableAutocaptureRemoteConfig = false))
 
         assertEquals(0, remoteConfig.callbacks.size)
@@ -889,9 +903,10 @@ class NetworkTrackingPluginTest {
     @Test
     fun `setup does NOT subscribe when enableRemoteConfig option is false`() {
         val remoteConfig = TestRemoteConfigClient()
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = false),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = false),
+            )
         plugin.setup(mockAndroidAmplitude(remoteConfig, enableAutocaptureRemoteConfig = true))
 
         assertEquals(0, remoteConfig.callbacks.size)
@@ -900,9 +915,10 @@ class NetworkTrackingPluginTest {
     @Test
     fun `setup with core Amplitude skips subscription`() {
         val coreAmplitude = mockk<Amplitude>(relaxed = true)
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = true),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(captureRules = listOf(CaptureRule(hosts = listOf("*"))), enableRemoteConfig = true),
+            )
         // Should not crash — setup returns early when amplitude is not android.Amplitude
         plugin.setup(coreAmplitude)
     }
@@ -910,12 +926,13 @@ class NetworkTrackingPluginTest {
     @Test
     fun `remote config disables tracking`() {
         val remoteConfig = TestRemoteConfigClient()
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(
-                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
-                enabled = true,
-            ),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                    enabled = true,
+                ),
+            )
         val amplitude = mockAndroidAmplitude(remoteConfig)
         plugin.setup(amplitude)
         plugin.amplitude = amplitude
@@ -931,12 +948,14 @@ class NetworkTrackingPluginTest {
     @Test
     fun `remote config re-enables tracking`() {
         val remoteConfig = TestRemoteConfigClient()
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(
-                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
-                enabled = false, // initially disabled
-            ),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                    // Initially disabled
+                    enabled = false,
+                ),
+            )
         val amplitude = mockAndroidAmplitude(remoteConfig)
         plugin.setup(amplitude)
         plugin.amplitude = amplitude
@@ -952,13 +971,14 @@ class NetworkTrackingPluginTest {
     @Test
     fun `remote config updates ignoreHosts`() {
         val remoteConfig = TestRemoteConfigClient()
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(
-                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
-                ignoreHosts = emptyList(),
-                ignoreAmplitudeRequests = false,
-            ),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                    ignoreHosts = emptyList(),
+                    ignoreAmplitudeRequests = false,
+                ),
+            )
         val amplitude = mockAndroidAmplitude(remoteConfig)
         plugin.setup(amplitude)
         plugin.amplitude = amplitude
@@ -974,12 +994,13 @@ class NetworkTrackingPluginTest {
     @Test
     fun `remote config updates captureRules`() {
         val remoteConfig = TestRemoteConfigClient()
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(
-                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (500..599).toList())),
-                ignoreAmplitudeRequests = false,
-            ),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (500..599).toList())),
+                    ignoreAmplitudeRequests = false,
+                ),
+            )
         val amplitude = mockAndroidAmplitude(remoteConfig)
         plugin.setup(amplitude)
         plugin.amplitude = amplitude
@@ -987,13 +1008,16 @@ class NetworkTrackingPluginTest {
         // Override rules to capture 200s instead
         remoteConfig.emit(
             mapOf(
-                "autocapture" to mapOf(
-                    "networkTracking" to mapOf(
-                        "captureRules" to listOf(
-                            mapOf("hosts" to listOf("*"), "statusCodeRange" to "200-299"),
-                        ),
+                "autocapture" to
+                    mapOf(
+                        "networkTracking" to
+                            mapOf(
+                                "captureRules" to
+                                    listOf(
+                                        mapOf("hosts" to listOf("*"), "statusCodeRange" to "200-299"),
+                                    ),
+                            ),
                     ),
-                ),
             ),
         )
 
@@ -1004,13 +1028,14 @@ class NetworkTrackingPluginTest {
     @Test
     fun `missing networkTracking section resets to local config`() {
         val remoteConfig = TestRemoteConfigClient()
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(
-                captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
-                enabled = true,
-                ignoreAmplitudeRequests = false,
-            ),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules = listOf(CaptureRule(hosts = listOf("*"), statusCodeRange = (200..299).toList())),
+                    enabled = true,
+                    ignoreAmplitudeRequests = false,
+                ),
+            )
         val amplitude = mockAndroidAmplitude(remoteConfig)
         plugin.setup(amplitude)
         plugin.amplitude = amplitude
@@ -1031,13 +1056,14 @@ class NetworkTrackingPluginTest {
     fun `partial remote config uses fresh overlay on local`() {
         val remoteConfig = TestRemoteConfigClient()
         val localRules = listOf(CaptureRule(hosts = listOf("local.com"), statusCodeRange = (200..299).toList()))
-        val plugin = NetworkTrackingPlugin(
-            NetworkTrackingOptions(
-                captureRules = localRules,
-                ignoreHosts = listOf("local-ignore.com"),
-                ignoreAmplitudeRequests = false,
-            ),
-        )
+        val plugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules = localRules,
+                    ignoreHosts = listOf("local-ignore.com"),
+                    ignoreAmplitudeRequests = false,
+                ),
+            )
         val amplitude = mockAndroidAmplitude(remoteConfig)
         plugin.setup(amplitude)
         plugin.amplitude = amplitude
@@ -1045,14 +1071,17 @@ class NetworkTrackingPluginTest {
         // First remote config: override ignoreHosts and add captureRules
         remoteConfig.emit(
             mapOf(
-                "autocapture" to mapOf(
-                    "networkTracking" to mapOf(
-                        "ignoreHosts" to listOf("remote-ignore.com"),
-                        "captureRules" to listOf(
-                            mapOf("hosts" to listOf("*"), "statusCodeRange" to "200-299"),
-                        ),
+                "autocapture" to
+                    mapOf(
+                        "networkTracking" to
+                            mapOf(
+                                "ignoreHosts" to listOf("remote-ignore.com"),
+                                "captureRules" to
+                                    listOf(
+                                        mapOf("hosts" to listOf("*"), "statusCodeRange" to "200-299"),
+                                    ),
+                            ),
                     ),
-                ),
             ),
         )
 

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -3,6 +3,7 @@ package com.amplitude.android.network
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
+import com.amplitude.android.network.NetworkTrackingOptions.URLPattern
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_COMPLETION_TIME
 import com.amplitude.core.Constants.EventProperties.NETWORK_TRACKING_DURATION
@@ -657,7 +658,7 @@ class NetworkTrackingPluginTest {
                     captureRules =
                         listOf(
                             CaptureRule(
-                                hosts = listOf("example.com"),
+                                urls = listOf(URLPattern.Regex(".*example\\.com.*")),
                                 statusCodeRange = (200..299).toList(),
                                 requestHeaders = captureHeader,
                                 responseHeaders = captureHeader,
@@ -704,7 +705,7 @@ class NetworkTrackingPluginTest {
                     captureRules =
                         listOf(
                             CaptureRule(
-                                hosts = listOf("example.com"),
+                                urls = listOf(URLPattern.Regex(".*example\\.com.*")),
                                 statusCodeRange = (200..299).toList(),
                                 requestBody = captureBody,
                                 responseBody = captureBody,
@@ -771,7 +772,7 @@ class NetworkTrackingPluginTest {
                     captureRules =
                         listOf(
                             CaptureRule(
-                                hosts = listOf("example.com"),
+                                urls = listOf(URLPattern.Regex(".*example\\.com.*")),
                                 statusCodeRange = (200..299).toList(),
                                 requestBody = captureBody,
                                 responseBody = captureBody,

--- a/android/src/test/kotlin/com/amplitude/android/utilities/ObjectFilterTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/ObjectFilterTest.kt
@@ -1,0 +1,537 @@
+package com.amplitude.android.utilities
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ObjectFilterMatchTests {
+    @Test
+    fun `matches exact path`() {
+        val filter = ObjectFilter()
+        assertTrue(filter.matches(listOf("user", "name"), listOf("user", "name")))
+        assertTrue(filter.matches(listOf("user", "metadata", "item1"), listOf("user", "metadata", "item1")))
+        assertFalse(filter.matches(listOf("user", "name"), listOf("user", "email")))
+        assertFalse(filter.matches(listOf("user", "name"), listOf("product", "name")))
+        assertFalse(filter.matches(listOf("user"), listOf("user", "name")))
+        assertFalse(filter.matches(listOf("user", "name"), listOf("user")))
+    }
+
+    @Test
+    fun `matches single wildcard`() {
+        val filter = ObjectFilter()
+        assertTrue(filter.matches(listOf("user", "name"), listOf("user", "*")))
+        assertTrue(filter.matches(listOf("user", "email"), listOf("user", "*")))
+        assertTrue(filter.matches(listOf("user", "metadata"), listOf("user", "*")))
+        assertFalse(filter.matches(listOf("user", "metadata", "item1"), listOf("user", "*")))
+        assertFalse(filter.matches(listOf("user"), listOf("user", "*")))
+
+        // * at the beginning
+        assertTrue(filter.matches(listOf("user", "name"), listOf("*", "name")))
+        assertTrue(filter.matches(listOf("product", "name"), listOf("*", "name")))
+        assertFalse(filter.matches(listOf("user", "metadata", "name"), listOf("*", "name")))
+
+        // * in the middle
+        assertTrue(filter.matches(listOf("user", "metadata", "item1"), listOf("user", "*", "item1")))
+        assertTrue(filter.matches(listOf("user", "settings", "item1"), listOf("user", "*", "item1")))
+        assertFalse(filter.matches(listOf("user", "item1"), listOf("user", "*", "item1")))
+
+        // Multiple * wildcards
+        assertTrue(filter.matches(listOf("user", "metadata", "item1"), listOf("*", "*", "item1")))
+        assertTrue(filter.matches(listOf("a", "b", "c"), listOf("*", "*", "*")))
+    }
+
+    @Test
+    fun `matches double wildcard`() {
+        val filter = ObjectFilter()
+        assertTrue(filter.matches(listOf("user"), listOf("user", "**")))
+        assertTrue(filter.matches(listOf("user", "name"), listOf("user", "**")))
+        assertTrue(filter.matches(listOf("user", "metadata", "item1"), listOf("user", "**")))
+        assertTrue(filter.matches(listOf("user", "metadata", "nested", "deep", "item"), listOf("user", "**")))
+
+        // ** at the beginning
+        assertTrue(filter.matches(listOf("user", "name"), listOf("**", "name")))
+        assertTrue(filter.matches(listOf("deep", "nested", "user", "name"), listOf("**", "name")))
+        assertTrue(filter.matches(listOf("name"), listOf("**", "name")))
+
+        // ** in the middle
+        assertTrue(filter.matches(listOf("user", "name"), listOf("user", "**", "name")))
+        assertTrue(filter.matches(listOf("user", "metadata", "nested", "name"), listOf("user", "**", "name")))
+
+        // ** at the end
+        assertTrue(filter.matches(listOf("user", "metadata"), listOf("**")))
+        assertTrue(filter.matches(listOf("a"), listOf("**")))
+        assertTrue(filter.matches(emptyList(), listOf("**")))
+    }
+
+    @Test
+    fun `matches array indexes`() {
+        val filter = ObjectFilter()
+        assertTrue(filter.matches(listOf("users", "0"), listOf("users", "0")))
+        assertTrue(filter.matches(listOf("users", "0", "name"), listOf("users", "0", "name")))
+        assertTrue(filter.matches(listOf("users", "0", "name"), listOf("users", "*", "name")))
+        assertTrue(filter.matches(listOf("users", "5", "metadata", "item"), listOf("users", "**", "item")))
+        assertFalse(filter.matches(listOf("users", "0"), listOf("users", "1")))
+        assertFalse(filter.matches(listOf("users", "abc"), listOf("users", "0")))
+    }
+
+    @Test
+    fun `matches complex wildcard combinations`() {
+        val filter = ObjectFilter()
+        assertTrue(filter.matches(listOf("user", "metadata", "nested", "item"), listOf("*", "**", "item")))
+        assertTrue(filter.matches(listOf("user", "item"), listOf("*", "**", "item")))
+        assertTrue(filter.matches(listOf("anything", "deep", "nested", "path", "item"), listOf("*", "**", "item")))
+
+        // ** followed by *
+        assertTrue(filter.matches(listOf("user", "metadata", "item1"), listOf("**", "*")))
+        assertTrue(filter.matches(listOf("item1"), listOf("**", "*")))
+        assertFalse(filter.matches(emptyList(), listOf("**", "*")))
+    }
+
+    @Test
+    fun `matches edge cases`() {
+        val filter = ObjectFilter()
+        assertTrue(filter.matches(emptyList(), emptyList()))
+        assertTrue(filter.matches(emptyList(), listOf("**")))
+        assertFalse(filter.matches(emptyList(), listOf("*")))
+        assertFalse(filter.matches(listOf("user"), emptyList()))
+
+        assertTrue(filter.matches(listOf("user"), listOf("user")))
+        assertTrue(filter.matches(listOf("user"), listOf("*")))
+        assertTrue(filter.matches(listOf("user"), listOf("**")))
+
+        assertTrue(filter.matches(listOf("0"), listOf("0")))
+        assertTrue(filter.matches(listOf("123"), listOf("*")))
+        assertTrue(filter.matches(listOf("0", "name"), listOf("*", "name")))
+    }
+
+    @Test
+    fun `matches combined wildcard patterns`() {
+        val filter = ObjectFilter()
+
+        // ** followed by *
+        assertTrue(filter.matches(listOf("a", "b"), listOf("**", "*")))
+        assertTrue(filter.matches(listOf("a", "b", "c", "d"), listOf("**", "*")))
+        assertTrue(filter.matches(listOf("x"), listOf("**", "*")))
+        assertFalse(filter.matches(emptyList(), listOf("**", "*")))
+
+        // * followed by **
+        assertTrue(filter.matches(listOf("user"), listOf("*", "**")))
+        assertTrue(filter.matches(listOf("user", "data"), listOf("*", "**")))
+        assertTrue(filter.matches(listOf("user", "data", "nested", "deep"), listOf("*", "**")))
+        assertFalse(filter.matches(emptyList(), listOf("*", "**")))
+
+        // ** with * in the middle
+        assertTrue(filter.matches(listOf("a", "b", "c", "d"), listOf("**", "*", "d")))
+        assertTrue(filter.matches(listOf("x", "y", "d"), listOf("**", "*", "d")))
+        assertTrue(filter.matches(listOf("c", "d"), listOf("**", "*", "d")))
+        assertFalse(filter.matches(listOf("d"), listOf("**", "*", "d")))
+
+        // * with ** in the middle
+        assertTrue(filter.matches(listOf("a", "b", "c"), listOf("*", "**", "c")))
+        assertTrue(filter.matches(listOf("x", "y", "z", "w", "c"), listOf("*", "**", "c")))
+        assertTrue(filter.matches(listOf("a", "c"), listOf("*", "**", "c")))
+        assertFalse(filter.matches(listOf("c"), listOf("*", "**", "c")))
+
+        // Multiple combinations
+        assertTrue(filter.matches(listOf("api", "v1", "users", "john", "profile"), listOf("*", "v1", "**", "profile")))
+        assertTrue(filter.matches(listOf("api", "v1", "profile"), listOf("*", "v1", "**", "profile")))
+        assertFalse(filter.matches(listOf("v1", "users", "profile"), listOf("*", "v1", "**", "profile")))
+    }
+
+    @Test
+    fun `matches nested wildcard scenarios`() {
+        val filter = ObjectFilter()
+
+        // Pattern: user/**/config/*
+        assertTrue(filter.matches(listOf("user", "config", "database"), listOf("user", "**", "config", "*")))
+        assertTrue(filter.matches(listOf("user", "app", "config", "cache"), listOf("user", "**", "config", "*")))
+        assertTrue(filter.matches(listOf("user", "a", "b", "c", "config", "item"), listOf("user", "**", "config", "*")))
+        assertFalse(filter.matches(listOf("user", "config"), listOf("user", "**", "config", "*")))
+        assertFalse(filter.matches(listOf("user", "config", "nested", "value"), listOf("user", "**", "config", "*")))
+
+        // Pattern: logs/**/*/*
+        assertTrue(filter.matches(listOf("logs", "2024", "jan"), listOf("logs", "**", "*", "*")))
+        assertTrue(filter.matches(listOf("logs", "error", "2024", "jan"), listOf("logs", "**", "*", "*")))
+        assertTrue(filter.matches(listOf("logs", "a", "b", "c", "x", "y"), listOf("logs", "**", "*", "*")))
+        assertFalse(filter.matches(listOf("logs", "single"), listOf("logs", "**", "*", "*")))
+        assertFalse(filter.matches(listOf("logs"), listOf("logs", "**", "*", "*")))
+
+        // Pattern with alternating wildcards: */**/*/**/*
+        assertTrue(filter.matches(listOf("a", "b", "c"), listOf("*", "**", "*", "**", "*")))
+        assertTrue(filter.matches(listOf("a", "b", "c", "d", "e"), listOf("*", "**", "*", "**", "*")))
+        assertFalse(filter.matches(listOf("a", "b"), listOf("*", "**", "*", "**", "*")))
+        assertFalse(filter.matches(emptyList(), listOf("*", "**", "*", "**", "*")))
+    }
+}
+
+class ObjectFilterTests {
+    @Test
+    fun `filtered basic dictionary`() {
+        val filter = ObjectFilter(allowList = listOf("user/name", "user/email"))
+        val input = mapOf(
+            "user" to mapOf("name" to "John", "email" to "john@example.com", "password" to "secret123"),
+            "product" to mapOf("name" to "product_1"),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        assertNotNull(result)
+        val user = result!!["user"] as? Map<*, *>
+        assertNotNull(user)
+        assertEquals("John", user!!["name"])
+        assertEquals("john@example.com", user["email"])
+        assertNull(user["password"])
+        assertNull(result["product"])
+    }
+
+    @Test
+    fun `filtered with block list`() {
+        val filter = ObjectFilter(
+            allowList = listOf("user/**"),
+            blockList = listOf("user/password", "user/metadata/secret"),
+        )
+        val input = mapOf(
+            "user" to mapOf(
+                "name" to "John",
+                "email" to "john@example.com",
+                "password" to "secret123",
+                "metadata" to mapOf("item1" to 1, "secret" to "hidden"),
+            ),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        val user = result?.get("user") as? Map<*, *>
+        assertEquals("John", user?.get("name"))
+        assertEquals("john@example.com", user?.get("email"))
+        assertNull(user?.get("password"))
+
+        val metadata = user?.get("metadata") as? Map<*, *>
+        assertNotNull(metadata)
+        assertEquals(1, metadata!!["item1"])
+        assertNull(metadata["secret"])
+    }
+
+    @Test
+    fun `filtered with single wildcard`() {
+        val filter = ObjectFilter(allowList = listOf("user/*"))
+        val input = mapOf(
+            "user" to mapOf(
+                "name" to "John",
+                "email" to "john@example.com",
+                "metadata" to mapOf("item1" to 1, "item2" to 2),
+                "tags" to listOf("return", "tier3"),
+            ),
+            "product" to mapOf("name" to "product_1"),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        val user = result?.get("user") as? Map<*, *>
+        assertEquals("John", user?.get("name"))
+        assertEquals("john@example.com", user?.get("email"))
+
+        // Containers should be preserved but empty
+        assertNotNull(user?.get("metadata"))
+        assertTrue((user?.get("metadata") as? Map<*, *>)?.isEmpty() ?: false)
+        assertNotNull(user?.get("tags"))
+        assertTrue((user?.get("tags") as? List<*>)?.isEmpty() ?: false)
+
+        assertNull(result?.get("product"))
+    }
+
+    @Test
+    fun `filtered with double wildcard`() {
+        val filter = ObjectFilter(allowList = listOf("user/**"))
+        val input = mapOf(
+            "user" to mapOf(
+                "name" to "John",
+                "email" to "john@example.com",
+                "metadata" to mapOf("item1" to 1, "item2" to 2),
+                "tags" to listOf("return", "tier3"),
+            ),
+            "product" to mapOf("name" to "product_1"),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        val user = result?.get("user") as? Map<*, *>
+        assertEquals("John", user?.get("name"))
+        assertEquals("john@example.com", user?.get("email"))
+
+        val metadata = user?.get("metadata") as? Map<*, *>
+        assertEquals(1, metadata?.get("item1"))
+        assertEquals(2, metadata?.get("item2"))
+
+        @Suppress("UNCHECKED_CAST")
+        val tags = user?.get("tags") as? List<String>
+        assertEquals(2, tags?.size)
+        assertEquals("return", tags?.get(0))
+        assertEquals("tier3", tags?.get(1))
+
+        assertNull(result?.get("product"))
+    }
+
+    @Test
+    fun `filtered with array`() {
+        val filter = ObjectFilter(allowList = listOf("users/0", "users/1/name"))
+        val input = mapOf(
+            "users" to listOf(
+                mapOf("name" to "John", "email" to "john@example.com"),
+                mapOf("name" to "Jane", "email" to "jane@example.com"),
+                mapOf("name" to "Bob", "email" to "bob@example.com"),
+            ),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        @Suppress("UNCHECKED_CAST")
+        val users = result?.get("users") as? List<Map<String, Any?>>
+        assertNotNull(users)
+        assertEquals(2, users!!.size)
+        assertEquals("John", users[0]["name"])
+        assertEquals("john@example.com", users[0]["email"])
+        assertEquals("Jane", users[1]["name"])
+        assertNull(users[1]["email"])
+    }
+
+    @Test
+    fun `filtered array at root`() {
+        val filter = ObjectFilter(allowList = listOf("0/name", "1"))
+        val input = listOf(
+            mapOf("name" to "John", "email" to "john@example.com"),
+            mapOf("name" to "Jane", "email" to "jane@example.com"),
+            mapOf("name" to "Bob", "email" to "bob@example.com"),
+        )
+        val result = filter.filtered(input) as? List<*>
+        assertNotNull(result)
+        assertEquals(2, result!!.size)
+        val first = result[0] as? Map<*, *>
+        assertEquals("John", first?.get("name"))
+        assertNull(first?.get("email"))
+        val second = result[1] as? Map<*, *>
+        assertEquals("Jane", second?.get("name"))
+        assertEquals("jane@example.com", second?.get("email"))
+    }
+
+    @Test
+    fun `filtered wildcard in middle`() {
+        val filter = ObjectFilter(allowList = listOf("users/*/metadata/public"))
+        val input = mapOf(
+            "users" to mapOf(
+                "john" to mapOf("metadata" to mapOf("public" to "visible", "private" to "hidden")),
+                "jane" to mapOf("metadata" to mapOf("public" to "also_visible", "private" to "also_hidden")),
+            ),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        val users = result?.get("users") as? Map<*, *>
+
+        val johnMeta = (users?.get("john") as? Map<*, *>)?.get("metadata") as? Map<*, *>
+        assertEquals("visible", johnMeta?.get("public"))
+        assertNull(johnMeta?.get("private"))
+
+        val janeMeta = (users?.get("jane") as? Map<*, *>)?.get("metadata") as? Map<*, *>
+        assertEquals("also_visible", janeMeta?.get("public"))
+        assertNull(janeMeta?.get("private"))
+    }
+
+    @Test
+    fun `filtered complex wildcards`() {
+        val filter = ObjectFilter(allowList = listOf("**/name", "users/*/age"))
+        val input = mapOf(
+            "name" to "Root Name",
+            "users" to mapOf(
+                "john" to mapOf("name" to "John", "age" to 30, "email" to "john@example.com"),
+                "jane" to mapOf("name" to "Jane", "age" to 25, "email" to "jane@example.com"),
+            ),
+            "product" to mapOf("name" to "Product Name", "price" to 100),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        assertEquals("Root Name", result?.get("name"))
+
+        val product = result?.get("product") as? Map<*, *>
+        assertEquals("Product Name", product?.get("name"))
+        assertNull(product?.get("price"))
+
+        val users = result?.get("users") as? Map<*, *>
+        val john = users?.get("john") as? Map<*, *>
+        assertEquals("John", john?.get("name"))
+        assertEquals(30, john?.get("age"))
+        assertNull(john?.get("email"))
+    }
+
+    @Test
+    fun `filtered empty allow list`() {
+        val filter = ObjectFilter(allowList = emptyList())
+        val input = mapOf("key" to "value")
+        assertNull(filter.filtered(input))
+    }
+
+    @Test
+    fun `filtered nil input`() {
+        val filter = ObjectFilter(allowList = listOf("user"))
+        assertNull(filter.filtered(null))
+    }
+
+    @Test
+    fun `filtered primitive root`() {
+        val filter = ObjectFilter(allowList = listOf("user"))
+        assertNull(filter.filtered("string value"))
+        assertNull(filter.filtered(42))
+        assertNull(filter.filtered(true))
+    }
+
+    @Test
+    fun `leading slash in allow list`() {
+        val input = mapOf("name" to "John", "age" to 30, "email" to "john@example.com")
+        val filter = ObjectFilter(allowList = listOf("/*"))
+        val result = filter.filtered(input) as? Map<*, *>
+        assertNotNull(result)
+        assertEquals("John", result!!["name"])
+        assertEquals(30, result["age"])
+        assertEquals("john@example.com", result["email"])
+    }
+
+    @Test
+    fun `consecutive slashes in allow list`() {
+        val input = mapOf(
+            "user" to mapOf("name" to "John", "age" to 30),
+            "product" to mapOf("title" to "Widget"),
+        )
+        val filter = ObjectFilter(allowList = listOf("*///*"))
+        val result = filter.filtered(input) as? Map<*, *>
+        val user = result?.get("user") as? Map<*, *>
+        assertEquals("John", user?.get("name"))
+        assertEquals(30, user?.get("age"))
+        val product = result?.get("product") as? Map<*, *>
+        assertEquals("Widget", product?.get("title"))
+    }
+
+    @Test
+    fun `only slashes return nil`() {
+        val input = mapOf("name" to "John")
+        val filter = ObjectFilter(allowList = listOf("///"))
+        assertNull(filter.filtered(input))
+    }
+
+    @Test
+    fun `block list with single wildcard`() {
+        val filter = ObjectFilter(
+            allowList = listOf("user/**"),
+            blockList = listOf("user/*/password"),
+        )
+        val input = mapOf(
+            "user" to mapOf(
+                "john" to mapOf("name" to "John Doe", "email" to "john@example.com", "password" to "secret123"),
+                "jane" to mapOf("name" to "Jane Smith", "email" to "jane@example.com", "password" to "secret456"),
+            ),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        val user = result?.get("user") as? Map<*, *>
+        val john = user?.get("john") as? Map<*, *>
+        assertEquals("John Doe", john?.get("name"))
+        assertEquals("john@example.com", john?.get("email"))
+        assertNull(john?.get("password"))
+        val jane = user?.get("jane") as? Map<*, *>
+        assertEquals("Jane Smith", jane?.get("name"))
+        assertNull(jane?.get("password"))
+    }
+
+    @Test
+    fun `block list with double wildcard`() {
+        val filter = ObjectFilter(
+            allowList = listOf("data/**"),
+            blockList = listOf("**/secret"),
+        )
+        val input = mapOf(
+            "data" to mapOf(
+                "user" to mapOf(
+                    "name" to "User",
+                    "secret" to "user_secret",
+                    "nested" to mapOf("info" to "public", "secret" to "nested_secret"),
+                ),
+                "config" to mapOf("setting" to "value", "secret" to "config_secret"),
+            ),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        val data = result?.get("data") as? Map<*, *>
+        val user = data?.get("user") as? Map<*, *>
+        assertEquals("User", user?.get("name"))
+        assertNull(user?.get("secret"))
+        val nested = user?.get("nested") as? Map<*, *>
+        assertEquals("public", nested?.get("info"))
+        assertNull(nested?.get("secret"))
+        val config = data?.get("config") as? Map<*, *>
+        assertEquals("value", config?.get("setting"))
+        assertNull(config?.get("secret"))
+    }
+
+    @Test
+    fun `block list priority over allow list`() {
+        val filter = ObjectFilter(
+            allowList = listOf("**"),
+            blockList = listOf("**/password", "*/temp/*", "logs/**"),
+        )
+        val input = mapOf(
+            "user" to mapOf("name" to "Alice", "password" to "secret"),
+            "cache" to mapOf(
+                "temp" to mapOf("file1" to "temp_data", "file2" to "temp_data2"),
+                "permanent" to "keep_this",
+            ),
+            "logs" to mapOf("error" to "error_log", "info" to "info_log"),
+            "config" to mapOf("settings" to "value"),
+        )
+        val result = filter.filtered(input) as? Map<*, *>
+        val user = result?.get("user") as? Map<*, *>
+        assertEquals("Alice", user?.get("name"))
+        assertNull(user?.get("password"))
+
+        val cache = result?.get("cache") as? Map<*, *>
+        assertNull(cache?.get("temp"))
+        assertEquals("keep_this", cache?.get("permanent"))
+
+        assertNull(result?.get("logs"))
+
+        val config = result?.get("config") as? Map<*, *>
+        assertEquals("value", config?.get("settings"))
+    }
+
+    @Test
+    fun `array index filtering`() {
+        val filter = ObjectFilter(allowList = listOf("items/0", "items/2"))
+        val input = mapOf("items" to listOf("first", "second", "third", "fourth"))
+        val result = filter.filtered(input) as? Map<*, *>
+        assertNotNull(result)
+        @Suppress("UNCHECKED_CAST")
+        val items = result!!["items"] as? List<String>
+        assertNotNull(items)
+        assertEquals(2, items!!.size)
+        assertEquals("first", items[0])
+        assertEquals("third", items[1])
+    }
+
+    @Test
+    fun `empty structures`() {
+        val filter = ObjectFilter(allowList = listOf("data/**", "array/**"))
+        val input = mapOf("data" to emptyMap<String, Any>(), "array" to emptyList<Any>())
+        val result = filter.filtered(input) as? Map<*, *>
+        assertNotNull(result)
+        assertNotNull(result!!["data"])
+        assertNotNull(result["array"])
+    }
+
+    @Test
+    fun `array compaction with block list`() {
+        val filter = ObjectFilter(allowList = listOf("**"), blockList = listOf("1"))
+        val input = listOf("one", "two", "three")
+        @Suppress("UNCHECKED_CAST")
+        val result = filter.filtered(input) as? List<String>
+        assertNotNull(result)
+        assertEquals(2, result!!.size)
+        assertEquals("one", result[0])
+        assertEquals("three", result[1])
+    }
+
+    @Test
+    fun `block list edge case - block everything`() {
+        val filter = ObjectFilter(allowList = listOf("root/**"), blockList = listOf("**"))
+        val input = mapOf(
+            "root" to mapOf("keep" to "this_should_be_blocked", "other" to "also_blocked"),
+            "outside" to "not_in_allowlist",
+        )
+        assertNull(filter.filtered(input))
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/utilities/ObjectFilterTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/ObjectFilterTest.kt
@@ -171,10 +171,11 @@ class ObjectFilterTests {
     @Test
     fun `filtered basic dictionary`() {
         val filter = ObjectFilter(allowList = listOf("user/name", "user/email"))
-        val input = mapOf(
-            "user" to mapOf("name" to "John", "email" to "john@example.com", "password" to "secret123"),
-            "product" to mapOf("name" to "product_1"),
-        )
+        val input =
+            mapOf(
+                "user" to mapOf("name" to "John", "email" to "john@example.com", "password" to "secret123"),
+                "product" to mapOf("name" to "product_1"),
+            )
         val result = filter.filtered(input) as? Map<*, *>
         assertNotNull(result)
         val user = result!!["user"] as? Map<*, *>
@@ -187,18 +188,21 @@ class ObjectFilterTests {
 
     @Test
     fun `filtered with block list`() {
-        val filter = ObjectFilter(
-            allowList = listOf("user/**"),
-            blockList = listOf("user/password", "user/metadata/secret"),
-        )
-        val input = mapOf(
-            "user" to mapOf(
-                "name" to "John",
-                "email" to "john@example.com",
-                "password" to "secret123",
-                "metadata" to mapOf("item1" to 1, "secret" to "hidden"),
-            ),
-        )
+        val filter =
+            ObjectFilter(
+                allowList = listOf("user/**"),
+                blockList = listOf("user/password", "user/metadata/secret"),
+            )
+        val input =
+            mapOf(
+                "user" to
+                    mapOf(
+                        "name" to "John",
+                        "email" to "john@example.com",
+                        "password" to "secret123",
+                        "metadata" to mapOf("item1" to 1, "secret" to "hidden"),
+                    ),
+            )
         val result = filter.filtered(input) as? Map<*, *>
         val user = result?.get("user") as? Map<*, *>
         assertEquals("John", user?.get("name"))
@@ -214,15 +218,17 @@ class ObjectFilterTests {
     @Test
     fun `filtered with single wildcard`() {
         val filter = ObjectFilter(allowList = listOf("user/*"))
-        val input = mapOf(
-            "user" to mapOf(
-                "name" to "John",
-                "email" to "john@example.com",
-                "metadata" to mapOf("item1" to 1, "item2" to 2),
-                "tags" to listOf("return", "tier3"),
-            ),
-            "product" to mapOf("name" to "product_1"),
-        )
+        val input =
+            mapOf(
+                "user" to
+                    mapOf(
+                        "name" to "John",
+                        "email" to "john@example.com",
+                        "metadata" to mapOf("item1" to 1, "item2" to 2),
+                        "tags" to listOf("return", "tier3"),
+                    ),
+                "product" to mapOf("name" to "product_1"),
+            )
         val result = filter.filtered(input) as? Map<*, *>
         val user = result?.get("user") as? Map<*, *>
         assertEquals("John", user?.get("name"))
@@ -240,15 +246,17 @@ class ObjectFilterTests {
     @Test
     fun `filtered with double wildcard`() {
         val filter = ObjectFilter(allowList = listOf("user/**"))
-        val input = mapOf(
-            "user" to mapOf(
-                "name" to "John",
-                "email" to "john@example.com",
-                "metadata" to mapOf("item1" to 1, "item2" to 2),
-                "tags" to listOf("return", "tier3"),
-            ),
-            "product" to mapOf("name" to "product_1"),
-        )
+        val input =
+            mapOf(
+                "user" to
+                    mapOf(
+                        "name" to "John",
+                        "email" to "john@example.com",
+                        "metadata" to mapOf("item1" to 1, "item2" to 2),
+                        "tags" to listOf("return", "tier3"),
+                    ),
+                "product" to mapOf("name" to "product_1"),
+            )
         val result = filter.filtered(input) as? Map<*, *>
         val user = result?.get("user") as? Map<*, *>
         assertEquals("John", user?.get("name"))
@@ -270,14 +278,17 @@ class ObjectFilterTests {
     @Test
     fun `filtered with array`() {
         val filter = ObjectFilter(allowList = listOf("users/0", "users/1/name"))
-        val input = mapOf(
-            "users" to listOf(
-                mapOf("name" to "John", "email" to "john@example.com"),
-                mapOf("name" to "Jane", "email" to "jane@example.com"),
-                mapOf("name" to "Bob", "email" to "bob@example.com"),
-            ),
-        )
+        val input =
+            mapOf(
+                "users" to
+                    listOf(
+                        mapOf("name" to "John", "email" to "john@example.com"),
+                        mapOf("name" to "Jane", "email" to "jane@example.com"),
+                        mapOf("name" to "Bob", "email" to "bob@example.com"),
+                    ),
+            )
         val result = filter.filtered(input) as? Map<*, *>
+
         @Suppress("UNCHECKED_CAST")
         val users = result?.get("users") as? List<Map<String, Any?>>
         assertNotNull(users)
@@ -291,11 +302,12 @@ class ObjectFilterTests {
     @Test
     fun `filtered array at root`() {
         val filter = ObjectFilter(allowList = listOf("0/name", "1"))
-        val input = listOf(
-            mapOf("name" to "John", "email" to "john@example.com"),
-            mapOf("name" to "Jane", "email" to "jane@example.com"),
-            mapOf("name" to "Bob", "email" to "bob@example.com"),
-        )
+        val input =
+            listOf(
+                mapOf("name" to "John", "email" to "john@example.com"),
+                mapOf("name" to "Jane", "email" to "jane@example.com"),
+                mapOf("name" to "Bob", "email" to "bob@example.com"),
+            )
         val result = filter.filtered(input) as? List<*>
         assertNotNull(result)
         assertEquals(2, result!!.size)
@@ -310,12 +322,14 @@ class ObjectFilterTests {
     @Test
     fun `filtered wildcard in middle`() {
         val filter = ObjectFilter(allowList = listOf("users/*/metadata/public"))
-        val input = mapOf(
-            "users" to mapOf(
-                "john" to mapOf("metadata" to mapOf("public" to "visible", "private" to "hidden")),
-                "jane" to mapOf("metadata" to mapOf("public" to "also_visible", "private" to "also_hidden")),
-            ),
-        )
+        val input =
+            mapOf(
+                "users" to
+                    mapOf(
+                        "john" to mapOf("metadata" to mapOf("public" to "visible", "private" to "hidden")),
+                        "jane" to mapOf("metadata" to mapOf("public" to "also_visible", "private" to "also_hidden")),
+                    ),
+            )
         val result = filter.filtered(input) as? Map<*, *>
         val users = result?.get("users") as? Map<*, *>
 
@@ -331,14 +345,16 @@ class ObjectFilterTests {
     @Test
     fun `filtered complex wildcards`() {
         val filter = ObjectFilter(allowList = listOf("**/name", "users/*/age"))
-        val input = mapOf(
-            "name" to "Root Name",
-            "users" to mapOf(
-                "john" to mapOf("name" to "John", "age" to 30, "email" to "john@example.com"),
-                "jane" to mapOf("name" to "Jane", "age" to 25, "email" to "jane@example.com"),
-            ),
-            "product" to mapOf("name" to "Product Name", "price" to 100),
-        )
+        val input =
+            mapOf(
+                "name" to "Root Name",
+                "users" to
+                    mapOf(
+                        "john" to mapOf("name" to "John", "age" to 30, "email" to "john@example.com"),
+                        "jane" to mapOf("name" to "Jane", "age" to 25, "email" to "jane@example.com"),
+                    ),
+                "product" to mapOf("name" to "Product Name", "price" to 100),
+            )
         val result = filter.filtered(input) as? Map<*, *>
         assertEquals("Root Name", result?.get("name"))
 
@@ -387,10 +403,11 @@ class ObjectFilterTests {
 
     @Test
     fun `consecutive slashes in allow list`() {
-        val input = mapOf(
-            "user" to mapOf("name" to "John", "age" to 30),
-            "product" to mapOf("title" to "Widget"),
-        )
+        val input =
+            mapOf(
+                "user" to mapOf("name" to "John", "age" to 30),
+                "product" to mapOf("title" to "Widget"),
+            )
         val filter = ObjectFilter(allowList = listOf("*///*"))
         val result = filter.filtered(input) as? Map<*, *>
         val user = result?.get("user") as? Map<*, *>
@@ -409,16 +426,19 @@ class ObjectFilterTests {
 
     @Test
     fun `block list with single wildcard`() {
-        val filter = ObjectFilter(
-            allowList = listOf("user/**"),
-            blockList = listOf("user/*/password"),
-        )
-        val input = mapOf(
-            "user" to mapOf(
-                "john" to mapOf("name" to "John Doe", "email" to "john@example.com", "password" to "secret123"),
-                "jane" to mapOf("name" to "Jane Smith", "email" to "jane@example.com", "password" to "secret456"),
-            ),
-        )
+        val filter =
+            ObjectFilter(
+                allowList = listOf("user/**"),
+                blockList = listOf("user/*/password"),
+            )
+        val input =
+            mapOf(
+                "user" to
+                    mapOf(
+                        "john" to mapOf("name" to "John Doe", "email" to "john@example.com", "password" to "secret123"),
+                        "jane" to mapOf("name" to "Jane Smith", "email" to "jane@example.com", "password" to "secret456"),
+                    ),
+            )
         val result = filter.filtered(input) as? Map<*, *>
         val user = result?.get("user") as? Map<*, *>
         val john = user?.get("john") as? Map<*, *>
@@ -432,20 +452,24 @@ class ObjectFilterTests {
 
     @Test
     fun `block list with double wildcard`() {
-        val filter = ObjectFilter(
-            allowList = listOf("data/**"),
-            blockList = listOf("**/secret"),
-        )
-        val input = mapOf(
-            "data" to mapOf(
-                "user" to mapOf(
-                    "name" to "User",
-                    "secret" to "user_secret",
-                    "nested" to mapOf("info" to "public", "secret" to "nested_secret"),
-                ),
-                "config" to mapOf("setting" to "value", "secret" to "config_secret"),
-            ),
-        )
+        val filter =
+            ObjectFilter(
+                allowList = listOf("data/**"),
+                blockList = listOf("**/secret"),
+            )
+        val input =
+            mapOf(
+                "data" to
+                    mapOf(
+                        "user" to
+                            mapOf(
+                                "name" to "User",
+                                "secret" to "user_secret",
+                                "nested" to mapOf("info" to "public", "secret" to "nested_secret"),
+                            ),
+                        "config" to mapOf("setting" to "value", "secret" to "config_secret"),
+                    ),
+            )
         val result = filter.filtered(input) as? Map<*, *>
         val data = result?.get("data") as? Map<*, *>
         val user = data?.get("user") as? Map<*, *>
@@ -461,19 +485,22 @@ class ObjectFilterTests {
 
     @Test
     fun `block list priority over allow list`() {
-        val filter = ObjectFilter(
-            allowList = listOf("**"),
-            blockList = listOf("**/password", "*/temp/*", "logs/**"),
-        )
-        val input = mapOf(
-            "user" to mapOf("name" to "Alice", "password" to "secret"),
-            "cache" to mapOf(
-                "temp" to mapOf("file1" to "temp_data", "file2" to "temp_data2"),
-                "permanent" to "keep_this",
-            ),
-            "logs" to mapOf("error" to "error_log", "info" to "info_log"),
-            "config" to mapOf("settings" to "value"),
-        )
+        val filter =
+            ObjectFilter(
+                allowList = listOf("**"),
+                blockList = listOf("**/password", "*/temp/*", "logs/**"),
+            )
+        val input =
+            mapOf(
+                "user" to mapOf("name" to "Alice", "password" to "secret"),
+                "cache" to
+                    mapOf(
+                        "temp" to mapOf("file1" to "temp_data", "file2" to "temp_data2"),
+                        "permanent" to "keep_this",
+                    ),
+                "logs" to mapOf("error" to "error_log", "info" to "info_log"),
+                "config" to mapOf("settings" to "value"),
+            )
         val result = filter.filtered(input) as? Map<*, *>
         val user = result?.get("user") as? Map<*, *>
         assertEquals("Alice", user?.get("name"))
@@ -517,6 +544,7 @@ class ObjectFilterTests {
     fun `array compaction with block list`() {
         val filter = ObjectFilter(allowList = listOf("**"), blockList = listOf("1"))
         val input = listOf("one", "two", "three")
+
         @Suppress("UNCHECKED_CAST")
         val result = filter.filtered(input) as? List<String>
         assertNotNull(result)
@@ -528,10 +556,11 @@ class ObjectFilterTests {
     @Test
     fun `block list edge case - block everything`() {
         val filter = ObjectFilter(allowList = listOf("root/**"), blockList = listOf("**"))
-        val input = mapOf(
-            "root" to mapOf("keep" to "this_should_be_blocked", "other" to "also_blocked"),
-            "outside" to "not_in_allowlist",
-        )
+        val input =
+            mapOf(
+                "root" to mapOf("keep" to "this_should_be_blocked", "other" to "also_blocked"),
+                "outside" to "not_in_allowlist",
+            )
         assertNull(filter.filtered(input))
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/utilities/ObjectFilterTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/ObjectFilterTest.kt
@@ -277,7 +277,7 @@ class ObjectFilterTests {
 
     @Test
     fun `filtered with array`() {
-        val filter = ObjectFilter(allowList = listOf("users/0", "users/1/name"))
+        val filter = ObjectFilter(allowList = listOf("users/0/**", "users/1/name"))
         val input =
             mapOf(
                 "users" to
@@ -301,7 +301,7 @@ class ObjectFilterTests {
 
     @Test
     fun `filtered array at root`() {
-        val filter = ObjectFilter(allowList = listOf("0/name", "1"))
+        val filter = ObjectFilter(allowList = listOf("0/name", "1/**"))
         val input =
             listOf(
                 mapOf("name" to "John", "email" to "john@example.com"),
@@ -388,6 +388,68 @@ class ObjectFilterTests {
         assertNull(filter.filtered("string value"))
         assertNull(filter.filtered(42))
         assertNull(filter.filtered(true))
+    }
+
+    @Test
+    fun `exact match on primitive value is captured`() {
+        val filter = ObjectFilter(allowList = listOf("name"))
+        val input = mapOf("name" to "John", "age" to 30)
+        val result = filter.filtered(input) as? Map<*, *>
+        assertNotNull(result)
+        assertEquals("John", result!!["name"])
+        assertNull(result["age"])
+    }
+
+    @Test
+    fun `exact match on container is not captured`() {
+        val filter = ObjectFilter(allowList = listOf("user"))
+        val input = mapOf("user" to mapOf("name" to "John", "password" to "secret"))
+        // "user" is a container — exact match without wildcard should not return it
+        assertNull(filter.filtered(input))
+    }
+
+    @Test
+    fun `exact match on container vs wildcard`() {
+        // "user" alone does not capture the object
+        val filter1 = ObjectFilter(allowList = listOf("user"))
+        val input = mapOf("user" to mapOf("name" to "John", "password" to "secret"))
+        assertNull(filter1.filtered(input))
+
+        // "user/**" captures the full object
+        val filter2 = ObjectFilter(allowList = listOf("user/**"))
+        val result2 = filter2.filtered(input) as? Map<*, *>
+        val user2 = result2?.get("user") as? Map<*, *>
+        assertEquals("John", user2?.get("name"))
+        assertEquals("secret", user2?.get("password"))
+
+        // "user/*" captures direct children only
+        val filter3 = ObjectFilter(allowList = listOf("user/*"))
+        val result3 = filter3.filtered(input) as? Map<*, *>
+        val user3 = result3?.get("user") as? Map<*, *>
+        assertEquals("John", user3?.get("name"))
+        assertEquals("secret", user3?.get("password"))
+    }
+
+    @Test
+    fun `exact match with blocklist on descendants now works`() {
+        // With "user/**" + blocklist, password is excluded
+        val filter =
+            ObjectFilter(
+                allowList = listOf("user/**"),
+                blockList = listOf("user/password"),
+            )
+        val input = mapOf("user" to mapOf("name" to "John", "password" to "secret"))
+        val result = filter.filtered(input) as? Map<*, *>
+        val user = result?.get("user") as? Map<*, *>
+        assertEquals("John", user?.get("name"))
+        assertNull(user?.get("password"))
+    }
+
+    @Test
+    fun `exact match on array is not captured`() {
+        val filter = ObjectFilter(allowList = listOf("items"))
+        val input = mapOf("items" to listOf("a", "b", "c"))
+        assertNull(filter.filtered(input))
     }
 
     @Test

--- a/android/src/test/kotlin/com/amplitude/android/utilities/ObjectFilterTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/ObjectFilterTest.kt
@@ -9,6 +9,26 @@ import org.junit.jupiter.api.Test
 
 class ObjectFilterMatchTests {
     @Test
+    fun `canMatchDescendants requires prefix compatibility when pattern has double wildcard`() {
+        val filter = ObjectFilter()
+        val method =
+            ObjectFilter::class.java.getDeclaredMethod(
+                "canMatchDescendants",
+                List::class.java,
+                List::class.java,
+            )
+        method.isAccessible = true
+
+        val mismatchedPrefix =
+            method.invoke(filter, listOf("a", "b"), listOf("c", "**")) as Boolean
+        val matchedPrefix =
+            method.invoke(filter, listOf("a", "b"), listOf("a", "**")) as Boolean
+
+        assertFalse(mismatchedPrefix)
+        assertTrue(matchedPrefix)
+    }
+
+    @Test
     fun `matches exact path`() {
         val filter = ObjectFilter()
         assertTrue(filter.matches(listOf("user", "name"), listOf("user", "name")))
@@ -613,6 +633,19 @@ class ObjectFilterTests {
         assertEquals(2, result!!.size)
         assertEquals("one", result[0])
         assertEquals("three", result[1])
+    }
+
+    @Test
+    fun `does not descend into mismatched prefix when pattern has double wildcard`() {
+        val filter = ObjectFilter(allowList = listOf("c/**"))
+        val input =
+            mapOf(
+                "a" to
+                    mapOf(
+                        "nested" to mapOf("value" to "ignored"),
+                    ),
+            )
+        assertNull(filter.filtered(input))
     }
 
     @Test

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -245,9 +245,13 @@ public final class com/amplitude/core/Constants$EventProperties {
 	public static final field NETWORK_TRACKING_COMPLETION_TIME Ljava/lang/String;
 	public static final field NETWORK_TRACKING_DURATION Ljava/lang/String;
 	public static final field NETWORK_TRACKING_ERROR_MESSAGE Ljava/lang/String;
+	public static final field NETWORK_TRACKING_REQUEST_BODY Ljava/lang/String;
 	public static final field NETWORK_TRACKING_REQUEST_BODY_SIZE Ljava/lang/String;
+	public static final field NETWORK_TRACKING_REQUEST_HEADERS Ljava/lang/String;
 	public static final field NETWORK_TRACKING_REQUEST_METHOD Ljava/lang/String;
+	public static final field NETWORK_TRACKING_RESPONSE_BODY Ljava/lang/String;
 	public static final field NETWORK_TRACKING_RESPONSE_BODY_SIZE Ljava/lang/String;
+	public static final field NETWORK_TRACKING_RESPONSE_HEADERS Ljava/lang/String;
 	public static final field NETWORK_TRACKING_START_TIME Ljava/lang/String;
 	public static final field NETWORK_TRACKING_STATUS_CODE Ljava/lang/String;
 	public static final field NETWORK_TRACKING_URL Ljava/lang/String;

--- a/core/src/main/java/com/amplitude/core/Constants.kt
+++ b/core/src/main/java/com/amplitude/core/Constants.kt
@@ -58,6 +58,10 @@ object Constants {
         const val NETWORK_TRACKING_DURATION = "[Amplitude] Duration"
         const val NETWORK_TRACKING_REQUEST_BODY_SIZE = "[Amplitude] Request Body Size"
         const val NETWORK_TRACKING_RESPONSE_BODY_SIZE = "[Amplitude] Response Body Size"
+        const val NETWORK_TRACKING_REQUEST_HEADERS = "[Amplitude] Request Headers"
+        const val NETWORK_TRACKING_RESPONSE_HEADERS = "[Amplitude] Response Headers"
+        const val NETWORK_TRACKING_REQUEST_BODY = "[Amplitude] Request Body"
+        const val NETWORK_TRACKING_RESPONSE_BODY = "[Amplitude] Response Body"
 
         // Accessibility properties
         const val TARGET_ACCESSIBILITY_LABEL = "[Amplitude] Target Accessibility Label"

--- a/samples/kotlin-android-app/src/main/AndroidManifest.xml
+++ b/samples/kotlin-android-app/src/main/AndroidManifest.xml
@@ -51,6 +51,10 @@
             android:name=".ComposeAdvancedActivity"
             android:label="Compose - Advanced Events"
             android:exported="false" />
+        <activity
+            android:name=".NetworkTrackingActivity"
+            android:label="Network Tracking Debug"
+            android:exported="false" />
 
         <meta-data
             android:name="com.google.android.gms.ads.AD_MANAGER_APP"

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/LauncherActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/LauncherActivity.kt
@@ -103,6 +103,27 @@ class LauncherActivity : ComponentActivity() {
                     modifier = Modifier.padding(8.dp),
                 )
             }
+
+            Button(
+                onClick = {
+                    val intent = Intent(this@LauncherActivity, NetworkTrackingActivity::class.java)
+                    startActivity(intent)
+                },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFF4CAF50),
+                    ),
+            ) {
+                Text(
+                    text = "Network Tracking",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(8.dp),
+                )
+            }
         }
     }
 

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/MainApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/MainApplication.kt
@@ -6,22 +6,90 @@ import com.amplitude.android.AutocaptureOption.Companion.ALL
 import com.amplitude.android.DeadClickOptions
 import com.amplitude.android.InteractionsOptions
 import com.amplitude.android.RageClickOptions
+import com.amplitude.android.network.NetworkTrackingOptions
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
+import com.amplitude.android.network.NetworkTrackingOptions.URLPattern
+import com.amplitude.android.network.NetworkTrackingPlugin
 import com.amplitude.common.Logger
 import com.amplitude.core.Constants
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
 import com.amplitude.experiment.Experiment
 import com.amplitude.experiment.ExperimentConfig
+import okhttp3.OkHttpClient
 
 class MainApplication : Application() {
     companion object {
         lateinit var amplitude: Amplitude
+        lateinit var sharedOkHttpClient: OkHttpClient
         const val AMPLITUDE_API_KEY = BuildConfig.AMPLITUDE_API_KEY
         const val EXPERIMENT_API_KEY = BuildConfig.EXPERIMENT_API_KEY
     }
 
     override fun onCreate() {
         super.onCreate()
+
+        // Multiple rules to showcase different capture configurations.
+        // "Last matching rule wins" — more specific URL rules override the fallback.
+        val networkTrackingPlugin =
+            NetworkTrackingPlugin(
+                NetworkTrackingOptions(
+                    captureRules =
+                        listOf(
+                            // Rule 1: Fallback — capture errors with no headers/body
+                            CaptureRule(
+                                hosts = listOf("*"),
+                                statusCodeRange = (400..599).toList(),
+                            ),
+                            // Rule 2: Exact URL — capture response headers only
+                            CaptureRule(
+                                urls = listOf(URLPattern.Exact("https://httpbin.org/get")),
+                                statusCodeRange = (0..599).toList(),
+                                responseHeaders =
+                                    CaptureHeader(
+                                        allowlist = listOf("x-custom"),
+                                        captureSafeHeaders = true,
+                                    ),
+                            ),
+                            // Rule 3: Regex URL + POST method — capture body with allowlist/blocklist
+                            CaptureRule(
+                                urls = listOf(URLPattern.Regex(".*httpbin\\.org/post")),
+                                methods = listOf("POST"),
+                                statusCodeRange = (0..599).toList(),
+                                requestBody = CaptureBody(allowlist = listOf("user/*"), blocklist = listOf("**/password")),
+                                responseBody = CaptureBody(allowlist = listOf("**")),
+                            ),
+                            // Rule 4: Exact URL — capture headers (safe + custom, Authorization blocked)
+                            CaptureRule(
+                                urls = listOf(URLPattern.Exact("https://httpbin.org/headers")),
+                                statusCodeRange = (0..599).toList(),
+                                requestHeaders =
+                                    CaptureHeader(
+                                        allowlist = listOf("x-custom"),
+                                        captureSafeHeaders = true,
+                                    ),
+                                responseHeaders = CaptureHeader(captureSafeHeaders = true),
+                            ),
+                            // Rule 5: Status endpoints — capture full headers + body
+                            CaptureRule(
+                                urls = listOf(URLPattern.Regex(".*httpbin\\.org/status/.*")),
+                                statusCodeRange = (0..599).toList(),
+                                requestHeaders = CaptureHeader(captureSafeHeaders = true),
+                                responseHeaders = CaptureHeader(captureSafeHeaders = true),
+                                requestBody = CaptureBody(allowlist = listOf("**")),
+                                responseBody = CaptureBody(allowlist = listOf("**")),
+                            ),
+                        ),
+                    ignoreAmplitudeRequests = true,
+                ),
+            )
+
+        sharedOkHttpClient =
+            OkHttpClient.Builder()
+                .addInterceptor(networkTrackingPlugin)
+                .build()
 
         amplitude =
             Amplitude(AMPLITUDE_API_KEY, applicationContext) {
@@ -30,6 +98,7 @@ class MainApplication : Application() {
                     CustomOkHttpClient(
                         apiKey = AMPLITUDE_API_KEY,
                         apiHost = Constants.DEFAULT_API_HOST,
+                        okHttpClient = sharedOkHttpClient,
                     )
                 interactionsOptions =
                     InteractionsOptions(
@@ -38,6 +107,8 @@ class MainApplication : Application() {
                         DeadClickOptions(enabled = false),
                     )
             }
+
+        amplitude.add(networkTrackingPlugin)
 
         // Sample for Experiment Integration
         val experimentConfig =

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/MainApplication.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/MainApplication.kt
@@ -58,7 +58,7 @@ class MainApplication : Application() {
                                 urls = listOf(URLPattern.Regex(".*httpbin\\.org/post")),
                                 methods = listOf("POST"),
                                 statusCodeRange = (0..599).toList(),
-                                requestBody = CaptureBody(allowlist = listOf("user/*"), blocklist = listOf("**/password")),
+                                requestBody = CaptureBody(allowlist = listOf("user/*"), excludelist = listOf("**/password")),
                                 responseBody = CaptureBody(allowlist = listOf("**")),
                             ),
                             // Rule 4: Exact URL — capture headers (safe + custom, Authorization blocked)

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/NetworkTrackingActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/NetworkTrackingActivity.kt
@@ -1,0 +1,274 @@
+package com.amplitude.android.sample
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons.AutoMirrored.Filled
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.amplitude.core.Constants
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.platform.Plugin
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class NetworkTrackingActivity : ComponentActivity() {
+    private var httpLog by mutableStateOf("")
+    private var eventLog by mutableStateOf("(no events captured yet)")
+
+    // Plugin that observes network tracking events and writes to eventLog
+    private val eventObserver =
+        object : Plugin {
+            override val type = Plugin.Type.Destination
+            override lateinit var amplitude: com.amplitude.core.Amplitude
+
+            override fun execute(event: BaseEvent): BaseEvent? {
+                if (event.eventType == Constants.EventTypes.NETWORK_TRACKING) {
+                    val props = event.eventProperties ?: emptyMap()
+                    val formatted =
+                        buildString {
+                            appendLine("--- [Amplitude] Network Request ---")
+                            props.entries
+                                .sortedBy { it.key }
+                                .forEach { (key, value) ->
+                                    val display =
+                                        when (value) {
+                                            is Map<*, *> -> value.entries.joinToString(", ") { "${it.key}: ${it.value}" }
+                                            is String -> if (value.length > 200) value.take(200) + "..." else value
+                                            else -> value.toString()
+                                        }
+                                    appendLine("  $key = $display")
+                                }
+                        }
+                    eventLog = formatted + "\n" + eventLog
+                }
+                return event
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        MainApplication.amplitude.add(eventObserver)
+
+        setContent {
+            MaterialTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background,
+                ) {
+                    NetworkTrackingScreen()
+                }
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        MainApplication.amplitude.remove(eventObserver)
+        super.onDestroy()
+    }
+
+    private fun makeRequest(request: Request) {
+        httpLog = "Loading..."
+        CoroutineScope(Dispatchers.Main).launch {
+            val result =
+                withContext(Dispatchers.IO) {
+                    try {
+                        val response = MainApplication.sharedOkHttpClient.newCall(request).execute()
+                        val body = response.body?.string()?.take(500) ?: "(empty body)"
+                        "${response.code} ${response.message}\n\n$body"
+                    } catch (e: Exception) {
+                        "Error: ${e.message}"
+                    }
+                }
+            httpLog = result
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    fun NetworkTrackingScreen() {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Network Tracking Debug") },
+                    navigationIcon = {
+                        IconButton(onClick = { finish() }) {
+                            Icon(
+                                imageVector = Filled.ArrowBack,
+                                contentDescription = "Back",
+                            )
+                        }
+                    },
+                )
+            },
+        ) { innerPadding ->
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .padding(horizontal = 16.dp)
+                        .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = "Each button exercises a different capture rule. Check the event log below.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(bottom = 4.dp),
+                )
+
+                RequestButton(
+                    label = "GET 200",
+                    description = "Rule 2 (exact URL). Captures response headers only — no body.",
+                ) {
+                    makeRequest(
+                        Request.Builder()
+                            .url("https://httpbin.org/get")
+                            .build(),
+                    )
+                }
+
+                RequestButton(
+                    label = "POST JSON",
+                    description = "Rule 3 (regex + POST). Body allowlist: user/*. Blocks **/password.",
+                ) {
+                    makeRequest(
+                        Request.Builder()
+                            .url("https://httpbin.org/post")
+                            .post(
+                                """{"user":{"name":"John","password":"secret","email":"john@test.com"}}"""
+                                    .toRequestBody("application/json".toMediaType()),
+                            )
+                            .build(),
+                    )
+                }
+
+                RequestButton(
+                    label = "GET 404",
+                    description = "Rule 5 (status regex). Full headers + body capture.",
+                ) {
+                    makeRequest(
+                        Request.Builder()
+                            .url("https://httpbin.org/status/404")
+                            .build(),
+                    )
+                }
+
+                RequestButton(
+                    label = "GET 500",
+                    description = "Rule 5 (status regex). Full headers + body capture.",
+                ) {
+                    makeRequest(
+                        Request.Builder()
+                            .url("https://httpbin.org/status/500")
+                            .build(),
+                    )
+                }
+
+                RequestButton(
+                    label = "GET Headers",
+                    description = "Rule 4 (exact URL). Safe headers + X-Custom. Authorization blocked.",
+                ) {
+                    makeRequest(
+                        Request.Builder()
+                            .url("https://httpbin.org/headers")
+                            .addHeader("X-Custom", "test-value")
+                            .addHeader("Authorization", "Bearer secret-token")
+                            .addHeader("Content-Type", "application/json")
+                            .build(),
+                    )
+                }
+
+                RequestButton(
+                    label = "POST Nested JSON",
+                    description = "Rule 3 (regex + POST). Body filtered through user/* allowlist.",
+                ) {
+                    makeRequest(
+                        Request.Builder()
+                            .url("https://httpbin.org/post")
+                            .post(
+                                """{"user":{"name":"Jane","password":"hidden","role":"admin"},"metadata":{"ts":12345}}"""
+                                    .toRequestBody("application/json".toMediaType()),
+                            )
+                            .build(),
+                    )
+                }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+                Text("HTTP Response", style = MaterialTheme.typography.titleSmall)
+                Text(
+                    text = httpLog,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+
+                Text("Captured Event Properties", style = MaterialTheme.typography.titleSmall)
+                Text(
+                    text = eventLog,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(bottom = 32.dp),
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun RequestButton(
+        label: String,
+        description: String = "",
+        onClick: () -> Unit,
+    ) {
+        Column {
+            Button(
+                onClick = onClick,
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFF4CAF50),
+                    ),
+            ) {
+                Text(label)
+            }
+            if (description.isNotEmpty()) {
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(start = 4.dp, bottom = 4.dp),
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉
Please fill out the following sections to help us quickly review your pull request.
--->

### Describe what this PR is addressing

The Android SDK's `NetworkTrackingPlugin` currently captures URL, method, status code, timing, and body *sizes* — but not the actual header values
  or body content. The Swift SDK already ships header/body capture with configurable filtering. This PR brings the Kotlin SDK to feature parity,
enabling developers to capture and filter request/response headers and bodies for network tracking events.

Additionally, the plugin lacked URL pattern matching (exact + regex), HTTP method filtering, and remote config integration — all of which the
Swift SDK supports.

### Describe the solution

#### Header & Body Capture
- `CaptureHeader` — filters headers via allowlist + safe headers list, with `authorization`/`cookie`/`proxy-authorization` always blocked
- `CaptureBody` — filters JSON bodies via path-based allowlist/blocklist using `ObjectFilter` (ported from Swift), supporting `/`, `*`, and `**`
wildcards
- New event properties: `[Amplitude] Request Headers`, `[Amplitude] Response Headers`, `[Amplitude] Request Body`, `[Amplitude] Response Body`

#### URL & Method Matching
- `CaptureRule` now supports `urls` (exact + regex patterns) in addition to `hosts`
- Two separate constructors enforce that only one of `hosts` or `urls` is set per rule — host-based rules are simple (no header/body params),
URL-based rules have the full config
- HTTP `methods` filter (e.g., `["GET", "POST"]`) on URL-based rules

#### Remote Config Integration
- Plugin subscribes to `RemoteConfigClient` in `setup()`, gated by both `Configuration.enableAutocaptureRemoteConfig` and
`NetworkTrackingOptions.enableRemoteConfig`
- Fresh overlay on local options each time — fields absent from remote fall back to local, not to a previous remote value
- Missing `networkTracking` section resets to local config entirely
- `enabled` + all options stored as a single `@Volatile` snapshot for atomic reads per request

#### API Design
- Converted `NetworkTrackingOptions`, `CaptureRule`, `CaptureHeader`, `CaptureBody` from `data class` to `class` — prevents auto-generated
`copy()`/`componentN()` from becoming ABI liabilities
- Defensive `toList()` on all list constructor params
- Regex URL patterns validated eagerly at construction (fail-fast, not on first request)
- Request body capture skips one-shot/duplex bodies and non-JSON content types
- Response body peek bounded to 1 MB with JSON content-type guard
- Recursion guard scoped to amplitude hosts only (avoids `writeTo()` on normal requests)

#### Sample App
- New "Network Tracking" debug page with 6 httpbin.org test buttons
- 5 capture rules showcasing host matching, exact/regex URL matching, method filtering, header allowlist, body allowlist/blocklist
- Live event property viewer showing captured data inline

### Steps to verify the change

**Automated:**
```bash
./gradlew test ktlintCheck apiCheck
```
- 32 NetworkTrackingPluginTest tests (including 9 remote config tests)
- 31 NetworkTrackingOptionsTest tests (header/body filtering, URL/method matching, remote config parsing)
- 25 ObjectFilterTest tests (wildcard matching, blocklist priority, array filtering)

Manual (sample app):
1. Set AMPLITUDE_API_KEY in samples/kotlin-android-app/local.properties
2. Build and run the sample app
3. Tap "Network Tracking" on the launcher screen
4. Tap each button and verify the "Captured Event Properties" log shows:
  - GET 200 → response headers captured, no body
  - POST JSON → request body shows name but not password (blocklist)
  - GET 404/500 → full headers + body
  - GET Headers → safe headers + X-Custom present, Authorization absent
  - POST Nested JSON → body filtered through user/* allowlist

### Useful links and documentation (optional)

### Checklist
* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [X] Does your PR have a breaking change?
*There are configuration changes, but since it moved from core to the android package and hasn’t been released yet, it’s not a breaking change.*


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it expands network tracking to optionally capture request/response headers and JSON bodies (sensitive data surface area) and introduces remote-config-driven behavior changes at runtime.
> 
> **Overview**
> Adds **configurable request/response header and JSON body capture** to Android `NetworkTrackingPlugin`, emitting new event properties (`[Amplitude] Request Headers`, `Response Headers`, `Request Body`, `Response Body`) with allowlist-based filtering (safe-header set + always-blocked auth/cookie headers) and JSON field filtering via a new path-wildcard `ObjectFilter`.
> 
> Extends capture rules from host-only matching to **URL exact/regex patterns and HTTP method filters**, updates rule matching to return the matched rule ("last match wins"), and tightens recursion/ignore logic to treat all `*.amplitude.com` hosts as Amplitude hosts while only scanning bodies on those hosts.
> 
> Introduces **remote config integration** for network tracking (subscribe in `setup()`, overlay remote values on local options with atomic `currentOptions` snapshots, reject malformed overrides), plus a sample-app debug screen demonstrating capture rules and updates to tests/APIs to reflect the new options and ABI-safe class changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d073c54384b8a4a82e748b56a2ee01583aec62f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->