### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash - quotation fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        uses: "lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f" # 2.0.2
         with:
           permission: "write"
         env:


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via [automated scripts](https://github.com/amplitude/tools/tree/master/seceng/github_actions/pin-gha).
This PR fixes an error with the previous script not correctly parsing lines in "" quotations.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

This pull request was created by [multi-gitter](https://github.com/lindell/multi-gitter).

Please merge this pull request by 4/10/2026.

For any questions, please ask in the Slack channel #help-security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only pins the `lannonbr/repo-permission-check-action` reference in the release workflow to an exact commit hash, with no functional logic changes expected.
> 
> **Overview**
> Pins the `lannonbr/repo-permission-check-action` used in `.github/workflows/release.yml` from the `2.0.2` tag to its full commit SHA for supply-chain hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68c33cb16e3d727c644b9dab77ae4a4ba9764b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->