### PR TITLE
chore(deps): update Kotlin to 2.3.20, AGP to 9.1.0, Gradle to 9.4.1

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -34,8 +34,8 @@ android {
         sourceCompatibility = JavaConfig.JAVA_VERSION
         targetCompatibility = JavaConfig.JAVA_VERSION
     }
-    kotlinOptions {
-        jvmTarget = KotlinConfig.JVM_TARGET
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
     }
     testOptions {
         targetSdk = AndroidVersions.TARGET_SDK

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.mavenPublish) apply false
     alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.compose.compiler) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.bcv)
@@ -23,9 +24,9 @@ allprojects {
     version = project.findProperty("VERSION_NAME") ?: "0.0.1-SNAPSHOT"
 
     tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = KotlinConfig.JVM_TARGET
-            freeCompilerArgs = listOf("-Xjvm-default=all")
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+            freeCompilerArgs.add("-Xjvm-default=all")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
+android.builtInKotlin=false
 kotlin.code.style=official
 
 android.nonTransitiveRClass=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,14 +3,14 @@ activityCompose = "1.10.1"
 bcv = "0.16.3"
 activityKtx = "1.9.1"
 analyticsConnector = "1.0.0"
-androidGradlePlugin = "8.10.1"
+androidGradlePlugin = "9.1.0"
 androidJunit5 = "1.12.2.0"
 appcompat = "1.4.1"
 composeBom = "2025.06.01"
 composeUi = "1.6.8"
 constraintlayout = "2.1.3"
 coreKtx = "1.7.0"
-coroutines = "1.8.1"
+coroutines = "1.10.2"
 curtains = "1.2.5"
 dokka = "2.0.0"
 espressoCore = "3.4.0"
@@ -20,8 +20,7 @@ gson = "2.10"
 json = "20211205"
 junit = "5.9.3"
 junit4 = "4.13.2"
-kotlin = "1.9.25"
-kotlinCompilerExtension = "1.5.15"
+kotlin = "2.3.20"
 ktlint = "12.3.0"
 material = "1.5.0"
 mavenPublish = "0.33.0"
@@ -88,6 +87,7 @@ android-library = { id = "com.android.library", version.ref = "androidGradlePlug
 android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/kotlin-android-app/build.gradle.kts
+++ b/samples/kotlin-android-app/build.gradle.kts
@@ -3,6 +3,7 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     kotlin("android")
+    alias(libs.plugins.kotlin.compose.compiler)
 }
 
 // Load properties from local.properties in the root project
@@ -49,8 +50,8 @@ android {
         sourceCompatibility = JavaConfig.JAVA_VERSION
         targetCompatibility = JavaConfig.JAVA_VERSION
     }
-    kotlinOptions {
-        jvmTarget = KotlinConfig.JVM_TARGET
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
     }
     lint {
         abortOnError = false
@@ -58,9 +59,6 @@ android {
     buildFeatures {
         buildConfig = true
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.kotlinCompilerExtension.get()
     }
 }
 


### PR DESCRIPTION
### Describe what this PR is addressing

Major build toolchain upgrade for the Amplitude Kotlin SDK. The current versions (Kotlin 1.9.25, AGP 8.10.1, Gradle 8.14.1) are multiple major versions behind the latest stable releases. This upgrade is necessary to:

- Access Kotlin 2.x language features and the K2 compiler
- Stay on supported AGP and Gradle versions
- Unblock further dependency updates (coroutines 1.10.x, OkHttp 5.x, Compose UI 1.10.x) that require Kotlin 2.x

### Describe the solution

**Version bumps:**

| Component | Old Version | New Version |
|---|---|---|
| Kotlin | 1.9.25 | 2.3.20 |
| Android Gradle Plugin | 8.10.1 | 9.1.0 |
| Gradle wrapper | 8.14.1 | 9.4.1 |
| kotlinx-coroutines | 1.8.1 | 1.10.2 |

**Build system changes:**

1. **`kotlinOptions` → `compilerOptions` DSL**: Kotlin 2.x deprecates `kotlinOptions` in favor of the typed `compilerOptions` API. Updated all build files (`build.gradle.kts`, `android/build.gradle.kts`, `samples/kotlin-android-app/build.gradle.kts`).

2. **Compose compiler migration**: With Kotlin 2.x, the Compose compiler is bundled with Kotlin. Replaced `composeOptions { kotlinCompilerExtensionVersion = "..." }` with the `org.jetbrains.kotlin.plugin.compose` plugin. Removed the now-unnecessary `kotlinCompilerExtension` version from the version catalog.

3. **AGP 9 built-in Kotlin opt-out**: Added `android.builtInKotlin=false` to `gradle.properties` to maintain the existing `kotlin("android")` plugin pattern. This can be removed in a follow-up when the team is ready to adopt AGP's built-in Kotlin support.

4. **Coroutines 1.10.2**: Required for Kotlin 2.x binary compatibility. Includes structured concurrency improvements and bug fixes.

### Steps to verify the change

1. `./gradlew build` — verify full project compiles
2. `./gradlew :core:test` — run core unit tests
3. `./gradlew :android:test` — run Android unit tests
4. `./gradlew apiCheck` — verify binary compatibility (public API surface)
5. `./gradlew apiDump` — regenerate `.api` files if needed (Kotlin 2.x K2 compiler may produce slightly different metadata)

### Useful links and documentation

- [Kotlin 2.3.20 release notes](https://blog.jetbrains.com/kotlin/2026/03/kotlin-2-3-20-released/)
- [K2 compiler migration guide](https://kotlinlang.org/docs/k2-compiler-migration-guide.html)
- [Kotlin 2.0 compatibility guide](https://kotlinlang.org/docs/compatibility-guide-20.html)
- [AGP 9.0 release notes](https://developer.android.com/build/releases/agp-9-0-0-release-notes)
- [AGP 9.1 release notes](https://developer.android.com/build/releases/agp-9-1-0-release-notes)
- [AGP 9 migration guide (nek12.dev)](https://nek12.dev/blog/en/agp-9-0-migration-guide-android-gradle-plugin-9-kmp-migration-kotlin/)
- [Gradle 9.0 upgrade guide](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html)
- [kotlinx-coroutines releases](https://github.com/Kotlin/kotlinx.coroutines/releases)

## ⚠️ Draft PR — Requires Human Review and CI Verification

This PR could not be build-verified locally due to environment restrictions (Google Maven unavailable). It is opened as a **draft** to allow CI to run and identify any additional issues.

**Known areas that may need attention:**

1. **Binary compatibility**: The K2 compiler may generate slightly different bytecode. `./gradlew apiCheck` should be run — if `.api` files change, they need to be regenerated with `./gradlew apiDump` and the diff reviewed carefully.

2. **`-Xjvm-default=all`**: This flag is retained for backward compatibility. In Kotlin 2.x, default method generation is the standard behavior, but the flag still works. It can be removed in a follow-up.

3. **AGP 9 DSL changes**: AGP 9.0 removed some deprecated DSL APIs. If any are used in the codebase (beyond what's in the build files), they may need updating.

4. **BCV plugin compatibility**: The binary-compatibility-validator (0.16.3) should be checked for Kotlin 2.x compatibility. May need updating.

5. **ktlint plugin compatibility**: The ktlint plugin (12.3.0) may need updating for Gradle 9 compatibility.

6. **Jetifier**: `android.enableJetifier=true` is retained but should be removed in a follow-up as all dependencies are AndroidX.

## Codex Review

Reviewed as a senior Android SDK engineer:

- **Binary compatibility**: This is the highest risk area. Kotlin 2.x's K2 compiler may generate different overloads or default parameter bridges. The `.api` files (`core/api/core.api`, `android/api/android.api`) must be checked via `apiCheck`/`apiDump`. Any changes should be reviewed line-by-line.
- **API surface**: No intentional public API changes. All modifications are to build files and the version catalog.
- **Customer impact**: coroutines 1.10.2 is binary-compatible with 1.8.x from the consumer's perspective. The `kotlin-stdlib` 2.3.20 is backward-compatible with code compiled against 1.9.x.
- **JVM target**: Remains at 1.8, preserving maximum compatibility for consumers.
- **Compose UI**: The `compileOnly` Compose UI dependency (1.6.8) is unchanged — it will work with the new Kotlin version since it's only used for API signatures.

## Adversarial Review

- **Security**: Kotlin 2.3.20, AGP 9.1.0, and Gradle 9.4.1 are all latest stable releases from trusted publishers (JetBrains, Google, Gradle Inc). No known CVEs. Coroutines 1.10.2 has no known security issues.
- **Silent behavior changes**: The K2 compiler has stricter type inference and smarter smart-casts. Code that compiled with Kotlin 1.9 might fail with K2 if it relied on lenient type checking. This should surface as compilation errors, not silent runtime changes.
- **Method count / AAR size**: Kotlin 2.x stdlib is slightly larger due to new APIs. The impact on the final SDK AAR should be measured. Coroutines 1.10.2 is roughly the same size as 1.8.1.
- **Runtime behavior**: Coroutines 1.10.2 includes bug fixes for structured concurrency edge cases. These are correctness improvements, not behavior changes.
- **Rollback plan**: If issues are found post-merge, the version catalog and build files can be reverted independently.

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change? — **Potentially (binary compatibility needs verification)**