### PR TITLE
test: regression coverage for remote config subscriber concurrency

### DIFF
--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -18,6 +18,8 @@ import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -25,6 +27,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class RemoteConfigClientTest {
     private val storage = InMemoryStorage()
@@ -359,6 +365,88 @@ class RemoteConfigClientTest {
                 )
             }
         }
+
+    @Test
+    fun `concurrent subscribe and updateConfigs - no crash under heavy contention`() {
+        // Use real threads + real dispatchers to reproduce the race that a
+        // StandardTestDispatcher cannot. Pre-fix (commit 7cedc4b), cleanupDeadReferences
+        // iterating CopyOnWriteArrayList.removeAll concurrently with subscribers
+        // mutating the same list threw ArrayIndexOutOfBoundsException from
+        // AutocaptureManager.<init>, taking down SDK init.
+        val executorService = Executors.newFixedThreadPool(8)
+        val networkDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        val storageDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        val scope = CoroutineScope(Dispatchers.Default)
+
+        val mockHttpClient = mockk<HttpClient>()
+        every { mockHttpClient.request(any()) } answers {
+            // Simulate network latency so fetches overlap subscribe calls.
+            Thread.sleep(2)
+            HttpClient.Response(
+                statusCode = 200,
+                body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
+                headers = emptyMap(),
+                statusMessage = "OK",
+            )
+        }
+
+        val client =
+            RemoteConfigClientImpl(
+                apiKey = "test-key",
+                serverZone = ServerZone.US,
+                coroutineScope = scope,
+                networkIODispatcher = networkDispatcher,
+                storageIODispatcher = storageDispatcher,
+                storage = InMemoryStorage(),
+                httpClient = mockHttpClient,
+                logger = silentLogger,
+            )
+
+        val iterations = 2_000
+        val errors = ConcurrentLinkedQueue<Throwable>()
+        val latch = CountDownLatch(iterations)
+
+        repeat(iterations) { i ->
+            executorService.submit {
+                try {
+                    val key =
+                        if (i % 2 == 0) {
+                            Key.SESSION_REPLAY_PRIVACY_CONFIG
+                        } else {
+                            Key.SESSION_REPLAY_SAMPLING_CONFIG
+                        }
+                    // Temp callback (not held) so some become dead references
+                    // and exercise cleanupDeadReferences' removeAll path.
+                    client.subscribe(key) { _, _, _ -> }
+
+                    if (i % 7 == 0) {
+                        client.updateConfigs()
+                    }
+
+                    if (i % 50 == 0) {
+                        System.gc()
+                    }
+                } catch (t: Throwable) {
+                    errors.add(t)
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        val finished = latch.await(30, TimeUnit.SECONDS)
+        executorService.shutdownNow()
+        executorService.awaitTermination(5, TimeUnit.SECONDS)
+        networkDispatcher.close()
+        storageDispatcher.close()
+
+        assertTrue(finished, "Test timed out waiting for tasks")
+        assertTrue(
+            errors.isEmpty(),
+            "Expected no errors, but got ${errors.size}: " +
+                errors.joinToString { "${it::class.simpleName}: ${it.message}" },
+        )
+    }
 
     // endregion Subscription Management
 


### PR DESCRIPTION
Follow-up to #393. Adds a multi-threaded stress test (8 threads x 2,000 iterations) that reproduces the ArrayIndexOutOfBoundsException from cleanupDeadReferences on the pre-fix code. Uses real threads + live dispatchers to surface the race that StandardTestDispatcher cannot.

<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉
Please fill out the following sections to help us quickly review your pull request.
--->

### Describe what this PR is addressing
<!-- Describe the motivation and context for the change so reviewers can understand the problem you're solving. -->

### Describe the solution
<!-- Describe the changes made in this PR. Include any relevant details about the implementation, design decisions, or trade-offs.
* Why did you choose this way to solve the problem?
* What future impact will this have?
-->

### Steps to verify the change
<!-- Describe how to test the changes made in this PR. Include any relevant details about the testing environment, tools, or frameworks used. -->

### Useful links and documentation (optional)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds a stress/regression test, but it introduces real-thread concurrency and timing that can be flaky/slow in CI if not well-bounded.
> 
> **Overview**
> Adds a new multithreaded stress test for `RemoteConfigClientImpl` that repeatedly calls `subscribe()` and intermittently `updateConfigs()` under heavy contention using real executors/dispatchers, asserting no exceptions are thrown.
> 
> The test simulates network latency and forces some callbacks to become dead weak references (via scope + occasional `System.gc()`) to specifically exercise the `cleanupDeadReferencesLocked()` removal path that previously crashed with `ArrayIndexOutOfBoundsException`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbbfa524120b04cc2fc9d9f0efd0fed0204e1afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->