### PR TITLE
chore(ci): bump JDK from 17 to 21

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [21]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -36,16 +36,16 @@ jobs:
           retention-days: 7
 
   test-and-lint:
-    name: Test and Lint with JDK 17
+    name: Test and Lint with JDK 21
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 


### PR DESCRIPTION
### Describe what this PR is addressing

Prerequisite for a follow-up `compileSdk` bump to 36. Android API 36 requires a JDK 21+ runtime to execute Robolectric tests — we need CI on JDK 21 before that PR can land.

### Describe the solution

Bumps `java-version` from `17` → `21` across three workflows:

| Workflow | Job |
|---|---|
| `pull-request-test.yml` | `build` matrix + `test-and-lint` |
| `release.yml` | Semantic Release |
| `docs.yml` | Dokka publish |

Nothing about the SDK bytecode changes — `JavaConfig.JVM_TARGET` stays at `1.8`. Consumer-facing binary is unaffected. This is a CI-only change.

Opening as draft to see CI results on JDK 21 before flipping to ready.

### Steps to verify the change

1. CI `build` job passes on JDK 21
2. CI `test-and-lint` job passes on JDK 21
3. `apiCheck` passes

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change? — No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates the Java runtime used in GitHub Actions; the main risk is unexpected build/test/release failures due to JDK 21 compatibility issues in Gradle/plugins or tooling.
> 
> **Overview**
> **CI now runs on JDK 21 instead of JDK 17** across the docs publish workflow (`docs.yml`), pull request build/test/lint workflows (`pull-request-test.yml`, including the build matrix), and the release workflow (`release.yml`).
> 
> No application/SDK build targets are changed; this only updates the GitHub Actions Java runtime used to execute Gradle, tests, and Dokka during CI/release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa739e4af13f8da145e792777b80554a4c05b242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->