### PR TITLE
chore(deps): bump compileSdk/targetSdk to 36

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [17]
+        java-version: [21]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -36,16 +36,16 @@ jobs:
           retention-days: 7
 
   test-and-lint:
-    name: Test and Lint with JDK 17
+    name: Test and Lint with JDK 21
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -38,7 +38,9 @@ android {
         jvmTarget = KotlinConfig.JVM_TARGET
     }
     testOptions {
-        targetSdk = AndroidVersions.TARGET_SDK
+        // Cap unit-test targetSdk to Robolectric's supported ceiling. Robolectric 4.15.1
+        // rejects test APKs with targetSdk > 35. Bump this alongside any Robolectric upgrade.
+        targetSdk = 35
         unitTests.isIncludeAndroidResources = true
         unitTests.isReturnDefaultValues = true
     }

--- a/buildSrc/src/main/kotlin/AndroidVersions.kt
+++ b/buildSrc/src/main/kotlin/AndroidVersions.kt
@@ -1,5 +1,5 @@
 object AndroidVersions {
-    const val COMPILE_SDK = 35
+    const val COMPILE_SDK = 36
     const val MIN_SDK = 21
     const val TARGET_SDK = COMPILE_SDK
 }


### PR DESCRIPTION
### Describe what this PR is addressing

Google Play requires `targetSdk 36` by **Aug 31 2026**. Bumping now is the smallest lever that unlocks the next wave of AndroidX deps (activity 1.11+, core-ktx 1.18+) for a future round.

**Stacked on #398** (CI JDK 17 → 21). Merge #398 first.

### Describe the solution

Two changes:

| Change | File | Why |
|---|---|---|
| `COMPILE_SDK = 35 → 36` | `buildSrc/src/main/kotlin/AndroidVersions.kt` | Target Android 16 / API 36 |
| `testOptions.targetSdk = 35` | `android/build.gradle.kts` | Cap unit-test APK `targetSdk` at Robolectric 4.15.1's ceiling |

**Why cap `testOptions.targetSdk` instead of upgrading Robolectric?**

Robolectric 4.15.1 rejects test APKs where `targetSdk > 35` (`Package targetSdkVersion=36 > maxSdkVersion=35`). Two options:

1. Upgrade Robolectric to 4.16+ — it accepts `targetSdk 36`, but drops support for API 21 / 22 sandboxes (`UnknownSdk`). Since `minSdk = 21`, we still want test coverage for those sandboxes.
2. Cap `testOptions.targetSdk` to 35 — Robolectric stays on 4.15.1 with full API 21+ sandbox support; the published library still targets API 36.

Option 2 is smaller and preserves pre-API-23 test coverage. When we later upgrade Robolectric, delete this override.

No code changes — the SDK source already uses only APIs present in API 21+.

### Steps to verify the change

- CI `Build with JDK 21`: ✅ passes
- CI `Test and Lint with JDK 21`: ✅ passes
- Local `./gradlew :android:testDebugUnitTest` on JDK 17: passes (tests use Robolectric 4.15.1 sandbox, not the runtime API 36)

### Useful links

- [Android 16 behavior changes for apps targeting 36](https://developer.android.com/about/versions/16/behavior-changes-16) — reviewed; none affect this SDK (no foreground services, no storage / privacy API changes, no lifecycle changes that touch us)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change? — No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-configuration change; main risk is CI/test behavior differences because unit tests now build against a capped `targetSdk` while the library targets API 36.
> 
> **Overview**
> Updates Android SDK levels to target API 36 by setting `AndroidVersions.COMPILE_SDK` (and thus `TARGET_SDK`) to `36`.
> 
> Adds a unit-test-only override in `android/build.gradle.kts` to cap `testOptions.targetSdk` at `35` to avoid Robolectric 4.15.1 rejecting test APKs with `targetSdk > 35`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac686edc3ca078b2ade87850dc99892d76e1931d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->