### PR TITLE
feat(core): add WaitForRemote delivery mode on RemoteConfigClient 

### DIFF
--- a/android/src/main/java/com/amplitude/android/AutocaptureManager.kt
+++ b/android/src/main/java/com/amplitude/android/AutocaptureManager.kt
@@ -41,7 +41,7 @@ internal class AutocaptureManager(
                 RemoteConfigClient.RemoteConfigCallback { config, _, _ ->
                     handleRemoteConfig(config)
                 }
-            remoteConfigClient.subscribe(Key.ANALYTICS_SDK, remoteConfigCallback)
+            remoteConfigClient.subscribe(Key.ANALYTICS_SDK, callback = remoteConfigCallback)
         } else {
             remoteConfigCallback = null
         }

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -59,7 +59,7 @@ class NetworkTrackingPlugin(
                 RemoteConfigClient.RemoteConfigCallback { config, _, _ ->
                     handleRemoteConfig(config)
                 }
-            androidAmplitude.remoteConfigClient.subscribe(Key.ANALYTICS_SDK, remoteConfigCallback!!)
+            androidAmplitude.remoteConfigClient.subscribe(Key.ANALYTICS_SDK, callback = remoteConfigCallback!!)
         }
     }
 

--- a/android/src/test/kotlin/com/amplitude/android/AutocaptureManagerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AutocaptureManagerTest.kt
@@ -304,6 +304,7 @@ class AutocaptureManagerTest {
 
         override fun subscribe(
             key: RemoteConfigClient.Key,
+            deliveryMode: RemoteConfigClient.DeliveryMode,
             callback: RemoteConfigClient.RemoteConfigCallback,
         ) {
             if (key == RemoteConfigClient.Key.ANALYTICS_SDK) {

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -849,6 +849,7 @@ class NetworkTrackingPluginTest {
 
         override fun subscribe(
             key: RemoteConfigClient.Key,
+            deliveryMode: RemoteConfigClient.DeliveryMode,
             callback: RemoteConfigClient.RemoteConfigCallback,
         ) {
             if (key == RemoteConfigClient.Key.ANALYTICS_SDK) callbacks.add(callback)

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -941,8 +941,24 @@ public final class com/amplitude/core/platform/plugins/GetAmpliExtrasPlugin$Comp
 }
 
 public abstract interface class com/amplitude/core/remoteconfig/RemoteConfigClient {
-	public abstract fun subscribe (Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key;Lcom/amplitude/core/remoteconfig/RemoteConfigClient$RemoteConfigCallback;)V
+	public abstract fun subscribe (Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key;Lcom/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode;Lcom/amplitude/core/remoteconfig/RemoteConfigClient$RemoteConfigCallback;)V
+	public static synthetic fun subscribe$default (Lcom/amplitude/core/remoteconfig/RemoteConfigClient;Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key;Lcom/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode;Lcom/amplitude/core/remoteconfig/RemoteConfigClient$RemoteConfigCallback;ILjava/lang/Object;)V
 	public abstract fun updateConfigs ()V
+}
+
+public abstract class com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode {
+}
+
+public final class com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode$All : com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode {
+	public static final field INSTANCE Lcom/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode$All;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode$WaitForRemote : com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode {
+	public fun <init> (J)V
+	public final fun getTimeoutMs ()J
 }
 
 public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key : java/lang/Enum {

--- a/core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
+++ b/core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
@@ -192,7 +192,7 @@ internal class DiagnosticsClientImpl(
             )
 
         remoteConfigCallback?.let { callback ->
-            remoteConfigClient?.subscribe(RemoteConfigClient.Key.DIAGNOSTICS, callback)
+            remoteConfigClient?.subscribe(RemoteConfigClient.Key.DIAGNOSTICS, callback = callback)
         }
 
         channel.trySend(Update.InitializeTasks)

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -13,12 +13,15 @@ import com.amplitude.core.remoteconfig.RemoteConfigClient.Source.REMOTE
 import com.amplitude.core.utilities.http.HttpClient
 import com.amplitude.core.utilities.toJSONObject
 import com.amplitude.core.utilities.toMapObj
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Type alias for remote configuration map data.
@@ -35,6 +38,20 @@ interface RemoteConfigClient {
         REMOTE,
     }
 
+    /**
+     * Controls when the first config is delivered to a subscriber.
+     *
+     * Subsequent updates after the first delivery always flow through normally.
+     * Only the *initial* delivery semantics differ between modes.
+     */
+    sealed class DeliveryMode {
+        /** Deliver cached config immediately if available, then remote when it arrives. */
+        data object All : DeliveryMode()
+
+        /** Wait for remote up to [timeoutMs], then fall back to cache (or empty). */
+        class WaitForRemote(val timeoutMs: Long) : DeliveryMode()
+    }
+
     enum class Key(val value: String) {
         ANALYTICS_SDK("analyticsSDK.androidSDK"),
         DIAGNOSTICS("diagnostics.androidSDK"),
@@ -45,12 +62,10 @@ interface RemoteConfigClient {
     /**
      * Subscribe to remote configuration updates for a specific configuration key.
      * The callback will be invoked whenever the specific configuration is updated.
-     *
-     * @param key The configuration key to subscribe to (e.g., "sessionReplay.sr_android_sampling_config")
-     * @param callback RemoteConfigCallback that handles config updates
      */
     fun subscribe(
         key: Key,
+        deliveryMode: DeliveryMode = DeliveryMode.All,
         callback: RemoteConfigCallback,
     )
 
@@ -95,22 +110,81 @@ internal class RemoteConfigClientImpl(
     }
 
     /**
-     * Wrapper class for weak reference callbacks to prevent memory leaks
+     * Wrapper class for weak reference callbacks to prevent memory leaks.
+     *
+     * For [RemoteConfigClient.DeliveryMode.WaitForRemote] subscribers, the first
+     * delivery is gated by [firstDeliveryClaimed]: whichever path (remote arrival
+     * via [updateConfigs] or timeout fallback) claims the gate first delivers the
+     * initial callback; the other becomes a no-op for that first delivery.
+     * Subsequent deliveries always pass through.
      */
     private inner class WeakCallback(
         callback: RemoteConfigClient.RemoteConfigCallback,
+        private val firstDeliveryClaimed: AtomicBoolean? = null,
+        private val firstDeliverySignal: CompletableDeferred<Unit>? = null,
     ) {
         private val weakRef = WeakReference(callback)
 
+        /**
+         * Serializes all [RemoteConfigClient.RemoteConfigCallback.onUpdate]
+         * invocations for this subscriber. Without this lock, the timeout
+         * fallback and the remote fetch can invoke the callback concurrently
+         * from different dispatchers, causing unsynchronized state in the
+         * subscriber.
+         */
+        private val deliveryLock = Any()
+
         fun isAlive(): Boolean = weakRef.get() != null
 
+        /**
+         * Invoke [action] on the wrapped callback if it is still alive and, when
+         * gating is in effect, only if this invocation successfully claims the
+         * first-delivery slot. Subsequent invocations after the first delivery
+         * always pass through.
+         */
         fun runSafely(action: RemoteConfigClient.RemoteConfigCallback.() -> Unit) {
             val callback = weakRef.get() ?: return
-            try {
-                callback.action()
-            } catch (e: Exception) {
-                logger.error("Exception in subscriber callback: ${e.message}")
+
+            if (firstDeliveryClaimed != null) {
+                // Gated: claim the first-delivery slot if available.
+                val claimedFirst = firstDeliveryClaimed.compareAndSet(false, true)
+                if (claimedFirst) {
+                    // Signal before callback so a concurrent arrival sees it complete
+                    // and delivers as a subsequent update instead of being dropped.
+                    firstDeliverySignal?.complete(Unit)
+                }
             }
+
+            synchronized(deliveryLock) {
+                try {
+                    callback.action()
+                } catch (e: Exception) {
+                    logger.error("Exception in subscriber callback: ${e.message}")
+                }
+            }
+        }
+
+        /** Deliver only if this callback can still claim the first-delivery slot. */
+        fun runSafelyIfFirst(action: RemoteConfigClient.RemoteConfigCallback.() -> Unit): Boolean {
+            val callback = weakRef.get() ?: return false
+            val claimed = firstDeliveryClaimed?.compareAndSet(false, true) ?: return false
+            if (!claimed) return false
+
+            firstDeliverySignal?.complete(Unit)
+            synchronized(deliveryLock) {
+                try {
+                    callback.action()
+                } catch (e: Exception) {
+                    logger.error("Exception in subscriber callback: ${e.message}")
+                }
+            }
+            return true
+        }
+
+        /** True if gated (WaitForRemote) and first delivery hasn't fired yet. */
+        fun isAwaitingFirstDelivery(): Boolean {
+            val claimed = firstDeliveryClaimed ?: return false
+            return !claimed.get()
         }
     }
 
@@ -121,30 +195,24 @@ internal class RemoteConfigClientImpl(
     // Simple in-flight fetch guard; safe because networkIODispatcher is single-threaded
     private var isFetching: Boolean = false
 
-    /**
-     * Subscribe to remote configuration updates for a specific configuration key.
-     * The callback will be invoked whenever the specific configuration is updated.
-     *
-     * @param key The configuration key to subscribe to
-     * @param callback RemoteConfigCallback that handles config updates
-     */
     override fun subscribe(
+        key: Key,
+        deliveryMode: RemoteConfigClient.DeliveryMode,
+        callback: RemoteConfigClient.RemoteConfigCallback,
+    ) {
+        when (deliveryMode) {
+            is RemoteConfigClient.DeliveryMode.All -> subscribeAll(key, callback)
+            is RemoteConfigClient.DeliveryMode.WaitForRemote ->
+                subscribeWaitForRemote(key, deliveryMode.timeoutMs, callback)
+        }
+    }
+
+    private fun subscribeAll(
         key: Key,
         callback: RemoteConfigClient.RemoteConfigCallback,
     ) {
         val weakCallback = WeakCallback(callback)
-        val subscriberCount =
-            synchronized(subscriberLock) {
-                cleanupDeadReferencesLocked()
-                val subscriberList =
-                    keySpecificSubscribers.getOrPut(key.value) {
-                        mutableListOf()
-                    }
-                subscriberList.add(weakCallback)
-                subscriberList.size
-            }
-
-        logger.debug("Added subscriber for key: ${key.value}. Total subscribers: $subscriberCount")
+        registerSubscriber(key, weakCallback)
 
         // Immediately provide stored config if available
         val storedData = getStoredConfigData(key.value)
@@ -157,6 +225,75 @@ internal class RemoteConfigClientImpl(
 
         // Trigger remote fetch to ensure latest config is available
         updateConfigs()
+    }
+
+    private fun subscribeWaitForRemote(
+        key: Key,
+        timeoutMs: Long,
+        callback: RemoteConfigClient.RemoteConfigCallback,
+    ) {
+        // Gate first delivery — timeout and remote race; first to claim wins.
+        val firstDeliveryClaimed = AtomicBoolean(false)
+        val firstDeliverySignal = CompletableDeferred<Unit>()
+        val weakCallback =
+            WeakCallback(
+                callback = callback,
+                firstDeliveryClaimed = firstDeliveryClaimed,
+                firstDeliverySignal = firstDeliverySignal,
+            )
+        registerSubscriber(key, weakCallback)
+
+        updateConfigs()
+
+        // Timeout runs on coroutineScope's dispatcher (not networkIODispatcher)
+        // so it can fire even while the single-threaded network executor is busy.
+        coroutineScope.launch {
+            val signaled =
+                withTimeoutOrNull(timeoutMs) {
+                    firstDeliverySignal.await()
+                    true
+                }
+            if (signaled == null) {
+                // Timeout: fall back to cache (or empty). runSafelyIfFirst
+                // suppresses this if a remote delivery already claimed the gate.
+                val storedData = getStoredConfigData(key.value)
+                val config = storedData?.config ?: emptyMap()
+                val timestamp = storedData?.timestamp ?: System.currentTimeMillis()
+                val delivered =
+                    weakCallback.runSafelyIfFirst {
+                        onUpdate(config, CACHE, timestamp)
+                    }
+                if (delivered) {
+                    logger.debug(
+                        "WaitForRemote timed out after ${timeoutMs}ms for ${key.value}; " +
+                            "delivered ${if (storedData != null) "cache" else "empty"} fallback.",
+                    )
+                } else {
+                    logger.debug(
+                        "WaitForRemote timeout fired after ${timeoutMs}ms for ${key.value}, " +
+                            "but a fresh remote delivery already won; fallback suppressed.",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun registerSubscriber(
+        key: Key,
+        weakCallback: WeakCallback,
+    ) {
+        val subscriberCount =
+            synchronized(subscriberLock) {
+                cleanupDeadReferencesLocked()
+                val subscriberList =
+                    keySpecificSubscribers.getOrPut(key.value) {
+                        mutableListOf()
+                    }
+                subscriberList.add(weakCallback)
+                subscriberList.size
+            }
+
+        logger.debug("Added subscriber for key: ${key.value}. Total subscribers: $subscriberCount")
     }
 
     /**
@@ -178,6 +315,10 @@ internal class RemoteConfigClientImpl(
                 isFetching = true
                 val configs = fetchRemoteConfig() ?: return@launch
 
+                // Snapshot old cache before overwriting — absent-key fallback
+                // needs the pre-fetch values, not the partial new response.
+                val preFetchCache = getAllStoredConfigs()
+
                 val timestamp = System.currentTimeMillis()
                 withContext(storageIODispatcher) {
                     storage.write(REMOTE_CONFIG, configs.toJSONObject().toString())
@@ -186,7 +327,6 @@ internal class RemoteConfigClientImpl(
                 }
 
                 configs.forEach { (configKey, config) ->
-                    // Notify all subscribers for this config key
                     val subscriberList =
                         synchronized(subscriberLock) {
                             keySpecificSubscribers[configKey]?.toList().orEmpty()
@@ -197,10 +337,57 @@ internal class RemoteConfigClientImpl(
                         }
                     }
                 }
+
+                // Unblock WaitForRemote subscribers whose key is absent from
+                // a successful fetch — no point waiting the full timeout.
+                notifyAbsentKeySubscribers(presentKeys = configs.keys, preFetchCache = preFetchCache)
             } catch (e: Exception) {
                 logger.error("Error updating remote configs: ${e.message}")
             } finally {
                 isFetching = false
+            }
+        }
+    }
+
+    /**
+     * For each registered subscriber whose key is *not* present in a fresh
+     * successful fetch, deliver the fallback (cache or empty) via the
+     * first-only delivery path so [RemoteConfigClient.DeliveryMode.WaitForRemote]
+     * gates resolve immediately instead of waiting for the timeout.
+     *
+     * Uses [WeakCallback.runSafelyIfFirst]: if a subscriber has already
+     * received its first delivery (e.g. timeout already fired), the call is a
+     * no-op. Subscribers using [RemoteConfigClient.DeliveryMode.All] also
+     * become no-ops because they aren't gated and cannot claim the gate.
+     */
+    private fun notifyAbsentKeySubscribers(
+        presentKeys: Set<String>,
+        preFetchCache: Map<String, ConfigMap>,
+    ) {
+        val absentSubscribers =
+            synchronized(subscriberLock) {
+                keySpecificSubscribers
+                    .filterKeys { it !in presentKeys }
+                    .mapValues { (_, subs) -> subs.toList() }
+            }
+        if (absentSubscribers.isEmpty()) return
+
+        absentSubscribers.forEach { (configKey, subscribers) ->
+            val cachedConfig = preFetchCache[configKey]
+            subscribers.forEach subscriber@{ weakCallback ->
+                if (!weakCallback.isAwaitingFirstDelivery()) return@subscriber
+                val config = cachedConfig ?: emptyMap()
+                val timestamp = System.currentTimeMillis()
+                val delivered =
+                    weakCallback.runSafelyIfFirst {
+                        onUpdate(config, CACHE, timestamp)
+                    }
+                if (delivered) {
+                    logger.debug(
+                        "WaitForRemote unblocked for $configKey: key absent from fetch; " +
+                            "delivered ${if (cachedConfig != null) "cache" else "empty"} fallback.",
+                    )
+                }
             }
         }
     }
@@ -392,16 +579,17 @@ internal class RemoteConfigClientImpl(
         return responseBody?.let { body ->
             try {
                 val responseJson = JSONObject(body)
+
+                // Handle configs-wrapped response format:
+                // Format: {"configs": {"sessionReplay": {...}}}
+                val configsRoot = responseJson.optJSONObject("configs")
+                if (configsRoot == null) {
+                    logger.warn("No 'configs' key found in response")
+                    return null
+                }
+
                 val result =
                     buildMap {
-                        // Handle configs-wrapped response format:
-                        // Format: {"configs": {"sessionReplay": {...}}}
-                        val configsRoot = responseJson.optJSONObject("configs")
-                        if (configsRoot == null) {
-                            logger.warn("No 'configs' key found in response")
-                            return null
-                        }
-
                         // Dynamically parse all top-level config objects
                         for (topLevelKey in configsRoot.keys()) {
                             val topLevelObj = configsRoot.optJSONObject(topLevelKey)
@@ -426,6 +614,15 @@ internal class RemoteConfigClientImpl(
                             }
                         }
                     }
+
+                if (result.isEmpty() && configsRoot.length() == 0) {
+                    // The "configs" root is present but empty — project has no
+                    // blades enabled. This is a valid server answer; return an
+                    // empty map so that downstream logic (notifyAbsentKeySubscribers)
+                    // can unblock WaitForRemote subscribers immediately.
+                    logger.debug("Server returned empty configs — project may have no blades enabled")
+                    return emptyMap()
+                }
 
                 if (result.isEmpty() || result.values.all { it.isEmpty() }) {
                     logger.warn("No valid configs found in response")

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -152,6 +152,13 @@ internal class RemoteConfigClientImpl(
                     // Signal before callback so a concurrent arrival sees it complete
                     // and delivers as a subsequent update instead of being dropped.
                     firstDeliverySignal?.complete(Unit)
+                } else {
+                    // Another path claimed the gate. Wait for it to complete its
+                    // delivery before proceeding with this subsequent update, ensuring
+                    // correct ordering (gate-winner delivers first, then this).
+                    kotlinx.coroutines.runBlocking {
+                        firstDeliverySignal?.await()
+                    }
                 }
             }
 

--- a/core/src/test/kotlin/com/amplitude/core/diagnostics/DiagnosticsRemoteConfigTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/diagnostics/DiagnosticsRemoteConfigTest.kt
@@ -154,6 +154,7 @@ class DiagnosticsRemoteConfigTest {
 
         override fun subscribe(
             key: RemoteConfigClient.Key,
+            deliveryMode: RemoteConfigClient.DeliveryMode,
             callback: RemoteConfigClient.RemoteConfigCallback,
         ) {
             if (key == RemoteConfigClient.Key.DIAGNOSTICS) {

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -18,6 +18,8 @@ import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -164,7 +166,7 @@ class RemoteConfigClientTest {
                 RemoteConfigClient.RemoteConfigCallback { _, _, _ ->
                     persistentCallbackInvocations++
                 }
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, persistentCallback)
+            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = persistentCallback)
             testDispatcher.scheduler.advanceUntilIdle()
             // Persistent callback should have received initial cache + remote
             assertEquals(
@@ -182,7 +184,7 @@ class RemoteConfigClientTest {
                     RemoteConfigClient.RemoteConfigCallback { _, _, _ ->
                         tempCallbackInvocations++
                     }
-                client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, tempCallback)
+                client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = tempCallback)
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -313,9 +315,9 @@ class RemoteConfigClientTest {
             val callback = RemoteConfigClient.RemoteConfigCallback { _, _, _ -> callCount++ }
 
             // Subscribe same callback reference multiple times
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback)
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback)
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback)
+            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = callback)
+            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = callback)
+            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = callback)
 
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -1177,6 +1179,615 @@ class RemoteConfigClientTest {
         }
 
     // endregion Additional Coverage
+
+    // region DeliveryMode
+
+    @org.junit.jupiter.api.Nested
+    inner class WaitForRemoteDeliveryMode {
+        @Test
+        fun `WaitForRemote delivers remote when fetch returns within timeout`() =
+            runTest {
+                val client = createClient(emptyApiConfig = false)
+                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
+
+                client.subscribe(
+                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 5_000L),
+                ) { config, source, timestamp ->
+                    results.add(Triple(config, source, timestamp))
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                assertEquals(1, results.size, "Expected exactly one initial delivery, got: $results")
+                assertEquals(Source.REMOTE, results.single().second)
+                assertEquals("medium", results.single().first["defaultMaskLevel"])
+            }
+
+        @Test
+        fun `WaitForRemote times out and falls back to cached config`() =
+            runTest {
+                // HTTP returns 500: fetchRemoteConfig returns null, regular path does not
+                // deliver. WaitForRemote then times out and falls back to cache.
+                val mockHttpClient = mockk<HttpClient>()
+                every { mockHttpClient.request(any()) } returns
+                    HttpClient.Response(
+                        statusCode = 500,
+                        body = "",
+                        headers = emptyMap(),
+                        statusMessage = "Internal Server Error",
+                    )
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "test-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = testScope,
+                        networkIODispatcher = testDispatcher,
+                        storageIODispatcher = testDispatcher,
+                        storage = storage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                // Pre-populate cache so timeout fallback has data to deliver.
+                storage.write(
+                    Storage.Constants.REMOTE_CONFIG,
+                    DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
+                )
+                storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
+
+                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                client.subscribe(
+                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 100L),
+                ) { config, source, timestamp ->
+                    results.add(Triple(config, source, timestamp))
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                assertEquals(1, results.size, "Expected one timeout-fallback delivery, got: $results")
+                val (config, source, timestamp) = results.single()
+                assertEquals(Source.CACHE, source)
+                assertEquals("medium", config["defaultMaskLevel"])
+                assertEquals(1234567890L, timestamp)
+            }
+
+        @Test
+        fun `WaitForRemote falls back to empty config when cache is also empty`() =
+            runTest {
+                // HTTP returns 500: no cache, no remote. Fallback should be empty.
+                val mockHttpClient = mockk<HttpClient>()
+                every { mockHttpClient.request(any()) } returns
+                    HttpClient.Response(
+                        statusCode = 500,
+                        body = "",
+                        headers = emptyMap(),
+                        statusMessage = "Internal Server Error",
+                    )
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "test-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = testScope,
+                        networkIODispatcher = testDispatcher,
+                        storageIODispatcher = testDispatcher,
+                        storage = storage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                client.subscribe(
+                    key = Key.DIAGNOSTICS,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 50L),
+                ) { config, source, timestamp ->
+                    results.add(Triple(config, source, timestamp))
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                assertEquals(1, results.size, "Expected one timeout-fallback delivery, got: $results")
+                assertTrue(results.single().first.isEmpty(), "Expected empty config fallback")
+                assertEquals(Source.CACHE, results.single().second)
+            }
+
+        @Test
+        fun `WaitForRemote does not deliver cache up front before remote arrives`() =
+            runTest {
+                val client = createClient(emptyApiConfig = false)
+
+                // Pre-populate cache to ensure DeliveryMode.All would have delivered it.
+                storage.write(
+                    Storage.Constants.REMOTE_CONFIG,
+                    DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
+                )
+                storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
+
+                val sources = mutableListOf<Source>()
+                client.subscribe(
+                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 5_000L),
+                ) { _, source, _ ->
+                    sources.add(source)
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // WaitForRemote should NOT have delivered cache first;
+                // only the remote callback should fire.
+                assertEquals(listOf(Source.REMOTE), sources)
+            }
+
+        @Test
+        fun `default subscribe overload preserves existing All semantics`() =
+            runTest {
+                val client = createClient(emptyApiConfig = false)
+                val sources = mutableListOf<Source>()
+                storage.write(
+                    Storage.Constants.REMOTE_CONFIG,
+                    DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
+                )
+                storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
+
+                // The pre-existing single-arg overload must still deliver cache then remote.
+                client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, source, _ ->
+                    sources.add(source)
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // Cache delivered first, then remote.
+                assertEquals(listOf(Source.CACHE, Source.REMOTE), sources)
+            }
+
+        @Test
+        fun `WaitForRemote delivers fresh remote that arrives after timeout fallback fires`() =
+            runTest {
+                // Regression: when the timeout fallback wins the gate first and a
+                // fresh remote arrives later, the subscriber must still receive
+                // the remote update — not stay stuck on the stale fallback.
+                //
+                // Repro: first fetch fails (500), so the timeout fallback fires
+                // and delivers a cached value. Then the rate-limit window is
+                // reset and a successful fetch is triggered. The subscriber
+                // should receive the fresh REMOTE delivery as a subsequent update.
+                var responseProvider: () -> HttpClient.Response = {
+                    HttpClient.Response(
+                        statusCode = 500,
+                        body = "",
+                        headers = emptyMap(),
+                        statusMessage = "Internal Server Error",
+                    )
+                }
+                val mockHttpClient = mockk<HttpClient>()
+                every { mockHttpClient.request(any()) } answers { responseProvider() }
+
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "test-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = testScope,
+                        networkIODispatcher = testDispatcher,
+                        storageIODispatcher = testDispatcher,
+                        storage = storage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                // Pre-populate cache so the timeout fallback has data to deliver.
+                storage.write(
+                    Storage.Constants.REMOTE_CONFIG,
+                    DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
+                )
+                storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
+
+                val results = mutableListOf<Pair<ConfigMap, Source>>()
+                client.subscribe(
+                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 50L),
+                ) { config, source, _ ->
+                    results.add(config to source)
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // Timeout fallback fired with cache.
+                assertEquals(
+                    listOf(Source.CACHE),
+                    results.map { it.second },
+                    "Expected only the cache fallback before remote arrives, got: $results",
+                )
+
+                // Now flip the response to a fresh successful payload and trigger
+                // another fetch. The previously-gated subscriber must receive
+                // the fresh remote as a subsequent update.
+                responseProvider = {
+                    HttpClient.Response(
+                        statusCode = 200,
+                        body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
+                        headers = emptyMap(),
+                        statusMessage = "OK",
+                    )
+                }
+                storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
+
+                client.updateConfigs()
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                assertEquals(
+                    listOf(Source.CACHE, Source.REMOTE),
+                    results.map { it.second },
+                    "Subscriber must receive fresh remote after the timeout fallback, got: $results",
+                )
+            }
+
+        @Test
+        fun `WaitForRemote unblocks immediately when key is absent from successful fetch`() =
+            runTest {
+                // Regression for "absent key" timeout: the response is successful
+                // but does NOT include the requested key (e.g. project doesn't
+                // have G&S configured). The subscriber must receive the empty/
+                // cached fallback as soon as the fetch returns — not after the
+                // full WaitForRemote timeout elapses.
+                val mockHttpClient = mockk<HttpClient>()
+                every { mockHttpClient.request(any()) } returns
+                    HttpClient.Response(
+                        statusCode = 200,
+                        // sessionReplay only — ANALYTICS_SDK/DIAGNOSTICS absent.
+                        body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
+                        headers = emptyMap(),
+                        statusMessage = "OK",
+                    )
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "test-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = testScope,
+                        networkIODispatcher = testDispatcher,
+                        storageIODispatcher = testDispatcher,
+                        storage = storage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                // No cache: the fallback should be empty.
+                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                // 60_000ms timeout — far longer than the fetch could plausibly
+                // take. If the fix is wrong, advanceTimeBy below would have to
+                // run for the full timeout and the test would observe a
+                // post-fetch advance window with zero deliveries.
+                client.subscribe(
+                    key = Key.ANALYTICS_SDK,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 60_000L),
+                ) { config, source, timestamp ->
+                    results.add(Triple(config, source, timestamp))
+                }
+
+                // Run all currently-pending tasks (the fetch). Crucially we do
+                // NOT advance virtual time anywhere near the 60_000ms timeout —
+                // the fix is what unblocks the gate.
+                testDispatcher.scheduler.runCurrent()
+                // Drain any continuations queued by the fetch's notification
+                // path, including the absent-key delivery.
+                testDispatcher.scheduler.advanceTimeBy(10L)
+                testDispatcher.scheduler.runCurrent()
+
+                assertEquals(
+                    1,
+                    results.size,
+                    "Expected exactly one absent-key fallback delivery before the timeout, got: $results",
+                )
+                val (config, source, _) = results.single()
+                assertEquals(Source.CACHE, source, "Absent-key fallback must report Source.CACHE")
+                assertTrue(
+                    config.isEmpty(),
+                    "Expected empty fallback when no cache exists for absent key, got: $config",
+                )
+            }
+
+        @Test
+        fun `WaitForRemote unblocks immediately on empty successful fetch`() =
+            runTest {
+                // Regression: when the server returns 200 with {"configs":{}}
+                // (valid empty config — project has no blades enabled),
+                // parseConfigsFromResponse used to return null causing the caller
+                // to treat it as a failure. WaitForRemote subscribers would then
+                // wait the full timeout. With the fix, an empty map is returned,
+                // notifyAbsentKeySubscribers fires, and the subscriber is unblocked.
+                val client = createClient(emptyApiConfig = true) // returns {"configs":{}}
+                storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
+
+                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                client.subscribe(
+                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 60_000L),
+                ) { config, source, timestamp ->
+                    results.add(Triple(config, source, timestamp))
+                }
+
+                // Run only the currently-pending tasks and a tiny virtual-time
+                // nudge — nowhere near the 60_000ms timeout. If the fix is wrong,
+                // the subscriber stays blocked until the timeout.
+                testDispatcher.scheduler.runCurrent()
+                testDispatcher.scheduler.advanceTimeBy(10L)
+                testDispatcher.scheduler.runCurrent()
+
+                assertEquals(
+                    1,
+                    results.size,
+                    "Expected one delivery from empty-config absent-key path, got: $results",
+                )
+                val (config, source, _) = results.single()
+                assertEquals(Source.CACHE, source, "Empty-config fallback must report Source.CACHE")
+                assertTrue(
+                    config.isEmpty(),
+                    "Expected empty fallback config, got: $config",
+                )
+            }
+
+        @Test
+        fun `WaitForRemote does not interfere with All subscribers on the absent key`() =
+            runTest {
+                // Sanity guard: the absent-key unblock path uses runSafelyIfFirst,
+                // which is a no-op for non-gated subscribers. A DeliveryMode.All
+                // subscriber on a key the response doesn't include should still
+                // see only its initial cache delivery (if any) and nothing
+                // synthesized by the absent-key path.
+                val mockHttpClient = mockk<HttpClient>()
+                every { mockHttpClient.request(any()) } returns
+                    HttpClient.Response(
+                        statusCode = 200,
+                        body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
+                        headers = emptyMap(),
+                        statusMessage = "OK",
+                    )
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "test-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = testScope,
+                        networkIODispatcher = testDispatcher,
+                        storageIODispatcher = testDispatcher,
+                        storage = storage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                client.subscribe(Key.DIAGNOSTICS) { config, source, timestamp ->
+                    results.add(Triple(config, source, timestamp))
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                // No cache on DIAGNOSTICS and no remote — All subscriber gets
+                // nothing, exactly as before. The absent-key path must not
+                // fabricate a delivery for it.
+                assertTrue(
+                    results.isEmpty(),
+                    "DeliveryMode.All on absent key must not receive a synthesized delivery, got: $results",
+                )
+            }
+
+        @Test
+        fun `WaitForRemote serializes callback delivery to prevent concurrent invocations`() {
+            // Regression: the timeout fallback and the remote fetch can invoke
+            // the callback concurrently from different dispatchers. This test
+            // blocks inside the fallback callback and verifies that the remote
+            // delivery waits until the fallback returns — no concurrent calls.
+            val networkExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
+            val storageExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
+            val networkDispatcher = networkExecutor.asCoroutineDispatcher()
+            val storageDispatcher = storageExecutor.asCoroutineDispatcher()
+            val realScope =
+                CoroutineScope(
+                    kotlinx.coroutines.SupervisorJob() +
+                        kotlinx.coroutines.Dispatchers.Default,
+                )
+            try {
+                val mockHttpClient = mockk<HttpClient>()
+                // HTTP takes ~150ms — well past the 30ms WaitForRemote timeout —
+                // so the timeout fallback fires first.
+                every { mockHttpClient.request(any()) } answers {
+                    Thread.sleep(150)
+                    HttpClient.Response(
+                        statusCode = 200,
+                        body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
+                        headers = emptyMap(),
+                        statusMessage = "OK",
+                    )
+                }
+
+                val freshStorage = InMemoryStorage()
+                kotlinx.coroutines.runBlocking {
+                    freshStorage.write(
+                        Storage.Constants.REMOTE_CONFIG,
+                        """
+                        {
+                            "sessionReplay.sr_android_privacy_config": {
+                                "defaultMaskLevel": "STALE"
+                            },
+                            "sessionReplay.sr_android_sampling_config": {
+                                "sample_rate": 0.0,
+                                "capture_enabled": false
+                            }
+                        }
+                        """.trimIndent(),
+                    )
+                    freshStorage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1")
+                }
+
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "race-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = realScope,
+                        networkIODispatcher = networkDispatcher,
+                        storageIODispatcher = storageDispatcher,
+                        storage = freshStorage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                // Track concurrency: increment on entry, decrement on exit.
+                // Peak must never exceed 1.
+                val concurrentCount = java.util.concurrent.atomic.AtomicInteger(0)
+                val peakConcurrent = java.util.concurrent.atomic.AtomicInteger(0)
+                val allDeliveries = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap, Source>>())
+                val allDone = java.util.concurrent.CountDownLatch(2)
+
+                client.subscribe(
+                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 30L),
+                ) { config, source, _ ->
+                    val current = concurrentCount.incrementAndGet()
+                    peakConcurrent.updateAndGet { peak -> maxOf(peak, current) }
+                    // Simulate slow processing in the fallback callback.
+                    Thread.sleep(100)
+                    allDeliveries.add(config to source)
+                    concurrentCount.decrementAndGet()
+                    allDone.countDown()
+                }
+
+                val gotBoth = allDone.await(3_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+                assertTrue(
+                    gotBoth,
+                    "Expected two deliveries (fallback + remote), got: $allDeliveries",
+                )
+                assertEquals(
+                    1,
+                    peakConcurrent.get(),
+                    "Callback must never be invoked concurrently; peak was ${peakConcurrent.get()}",
+                )
+                // Final observed config must be the fresh remote, not the stale cache.
+                val snapshot = synchronized(allDeliveries) { allDeliveries.toList() }
+                val last = snapshot.last()
+                assertEquals(
+                    Source.REMOTE,
+                    last.second,
+                    "Last delivery must be the fresh remote: $snapshot",
+                )
+                assertEquals(
+                    "medium",
+                    last.first["defaultMaskLevel"],
+                    "Last delivery must carry fresh remote data: $snapshot",
+                )
+            } finally {
+                realScope.cancel()
+                networkExecutor.shutdownNow()
+                storageExecutor.shutdownNow()
+            }
+        }
+
+        @Test
+        fun `WaitForRemote suppresses timeout fallback when remote arrived during slow callback`() {
+            // Race regression: the timeout fallback path must not overwrite a
+            // fresh remote delivery that won the gate while the timeout
+            // continuation was being scheduled. Uses real dispatchers and a
+            // slow HTTP response so the race is observable end-to-end.
+            val networkExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
+            val storageExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
+            val networkDispatcher = networkExecutor.asCoroutineDispatcher()
+            val storageDispatcher = storageExecutor.asCoroutineDispatcher()
+            val realScope =
+                CoroutineScope(
+                    kotlinx.coroutines.SupervisorJob() +
+                        kotlinx.coroutines.Dispatchers.Default,
+                )
+            try {
+                val mockHttpClient = mockk<HttpClient>()
+                // HTTP takes ~80ms — well past the 30ms WaitForRemote timeout —
+                // but eventually returns fresh config.
+                every { mockHttpClient.request(any()) } answers {
+                    Thread.sleep(80)
+                    HttpClient.Response(
+                        statusCode = 200,
+                        body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
+                        headers = emptyMap(),
+                        statusMessage = "OK",
+                    )
+                }
+
+                val freshStorage = InMemoryStorage()
+                // Cache contains a marker that differs from the fresh remote so
+                // we can tell which delivery the subscriber observed last.
+                kotlinx.coroutines.runBlocking {
+                    freshStorage.write(
+                        Storage.Constants.REMOTE_CONFIG,
+                        """
+                        {
+                            "sessionReplay.sr_android_privacy_config": {
+                                "defaultMaskLevel": "STALE"
+                            },
+                            "sessionReplay.sr_android_sampling_config": {
+                                "sample_rate": 0.0,
+                                "capture_enabled": false
+                            }
+                        }
+                        """.trimIndent(),
+                    )
+                    freshStorage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1")
+                }
+
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "race-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = realScope,
+                        networkIODispatcher = networkDispatcher,
+                        storageIODispatcher = storageDispatcher,
+                        storage = freshStorage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                val results = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap, Source>>())
+                val secondDelivery = java.util.concurrent.CountDownLatch(2)
+
+                client.subscribe(
+                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 30L),
+                ) { config, source, _ ->
+                    results.add(config to source)
+                    secondDelivery.countDown()
+                }
+
+                // Wait until the fetch has had time to land and the subscriber
+                // has received both the timeout fallback and the fresh remote.
+                // If our fix is wrong, the fresh remote is silently dropped
+                // and we never see a REMOTE delivery.
+                val gotBoth = secondDelivery.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+                assertTrue(
+                    gotBoth,
+                    "Expected timeout fallback + fresh remote, got: $results",
+                )
+                // Snapshot deliveries (synchronizedList iteration must hold the lock).
+                val snapshot = synchronized(results) { results.toList() }
+                assertTrue(
+                    snapshot.any { it.second == Source.REMOTE && it.first["defaultMaskLevel"] == "medium" },
+                    "Expected fresh remote delivery (defaultMaskLevel=medium), got: $snapshot",
+                )
+                // The fallback must not have overwritten the fresh remote in the
+                // delivery order: the last delivery should be the fresh remote.
+                val last = snapshot.last()
+                assertEquals(
+                    Source.REMOTE,
+                    last.second,
+                    "Last delivery must be the fresh remote, not a stale fallback: $snapshot",
+                )
+            } finally {
+                realScope.cancel()
+                networkExecutor.shutdownNow()
+                storageExecutor.shutdownNow()
+            }
+        }
+    }
+
+    // endregion DeliveryMode
 
     companion object {
         private const val DEFAULT_API_REMOTE_CONFIG_JSON =


### PR DESCRIPTION
### Describe what this PR is addressing
Blade SDKs need a way to wait for remote config before acting on first screen render. iOS and Web have this; Android doesn't.

### Describe the solution
Consolidates `subscribe` into a single method with `deliveryMode` defaulting to `All`. Adds `DeliveryMode.WaitForRemote(timeoutMs)` — gates first delivery until remote returns or timeout elapses, then falls back to cache.

### Steps to verify the change
`./gradlew build apiCheck` passes. 36 RemoteConfigClientTest unit tests green.

### Checklist
* [x] Does your PR title have the correct title format?
* [ ] Does your PR have a breaking change? No.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `RemoteConfigClient.subscribe` API and delivery semantics, adding new timeout-based gating and concurrency control; mistakes could delay or suppress remote-config delivery on app startup.
> 
> **Overview**
> Adds `RemoteConfigClient.DeliveryMode` and extends `subscribe` to support `WaitForRemote(timeoutMs)`, which **gates the first config delivery** until a remote fetch succeeds or the timeout elapses, then falls back to cached/empty config.
> 
> Updates `RemoteConfigClientImpl` to coordinate timeout-vs-remote races (first-delivery claiming), serialize callback invocations, and unblock `WaitForRemote` subscribers immediately when a successful fetch omits their key or returns `{"configs":{}}`. Updates API surface (`core.api`) and adjusts Android/core call sites and tests to the new `subscribe` signature, with extensive new unit coverage for the new delivery mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7167a69fcd41e04d5062eb97fd79592e7eea7aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->