### PR TITLE
feat(core): Plugin contract for unified blades

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -27,7 +27,6 @@ import java.io.File
 import java.util.concurrent.Executors
 import com.amplitude.core.Amplitude as CoreAmplitude
 
-@OptIn(RestrictedAmplitudeFeature::class)
 open class Amplitude internal constructor(
     configuration: Configuration,
     state: State,
@@ -45,16 +44,7 @@ open class Amplitude internal constructor(
     ) {
     constructor(configuration: Configuration) : this(configuration, State())
 
-    internal val autocaptureManager: AutocaptureManager by lazy {
-        val androidConfig = configuration
-        AutocaptureManager(
-            initialAutocapture = androidConfig.autocapture,
-            initialInteractionsOptions = androidConfig.interactionsOptions,
-            remoteConfigClient = if (androidConfig.enableAutocaptureRemoteConfig) remoteConfigClient else null,
-            logger = logger,
-            diagnosticsClient = diagnosticsClient,
-        )
-    }
+    internal val autocaptureManager: AutocaptureManager by lazy { buildAutocaptureManager() }
 
     val sessionId: Long
         get() {
@@ -133,12 +123,16 @@ open class Amplitude internal constructor(
     }
 
     override fun reset(): Amplitude {
-        setUserId(null)
-        if (isBuilt.isCompleted) {
-            androidContextPlugin.initializeDeviceId(configuration as Configuration, forceRegenerate = true)
-        } else {
-            setDeviceId(ContextPlugin.generateRandomDeviceId())
-        }
+        // Resolve the new device id first so we can emit one bundled identity-change
+        // notification (userId -> null AND deviceId -> resolved) rather than two.
+        val newDeviceId =
+            if (isBuilt.isCompleted) {
+                androidContextPlugin.resolveDeviceId(configuration as Configuration, forceRegenerate = true)
+                    ?: ContextPlugin.generateRandomDeviceId()
+            } else {
+                ContextPlugin.generateRandomDeviceId()
+            }
+        doAndroidReset(newDeviceId)
         return this
     }
 
@@ -180,6 +174,26 @@ open class Amplitude internal constructor(
          */
         const val END_SESSION_EVENT = "session_end"
     }
+}
+
+// ── restricted-feature bridge: the only place @OptIn lives ──
+
+@OptIn(RestrictedAmplitudeFeature::class)
+private fun Amplitude.buildAutocaptureManager(): AutocaptureManager {
+    val androidConfig = configuration as Configuration
+    return AutocaptureManager(
+        initialAutocapture = androidConfig.autocapture,
+        initialInteractionsOptions = androidConfig.interactionsOptions,
+        remoteConfigClient = if (androidConfig.enableAutocaptureRemoteConfig) remoteConfigClient else null,
+        logger = logger,
+        diagnosticsClient = diagnosticsClient,
+    )
+}
+
+@OptIn(RestrictedAmplitudeFeature::class)
+private fun Amplitude.doAndroidReset(newDeviceId: String) {
+    resetIdentity(newDeviceId)
+    notifyAllPlugins { it.onReset() }
 }
 
 /**

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -2,6 +2,7 @@ package com.amplitude.android
 
 import com.amplitude.android.Amplitude.Companion.END_SESSION_EVENT
 import com.amplitude.android.Amplitude.Companion.START_SESSION_EVENT
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.Storage
 import com.amplitude.core.Storage.Constants
 import com.amplitude.core.Storage.Constants.LAST_EVENT_ID
@@ -156,6 +157,10 @@ class Timeline(
     private suspend fun setSessionId(timestamp: Long) {
         _sessionId.set(timestamp)
         amplitude.storage.write(PREVIOUS_SESSION_ID, sessionId.toString())
+        // Fire onSessionIdChanged on every plugin (timeline + observe store).
+        // This is the callback's only invocation site: it was declared on the
+        // Plugin interface but never wired to the session manager before.
+        amplitude.fireSessionIdChanged(timestamp)
     }
 
     private suspend fun startNewSession(timestamp: Long): List<BaseEvent> {
@@ -211,6 +216,11 @@ class Timeline(
         return read(key)?.toLongOrNull() ?: default
     }
 }
+
+// ── restricted-feature bridge: the only place @OptIn lives ──
+
+@OptIn(RestrictedAmplitudeFeature::class)
+private fun com.amplitude.core.Amplitude.fireSessionIdChanged(timestamp: Long) = notifyAllPlugins { it.onSessionIdChanged(timestamp) }
 
 sealed class EventQueueMessage {
     data class Event(val event: BaseEvent) : EventQueueMessage()

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -157,9 +157,6 @@ class Timeline(
     private suspend fun setSessionId(timestamp: Long) {
         _sessionId.set(timestamp)
         amplitude.storage.write(PREVIOUS_SESSION_ID, sessionId.toString())
-        // Fire onSessionIdChanged on every plugin (timeline + observe store).
-        // This is the callback's only invocation site: it was declared on the
-        // Plugin interface but never wired to the session manager before.
         amplitude.fireSessionIdChanged(timestamp)
     }
 

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -42,7 +42,11 @@ class Timeline(
                 isBuilt.await()
 
                 if (initialSessionId == null) {
-                    _sessionId.set(storage.readLong(PREVIOUS_SESSION_ID, DEFAULT_SESSION_ID))
+                    val restoredSessionId = storage.readLong(PREVIOUS_SESSION_ID, DEFAULT_SESSION_ID)
+                    _sessionId.set(restoredSessionId)
+                    if (restoredSessionId > DEFAULT_SESSION_ID) {
+                        amplitude.fireSessionIdChanged(restoredSessionId)
+                    }
                 }
                 lastEventId = storage.readLong(LAST_EVENT_ID, DEFAULT_EVENT_ID_OR_TIME)
                 lastEventTime = storage.readLong(LAST_EVENT_TIME, DEFAULT_EVENT_ID_OR_TIME)

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -60,18 +60,30 @@ open class AndroidContextPlugin : Plugin {
         configuration: Configuration,
         forceRegenerate: Boolean = false,
     ) {
+        val resolved = resolveDeviceId(configuration, forceRegenerate)
+        // null means "keep the existing device id" (only happens when forceRegenerate is false
+        // and the current value in [State] is already valid).
+        resolved?.let { setDeviceId(it) }
+    }
+
+    /**
+     * Resolve the device id to use, applying the same precedence rules as
+     * [initializeDeviceId] but without writing it to [State]. Returns null if
+     * the existing device id in the store should be retained (only possible
+     * when [forceRegenerate] is false).
+     */
+    internal fun resolveDeviceId(
+        configuration: Configuration,
+        forceRegenerate: Boolean = false,
+    ): String? {
         // Check configuration
-        var deviceId = configuration.deviceId
-        if (deviceId != null) {
-            setDeviceId(deviceId)
-            return
-        }
+        configuration.deviceId?.let { return it }
 
         // Check store
         if (!forceRegenerate) {
-            deviceId = amplitude.store.deviceId
-            if (deviceId != null && validDeviceId(deviceId) && !deviceId.endsWith(APP_SET_DEVICE_ID_SUFFIX)) {
-                return
+            val existing = amplitude.store.deviceId
+            if (existing != null && validDeviceId(existing) && !existing.endsWith(APP_SET_DEVICE_ID_SUFFIX)) {
+                return null
             }
         }
 
@@ -82,8 +94,7 @@ open class AndroidContextPlugin : Plugin {
         ) {
             val advertisingId = contextProvider.advertisingId
             if (advertisingId != null && validDeviceId(advertisingId)) {
-                setDeviceId(advertisingId)
-                return
+                return advertisingId
             }
         }
 
@@ -91,13 +102,12 @@ open class AndroidContextPlugin : Plugin {
         if (configuration.useAppSetIdForDeviceId) {
             val appSetId = contextProvider.appSetId
             if (appSetId != null && validDeviceId(appSetId)) {
-                setDeviceId("$appSetId$APP_SET_DEVICE_ID_SUFFIX")
-                return
+                return "$appSetId$APP_SET_DEVICE_ID_SUFFIX"
             }
         }
 
         // Generate random id
-        setDeviceId(ContextPlugin.generateRandomDeviceId())
+        return ContextPlugin.generateRandomDeviceId()
     }
 
     private fun applyContextData(event: BaseEvent) {

--- a/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
@@ -1,0 +1,215 @@
+package com.amplitude.android
+
+import android.app.Application
+import android.content.Context
+import android.net.ConnectivityManager
+import com.amplitude.MainDispatcherRule
+import com.amplitude.android.utilities.createFakeAmplitude
+import com.amplitude.android.utilities.enterForeground
+import com.amplitude.android.utilities.setupMockAndroidContext
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.platform.ObservePlugin
+import com.amplitude.core.platform.Plugin
+import com.amplitude.core.utilities.ConsoleLoggerProvider
+import com.amplitude.core.utilities.InMemoryStorageProvider
+import com.amplitude.id.IMIdentityStorageProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+/**
+ * Phase 0 — Android-specific Plugin contract wiring (session-id callback, reset
+ * via the AndroidContextPlugin path, and dedup against the platform timeline).
+ */
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class PluginContractAndroidTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private fun configuration(): Configuration {
+        setupMockAndroidContext()
+        val context = mockk<Application>(relaxed = true)
+        val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
+        every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        val dirNameSlot = slot<String>()
+        every { context.getDir(capture(dirNameSlot), any()) } answers {
+            File("/tmp/amplitude-kotlin/${dirNameSlot.captured}")
+        }
+        return Configuration(
+            apiKey = "api-key",
+            context = context,
+            instanceName = "plugin-contract-test",
+            minTimeBetweenSessionsMillis = 100,
+            storageProvider = InMemoryStorageProvider(),
+            autocapture =
+                autocaptureOptions {
+                    +sessions
+                },
+            loggerProvider = ConsoleLoggerProvider(),
+            identifyInterceptStorageProvider = InMemoryStorageProvider(),
+            identityStorageProvider = IMIdentityStorageProvider(),
+        )
+    }
+
+    @Test
+    fun `onSessionIdChanged fires when a new session starts`() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    server = null,
+                    scheduler = testScheduler,
+                    configuration = configuration(),
+                )
+            val recorder = SessionRecordingPlugin()
+            amplitude.add(recorder)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            enterForeground(amplitude, 1_000L)
+
+            assertTrue("expected onSessionIdChanged to fire, saw ${recorder.sessionIds}", recorder.sessionIds.isNotEmpty())
+            assertEquals(amplitude.sessionId, recorder.sessionIds.last())
+        }
+
+    @Test
+    fun `onSessionIdChanged also fires for ObservePlugins in the store`() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    server = null,
+                    scheduler = testScheduler,
+                    configuration = configuration(),
+                )
+            val observer = SessionRecordingObservePlugin()
+            amplitude.add(observer)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            enterForeground(amplitude, 2_000L)
+
+            assertTrue("ObservePlugin missed onSessionIdChanged: ${observer.sessionIds}", observer.sessionIds.isNotEmpty())
+        }
+
+    @Test
+    fun `reset rotates deviceId and emits one bundled identity-change plus onReset`() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    server = null,
+                    scheduler = testScheduler,
+                    configuration = configuration(),
+                )
+            amplitude.isBuilt.await()
+            amplitude.setUserId("u-1")
+            advanceUntilIdle()
+            val before = amplitude.getDeviceId()
+
+            val recorder = ResetRecordingPlugin()
+            amplitude.add(recorder)
+
+            amplitude.reset()
+            advanceUntilIdle()
+
+            assertNotNull(before)
+            assertNotEquals(before, amplitude.getDeviceId())
+            assertEquals(1, recorder.userIds.size)
+            assertEquals(1, recorder.deviceIds.size)
+            assertEquals(1, recorder.resets)
+        }
+
+    @Test
+    fun `add evicts a previously-registered plugin sharing the same name`() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    server = null,
+                    scheduler = testScheduler,
+                    configuration = configuration(),
+                )
+            amplitude.isBuilt.await()
+
+            val first = NamedPlugin("dedup-target")
+            val second = NamedPlugin("dedup-target")
+            amplitude.add(first)
+            amplitude.add(second)
+
+            assertTrue(first.tornDown)
+            assertSame(second, amplitude.findPlugin<NamedPlugin>())
+        }
+}
+
+private class SessionRecordingPlugin : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: com.amplitude.core.Amplitude
+    override val name: String = "session-recorder"
+    val sessionIds = mutableListOf<Long>()
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onSessionIdChanged(sessionId: Long) {
+        sessionIds += sessionId
+    }
+}
+
+private class SessionRecordingObservePlugin : ObservePlugin() {
+    override lateinit var amplitude: com.amplitude.core.Amplitude
+    override val name: String = "session-observer"
+    val sessionIds = mutableListOf<Long>()
+
+    override fun onUserIdChanged(userId: String?) {}
+
+    override fun onDeviceIdChanged(deviceId: String?) {}
+
+    override fun onSessionIdChanged(sessionId: Long) {
+        sessionIds += sessionId
+    }
+}
+
+private class ResetRecordingPlugin : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: com.amplitude.core.Amplitude
+    override val name: String = "reset-recorder"
+    val userIds = mutableListOf<String?>()
+    val deviceIds = mutableListOf<String?>()
+    var resets: Int = 0
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onUserIdChanged(userId: String?) {
+        userIds += userId
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds += deviceId
+    }
+
+    override fun onReset() {
+        resets += 1
+    }
+}
+
+private class NamedPlugin(override val name: String?) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: com.amplitude.core.Amplitude
+    var tornDown: Boolean = false
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        tornDown = true
+    }
+}

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -83,8 +83,10 @@ public class com/amplitude/core/Amplitude {
 	public final fun isBuilt ()Lkotlinx/coroutines/Deferred;
 	public final fun logEvent (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/Amplitude;
 	public final fun logRevenue (Lcom/amplitude/core/events/Revenue;)Lcom/amplitude/core/Amplitude;
+	public final fun notifyAllPlugins (Lkotlin/jvm/functions/Function1;)V
 	public final fun remove (Lcom/amplitude/core/platform/Plugin;)Lcom/amplitude/core/Amplitude;
 	public fun reset ()Lcom/amplitude/core/Amplitude;
+	public final fun resetIdentity (Ljava/lang/String;)V
 	public final fun revenue (Lcom/amplitude/core/events/Revenue;)Lcom/amplitude/core/Amplitude;
 	public final fun revenue (Lcom/amplitude/core/events/Revenue;Lcom/amplitude/core/events/EventOptions;)Lcom/amplitude/core/Amplitude;
 	public final fun revenue (Lcom/amplitude/core/events/RevenueEvent;)Lcom/amplitude/core/Amplitude;
@@ -803,7 +805,13 @@ public abstract class com/amplitude/core/platform/ObservePlugin : com/amplitude/
 public abstract interface class com/amplitude/core/platform/Plugin {
 	public fun execute (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;
 	public abstract fun getAmplitude ()Lcom/amplitude/core/Amplitude;
+	public fun getName ()Ljava/lang/String;
 	public abstract fun getType ()Lcom/amplitude/core/platform/Plugin$Type;
+	public fun onDeviceIdChanged (Ljava/lang/String;)V
+	public fun onOptOutChanged (Z)V
+	public fun onReset ()V
+	public fun onSessionIdChanged (J)V
+	public fun onUserIdChanged (Ljava/lang/String;)V
 	public abstract fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
 	public fun setup (Lcom/amplitude/core/Amplitude;)V
 	public fun teardown ()V

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -133,11 +133,13 @@ open class Amplitude(
         get() = configuration.optOut
         set(value) {
             configuration.optOut = value
+            fireOptOut(value)
         }
 
     init {
         require(configuration.isValid()) { "invalid configuration" }
         timeline = this.createTimeline()
+        wireIdentityNotifications() // must run before build() so bootstrap identity callbacks are not lost
         isBuilt = this.build()
         isBuilt.start()
     }
@@ -343,11 +345,14 @@ open class Amplitude(
      * Reset identity:
      *  - reset userId to "null"
      *  - reset deviceId to random UUID
+     *
+     * Plugins receive [Plugin.onReset] together with one bundled identity-change
+     * notification covering both userId and deviceId — never two interleaved.
+     *
      * @return the Amplitude instance
      */
     open fun reset(): Amplitude {
-        setUserId(null)
-        setDeviceId(ContextPlugin.generateRandomDeviceId())
+        doReset(ContextPlugin.generateRandomDeviceId())
         return this
     }
 
@@ -513,10 +518,19 @@ open class Amplitude(
     /**
      * Add a plugin.
      *
+     * If [plugin] declares a non-null [Plugin.name], any existing plugin with
+     * the same name is removed (and its [Plugin.teardown] invoked) before the
+     * new plugin is wired in. Plugins with a `null` name are never deduplicated.
+     *
      * @param plugin the plugin
      * @return the Amplitude instance
      */
     fun add(plugin: Plugin): Amplitude {
+        plugin.name?.let { pluginName ->
+            timeline.removeByName(pluginName)
+            store.removeByName(pluginName)
+        }
+
         when (plugin) {
             is ObservePlugin -> {
                 this.store.add(plugin, this)
@@ -527,6 +541,22 @@ open class Amplitude(
         }
 
         return this
+    }
+
+    /**
+     * Find the first plugin of type [T] registered with this Amplitude
+     * instance, traversing every timeline layer (Before, Enrichment,
+     * Destination, Utility, Observe) **and** the [ObservePlugin] store.
+     * Returns null if no plugin matches.
+     *
+     * Note: an [ObservePlugin] registered via [Amplitude.add] lives in
+     * [State.plugins] rather than the timeline, so the type-based lookup
+     * searches both.
+     */
+    inline fun <reified T : Plugin> findPlugin(): T? {
+        timeline.findPlugin<T>()?.let { return it }
+        val snapshot = synchronized(store.plugins) { store.plugins.toList() }
+        return snapshot.firstOrNull { it is T } as? T
     }
 
     fun remove(plugin: Plugin): Amplitude {
@@ -552,6 +582,44 @@ open class Amplitude(
         }
     }
 
+    /**
+     * Fan a closure out to every plugin registered with this Amplitude
+     * instance — both timeline plugins and [ObservePlugin]s in the store.
+     * Used for state-change callbacks where ObservePlugin authors reasonably
+     * expect to be notified ([Plugin.onOptOutChanged], [Plugin.onReset],
+     * [Plugin.onSessionIdChanged]).
+     *
+     * Each per-plugin invocation is isolated: if a plugin throws, the failure
+     * is logged and the remaining plugins still get notified.
+     *
+     * Restricted to platform-SDK use; not part of the customer surface.
+     */
+    @RestrictedAmplitudeFeature
+    fun notifyAllPlugins(block: (Plugin) -> Unit) {
+        timeline.applyClosure { plugin -> safelyNotify(plugin, logger, block) }
+        // Snapshot the observe store before iterating: callbacks routinely call
+        // amplitude.add()/remove(), which would mutate state.plugins under us
+        // and risk a ConcurrentModificationException (or skip remaining
+        // observers). Timeline iteration is already safe — its mediators use
+        // CopyOnWriteArrayList. Newly added plugins do NOT receive the
+        // in-progress notification (snapshot semantics).
+        val observeSnapshot =
+            synchronized(store.plugins) {
+                store.plugins.toList()
+            }
+        observeSnapshot.forEach { plugin -> safelyNotify(plugin, logger, block) }
+    }
+
+    /**
+     * Reset identity atomically: clear userId and rotate to [newDeviceId].
+     * Plugins observe one bundled identity-change notification rather than
+     * two interleaved ones. Restricted to platform-SDK use.
+     */
+    @RestrictedAmplitudeFeature
+    fun resetIdentity(newDeviceId: String) {
+        identityCoordinator.resetIdentity(newDeviceId)
+    }
+
     private fun convertPropertiesToIdentify(userProperties: Map<String, Any?>?): Identify {
         val identify = Identify()
         userProperties?.forEach { property ->
@@ -559,6 +627,29 @@ open class Amplitude(
         }
         return identify
     }
+}
+
+// ── restricted-feature bridge: the only place @OptIn lives ──
+
+@OptIn(RestrictedAmplitudeFeature::class)
+private fun Amplitude.fireOptOut(value: Boolean) = notifyAllPlugins { it.onOptOutChanged(value) }
+
+@OptIn(RestrictedAmplitudeFeature::class)
+private fun Amplitude.wireIdentityNotifications() {
+    store.onIdentityChanged = { state, changes ->
+        if (changes.contains(State.IdentityChangeType.USER_ID)) {
+            notifyAllPlugins { it.onUserIdChanged(state.userId) }
+        }
+        if (changes.contains(State.IdentityChangeType.DEVICE_ID)) {
+            notifyAllPlugins { it.onDeviceIdChanged(state.deviceId) }
+        }
+    }
+}
+
+@OptIn(RestrictedAmplitudeFeature::class)
+private fun Amplitude.doReset(newDeviceId: String) {
+    resetIdentity(newDeviceId)
+    notifyAllPlugins { it.onReset() }
 }
 
 /**

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -132,6 +132,7 @@ open class Amplitude(
     open var optOut: Boolean
         get() = configuration.optOut
         set(value) {
+            if (configuration.optOut == value) return
             configuration.optOut = value
             fireOptOut(value)
         }

--- a/core/src/main/java/com/amplitude/core/IdentityCoordinator.kt
+++ b/core/src/main/java/com/amplitude/core/IdentityCoordinator.kt
@@ -1,6 +1,7 @@
 package com.amplitude.core
 
 import com.amplitude.id.IdentityManager
+import java.util.EnumSet
 
 /**
  * Coordinates identity (userId/deviceId) updates between [State] and [IdentityManager].
@@ -8,6 +9,19 @@ import com.amplitude.id.IdentityManager
  * All mutations go through synchronized blocks to ensure atomic state + persistence.
  * Before build, only [State] is updated and pending flags are set.
  * During [bootstrap], persisted identity is reconciled with any pre-build changes.
+ *
+ * ## Reentrancy safety
+ *
+ * Plugin callbacks (e.g. [com.amplitude.core.platform.Plugin.onUserIdChanged]) can call
+ * back into [setUserId]/[setDeviceId] on the same thread. Because [synchronized] is
+ * reentrant on the JVM, a naive implementation that fires [State.onIdentityChanged] while
+ * holding the lock allows the inner call to fully commit, then the outer call's commit
+ * overwrites the inner value — a silent data-loss bug.
+ *
+ * Fix: under the lock we write to [State]'s backing fields silently (no notification) and
+ * commit to [IdentityManager]. After the lock is released we dispatch the notification.
+ * If a callback then calls [setUserId] again, that call acquires the lock, updates state,
+ * and dispatches its own notification — without any outer commit following it.
  */
 internal class IdentityCoordinator internal constructor(private val state: State) {
     private val lock = Any()
@@ -22,18 +36,47 @@ internal class IdentityCoordinator internal constructor(private val state: State
 
     fun setUserId(userId: String?) {
         synchronized(lock) {
-            state.userId = userId
+            state.setUserIdSilent(userId)
             identityManager?.editIdentity()?.setUserId(userId)?.commit()
                 ?: run { pendingUserId = Pending(userId) }
         }
+        // Dispatch notification OUTSIDE the lock so plugin callbacks cannot
+        // re-enter this coordinator while it holds the lock.
+        state.notifyIdentityChanged(EnumSet.of(State.IdentityChangeType.USER_ID))
     }
 
     fun setDeviceId(deviceId: String) {
         synchronized(lock) {
-            state.deviceId = deviceId
+            state.setDeviceIdSilent(deviceId)
             identityManager?.editIdentity()?.setDeviceId(deviceId)?.commit()
                 ?: run { pendingDeviceId = Pending(deviceId) }
         }
+        // Dispatch notification OUTSIDE the lock.
+        state.notifyIdentityChanged(EnumSet.of(State.IdentityChangeType.DEVICE_ID))
+    }
+
+    /**
+     * Reset the identity atomically: userId is cleared, deviceId rotates to
+     * [newDeviceId]. Plugins observe a single bundled identity-change
+     * notification rather than two (one for userId, one for deviceId).
+     */
+    fun resetIdentity(newDeviceId: String) {
+        synchronized(lock) {
+            state.setUserIdSilent(null)
+            state.setDeviceIdSilent(newDeviceId)
+            identityManager?.editIdentity()
+                ?.setUserId(null)
+                ?.setDeviceId(newDeviceId)
+                ?.commit()
+                ?: run {
+                    pendingUserId = Pending(null)
+                    pendingDeviceId = Pending(newDeviceId)
+                }
+        }
+        // Dispatch a single bundled notification OUTSIDE the lock.
+        state.notifyIdentityChanged(
+            EnumSet.of(State.IdentityChangeType.USER_ID, State.IdentityChangeType.DEVICE_ID),
+        )
     }
 
     /**
@@ -48,8 +91,12 @@ internal class IdentityCoordinator internal constructor(private val state: State
             val userId = pendingUserId.getOrElse(persisted.userId)
             val deviceId = pendingDeviceId.getOrElse(persisted.deviceId)
 
-            state.userId = userId
-            state.deviceId = deviceId
+            // Write silently under the lock; notify after release (same
+            // reentrancy contract as setUserId/setDeviceId) so a plugin
+            // callback that re-enters setUserId can't be overwritten by the
+            // remainder of bootstrap.
+            state.setUserIdSilent(userId)
+            state.setDeviceIdSilent(deviceId)
 
             identityManager.editIdentity()
                 .setUserId(userId)
@@ -59,5 +106,9 @@ internal class IdentityCoordinator internal constructor(private val state: State
             pendingUserId = null
             pendingDeviceId = null
         }
+        // Dispatch the bundled notification OUTSIDE the lock.
+        state.notifyIdentityChanged(
+            EnumSet.of(State.IdentityChangeType.USER_ID, State.IdentityChangeType.DEVICE_ID),
+        )
     }
 }

--- a/core/src/main/java/com/amplitude/core/PluginNotify.kt
+++ b/core/src/main/java/com/amplitude/core/PluginNotify.kt
@@ -1,0 +1,30 @@
+package com.amplitude.core
+
+import com.amplitude.common.Logger
+import com.amplitude.core.platform.Plugin
+
+/**
+ * Invoke [block] on [plugin], catching any [Exception] so one misbehaving
+ * plugin can't break the notification fan-out (or terminate the coroutine
+ * draining the Android event-message channel). Fatal [Error]s (e.g.
+ * [OutOfMemoryError]) are intentionally left to propagate.
+ *
+ * Shared by [Amplitude.notifyAllPlugins]
+ * and [State]'s identity-callback iteration so all plugin-callback fan-outs
+ * follow the same isolation contract: never propagate a plugin failure back
+ * to the caller; log at warn level instead. [logger] is nullable so callers
+ * without ready logger access (e.g. [State] before [Amplitude] wires one in)
+ * still get the isolation guarantee.
+ */
+internal fun safelyNotify(
+    plugin: Plugin,
+    logger: Logger?,
+    block: (Plugin) -> Unit,
+) {
+    try {
+        block(plugin)
+    } catch (e: Exception) {
+        val identifier = plugin.name ?: plugin::class.java.name
+        logger?.warn("Plugin '$identifier' threw during notify callback: $e")
+    }
+}

--- a/core/src/main/java/com/amplitude/core/README.md
+++ b/core/src/main/java/com/amplitude/core/README.md
@@ -1,0 +1,153 @@
+# Plugins & Identity — `com.amplitude.core`
+
+A short guide to how the SDK is extended (plugins) and how identity (userId /
+deviceId / sessionId) flows to those plugins. If you're touching `Plugin`,
+`Timeline`, `State`, or `IdentityCoordinator`, read this first.
+
+---
+
+## 1. Plugins
+
+A **plugin** observes or transforms the SDK's behaviour. Every plugin declares a
+`Plugin.Type` that decides *where* it runs.
+
+| Type | Runs during event processing? | Lives in |
+|------|-------------------------------|----------|
+| `Before` | yes — first, can mutate/enrich every event | Timeline mediator |
+| `Enrichment` | yes — after `Before` | Timeline mediator |
+| `Destination` | yes — terminal, sends events out | Timeline mediator |
+| `Utility` | no — side-channel helpers | Timeline mediator |
+| `Observe` | no — reacts to state changes only | see note below |
+
+There are two ways a plugin reaches the "Observe" world:
+
+- An **`ObservePlugin`** (the abstract class) is routed by `Amplitude.add()` to the
+  **`State` store**, *not* the timeline.
+- A plain **`Plugin` that just declares `type = Observe`** lands in the timeline's
+  `Observe` mediator. (Before SDKA-6 there was no such mediator and these plugins
+  were silently dropped — that gap is now closed.)
+
+Both buckets receive state-change callbacks (§3).
+
+```mermaid
+flowchart TD
+    App["App code"] -->|"add(plugin)"| Add{"Amplitude.add"}
+    Add -->|"is ObservePlugin"| Store[("State.store.plugins")]
+    Add -->|"else, by type"| TL
+
+    subgraph TL["Timeline"]
+        B["Before mediator"]
+        E["Enrichment mediator"]
+        D["Destination mediator"]
+        U["Utility mediator"]
+        O["Observe mediator"]
+    end
+
+    CB["notifyAllPlugins"]
+    Store -.->|"state callbacks"| CB
+    TL -.->|"state callbacks"| CB
+```
+
+### Lifecycle
+
+- `add(plugin)` — if `plugin.name != null`, any existing plugin with the same name
+  is removed (and `teardown()` called) first. **Dedup is best-effort**: `add()` is
+  expected to be called from a single thread.
+- `setup(amplitude)` — wiring; `teardown()` — cleanup.
+- `findPlugin<T>()` — look a plugin up by type across **both** the timeline mediators
+  and the store (store iteration is snapshotted under a lock).
+
+### Event flow (the processing types)
+
+```mermaid
+flowchart LR
+    Ev[track / identify / revenue] --> Before --> Enrichment --> Destination --> Out[(Amplitude / other sinks)]
+```
+
+`Observe` and `Utility` plugins are **not** in this path — they never see the event
+stream, only the callbacks below.
+
+---
+
+## 2. State-change callbacks
+
+`Plugin` exposes no-op default callbacks so existing plugins are unaffected:
+
+- `onUserIdChanged(userId)` / `onDeviceIdChanged(deviceId)`
+- `onSessionIdChanged(sessionId)` *(Android only — it owns sessions)*
+- `onOptOutChanged(optOut)`
+- `onReset()` *(paired with a bundled identity change)*
+
+They are delivered by `Amplitude.notifyAllPlugins`, which fans the callback out to
+**every** plugin — timeline mediators **and** a snapshot of the store. Each
+invocation is isolated by `safelyNotify`: a throwing plugin is logged, not
+propagated, so one bad plugin can't break the fan-out or the event loop.
+
+```mermaid
+flowchart TD
+    Src["optOut setter / identity change / session change"] --> NAP["notifyAllPlugins"]
+    NAP --> T["timeline.applyClosure, each mediator"]
+    NAP --> S["store snapshot (synchronized)"]
+    T --> SN1["safelyNotify per plugin"]
+    S --> SN2["safelyNotify per plugin"]
+```
+
+> **Delivery is latest-value, not per-transition.** Identity mutation is expected
+> from a single thread; if a value changes again before its callback runs,
+> notifications may coalesce to the most recent value. The value a plugin sees is
+> always consistent with the instance's current identity.
+
+---
+
+## 3. Identity changes & reentrancy
+
+Identity (userId / deviceId) is owned by **`IdentityCoordinator`**, which keeps two
+things in sync: the in-memory `State` and the persisted `IdentityManager`.
+
+The tricky part: a plugin's `onUserIdChanged` callback may itself call
+`setUserId(...)` — on the **same thread**. Because JVM `synchronized` is
+**reentrant**, a naive "notify while holding the lock" design lets that inner call
+fully commit, then the *outer* call commits its older value last and **silently
+clobbers** the inner write.
+
+**The fix — commit under the lock, notify after releasing it:**
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant IC as IdentityCoordinator
+    participant State
+    participant IM as IdentityManager
+    participant Plugin
+
+    Caller->>IC: setUserId("a")
+    activate IC
+    Note over IC: synchronized(lock)
+    IC->>State: setUserIdSilent("a")   // no callback
+    IC->>IM: commit("a")
+    Note over IC: lock released
+    deactivate IC
+    IC->>Plugin: notifyIdentityChanged(USER_ID)
+    Plugin->>IC: setUserId("b")  // reentrant call
+    activate IC
+    Note over IC: fresh lock acquire
+    IC->>State: setUserIdSilent("b")
+    IC->>IM: commit("b")
+    Note over IC: lock released
+    deactivate IC
+    IC->>Plugin: notifyIdentityChanged(USER_ID)
+    Note over IM: final persisted value = "b" ✓ (no clobber)
+```
+
+Key points:
+
+- **Writes happen under the lock** (`setUserIdSilent` / `setDeviceIdSilent` + commit)
+  so state + persistence stay atomic.
+- **Notification happens after the lock is released**, so a re-entering callback
+  can't have its write overwritten by a trailing outer commit.
+- `resetIdentity()` does the same with **one bundled** notification (userId +
+  deviceId), and `bootstrap()` (startup reconciliation) follows the identical
+  pattern.
+
+`notifyAllPlugins` and `resetIdentity` are gated with `@RestrictedAmplitudeFeature`
+(`@RequiresOptIn`) — they're for platform-SDK use, not the customer surface.

--- a/core/src/main/java/com/amplitude/core/State.kt
+++ b/core/src/main/java/com/amplitude/core/State.kt
@@ -1,36 +1,121 @@
 package com.amplitude.core
 
 import com.amplitude.core.platform.ObservePlugin
+import com.amplitude.core.platform.Plugin
+import java.util.EnumSet
 
 class State {
-    var userId: String? = null
-        set(value: String?) {
-            field = value
-            plugins.forEach { plugin ->
-                plugin.onUserIdChanged(value)
-            }
+    /**
+     * The kinds of identity values an [Amplitude] instance can mutate. Used by
+     * [onIdentityChanged] to deliver one batched notification when callers like
+     * [Amplitude.reset] flip multiple identity fields together.
+     */
+    internal enum class IdentityChangeType {
+        USER_ID,
+        DEVICE_ID,
+    }
+
+    /**
+     * Internal hook wired by [Amplitude] to fan-out identity mutations to
+     * timeline + observe plugins. The set tells the consumer which fields
+     * changed in this notification (one or many).
+     */
+    internal var onIdentityChanged: ((State, EnumSet<IdentityChangeType>) -> Unit)? = null
+
+    // Private backing fields allow silent writes (without firing onIdentityChanged)
+    // so that IdentityCoordinator can update state under its lock and dispatch
+    // the notification afterwards, outside the lock.
+    private var _userId: String? = null
+    private var _deviceId: String? = null
+
+    // Supported identity mutation goes through Amplitude.setUserId/setDeviceId
+    // (via IdentityCoordinator). These public setters remain for backward
+    // compatibility; they fire onIdentityChanged, whose wiring fans out through
+    // Amplitude.notifyAllPlugins — so each plugin callback is isolated
+    // (a throwing plugin can't propagate back to the setter's caller). They do
+    // NOT run under the IdentityCoordinator lock, so prefer the Amplitude API.
+    var userId: String?
+        get() = _userId
+        set(value) {
+            _userId = value
+            onIdentityChanged?.invoke(this, EnumSet.of(IdentityChangeType.USER_ID))
         }
 
-    var deviceId: String? = null
-        set(value: String?) {
-            field = value
-            plugins.forEach { plugin ->
-                plugin.onDeviceIdChanged(value)
-            }
+    var deviceId: String?
+        get() = _deviceId
+        set(value) {
+            _deviceId = value
+            onIdentityChanged?.invoke(this, EnumSet.of(IdentityChangeType.DEVICE_ID))
         }
+
+    /**
+     * Write [value] to the userId backing field without firing [onIdentityChanged].
+     * Callers must invoke [notifyIdentityChanged] afterwards (outside any lock)
+     * to dispatch the notification. Used by [com.amplitude.core.IdentityCoordinator]
+     * to prevent reentrancy: field mutation happens under the coordinator's lock,
+     * notification dispatch happens after the lock is released.
+     */
+    internal fun setUserIdSilent(value: String?) {
+        _userId = value
+    }
+
+    /**
+     * Write [value] to the deviceId backing field without firing [onIdentityChanged].
+     * See [setUserIdSilent] for the reentrancy rationale.
+     */
+    internal fun setDeviceIdSilent(value: String?) {
+        _deviceId = value
+    }
+
+    /**
+     * Fire [onIdentityChanged] for the given [changes]. Called by
+     * [com.amplitude.core.IdentityCoordinator] after releasing its lock so that
+     * plugin callbacks cannot re-enter the coordinator while it holds the lock.
+     */
+    internal fun notifyIdentityChanged(changes: EnumSet<IdentityChangeType>) {
+        onIdentityChanged?.invoke(this, changes)
+    }
 
     val plugins: MutableList<ObservePlugin> = mutableListOf()
 
     fun add(
         plugin: ObservePlugin,
         amplitude: Amplitude,
-    ) = synchronized(plugins) {
+    ): Boolean {
         plugin.setup(amplitude)
-        plugins.add(plugin)
+        return synchronized(plugins) {
+            plugins.add(plugin)
+        }
     }
 
-    fun remove(plugin: ObservePlugin) =
-        synchronized(plugins) {
-            plugins.removeAll { it === plugin }
+    fun remove(plugin: ObservePlugin): Boolean {
+        val removed =
+            synchronized(plugins) {
+                plugins.removeAll { it === plugin }
+            }
+        if (removed) plugin.teardown()
+        return removed
+    }
+
+    /**
+     * Remove every [ObservePlugin] whose [Plugin.name] matches [name] from the
+     * store, calling [Plugin.teardown] on each. Returns true if at least one
+     * plugin was removed.
+     */
+    internal fun removeByName(name: String): Boolean {
+        val toRemove =
+            synchronized(plugins) {
+                val matches = plugins.filter { it.name == name }
+                if (matches.isEmpty()) return false
+                plugins.removeAll(matches)
+                matches
+            }
+        toRemove.forEach {
+            try {
+                it.teardown()
+            } catch (_: Exception) {
+            }
         }
+        return true
+    }
 }

--- a/core/src/main/java/com/amplitude/core/platform/Mediator.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Mediator.kt
@@ -15,6 +15,24 @@ internal class Mediator(
 
     fun remove(plugin: Plugin) = plugins.removeAll { it === plugin }
 
+    /**
+     * Remove every plugin whose [Plugin.name] matches [name] and call
+     * [Plugin.teardown] on each removed plugin. Returns true if at least one
+     * plugin was removed.
+     */
+    fun removeByName(name: String): Boolean {
+        val toRemove = plugins.filter { it.name == name }
+        if (toRemove.isEmpty()) return false
+        plugins.removeAll(toRemove)
+        toRemove.forEach {
+            try {
+                it.teardown()
+            } catch (_: Exception) {
+            }
+        }
+        return true
+    }
+
     fun execute(event: BaseEvent): BaseEvent? {
         var result: BaseEvent? = event
 

--- a/core/src/main/java/com/amplitude/core/platform/Plugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Plugin.kt
@@ -18,6 +18,23 @@ interface Plugin {
     val type: Type
     var amplitude: Amplitude
 
+    /**
+     * Optional unique identifier for this plugin, used for deduplication.
+     *
+     * When a plugin with a non-null [name] is added via [Amplitude.add], any
+     * previously registered plugin with the same name is removed (and its
+     * [teardown] called) before the new plugin is wired in. Plugins that leave
+     * [name] as `null` are never deduplicated.
+     *
+     * Deduplication is best-effort: [Amplitude.add] is expected to be called
+     * from a single thread (typically setup). Concurrent `add()` calls with the
+     * same [name] from different threads may race and leave more than one
+     * instance registered.
+     *
+     * Defaults to `null` to preserve binary compatibility with existing plugins.
+     */
+    val name: String? get() = null
+
     fun setup(amplitude: Amplitude) {
         this.amplitude = amplitude
     }
@@ -29,6 +46,50 @@ interface Plugin {
     fun teardown() {
         // Clean up any resources from setup if necessary
     }
+
+    /**
+     * Invoked when [Amplitude.setUserId] mutates the userId on the
+     * Amplitude instance this plugin is registered with.
+     *
+     * Delivery is latest-value, not per-transition: identity mutation is
+     * expected from a single thread, but if the userId changes again before
+     * this callback runs, notifications may coalesce to the most recent value.
+     * The value passed is always consistent with the instance's current
+     * identity.
+     *
+     * Plugins registered before the SDK finishes building may not receive
+     * the initial identity values delivered during bootstrap — bootstrap/startup
+     * delivery is best-effort.
+     */
+    fun onUserIdChanged(userId: String?) {}
+
+    /**
+     * Invoked when [Amplitude.setDeviceId] mutates the deviceId on the
+     * Amplitude instance this plugin is registered with. Delivery semantics
+     * match [onUserIdChanged] (latest-value, may coalesce under concurrency;
+     * bootstrap delivery is best-effort).
+     */
+    fun onDeviceIdChanged(deviceId: String?) {}
+
+    /**
+     * Invoked when the session id changes on the Amplitude instance this plugin
+     * is registered with. Only fires for SDK builds that maintain a session id
+     * (e.g. the Android SDK).
+     */
+    fun onSessionIdChanged(sessionId: Long) {}
+
+    /**
+     * Invoked when the [Amplitude.optOut] flag flips on the Amplitude instance
+     * this plugin is registered with.
+     */
+    fun onOptOutChanged(optOut: Boolean) {}
+
+    /**
+     * Invoked when [Amplitude.reset] is called on the Amplitude instance this
+     * plugin is registered with. The accompanying userId/deviceId changes are
+     * delivered via the same notification (one batched callback, not two).
+     */
+    fun onReset() {}
 }
 
 interface EventPlugin : Plugin {
@@ -108,9 +169,9 @@ abstract class DestinationPlugin : EventPlugin {
 abstract class ObservePlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.Observe
 
-    abstract fun onUserIdChanged(userId: String?)
+    abstract override fun onUserIdChanged(userId: String?)
 
-    abstract fun onDeviceIdChanged(deviceId: String?)
+    abstract override fun onDeviceIdChanged(deviceId: String?)
 
     final override fun execute(event: BaseEvent): BaseEvent? {
         return null

--- a/core/src/main/java/com/amplitude/core/platform/Timeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Timeline.kt
@@ -10,6 +10,11 @@ open class Timeline {
             Plugin.Type.Enrichment to Mediator(),
             Plugin.Type.Destination to Mediator(),
             Plugin.Type.Utility to Mediator(),
+            // Observe-typed plain Plugins live here so they receive state callbacks
+            // and don't get silently dropped on add(). ObservePlugin instances are
+            // routed to the [com.amplitude.core.State] store by Amplitude.add() and
+            // do not flow through this mediator.
+            Plugin.Type.Observe to Mediator(),
         )
     lateinit var amplitude: Amplitude
 
@@ -62,6 +67,29 @@ open class Timeline {
                 plugin.teardown()
             }
         }
+    }
+
+    /**
+     * Remove every plugin whose [Plugin.name] matches [name] across all plugin
+     * layers, calling [Plugin.teardown] on each removed plugin. Used internally
+     * for plugin deduplication when adding a new plugin with a non-null name.
+     */
+    internal fun removeByName(name: String) {
+        plugins.forEach { (_, mediator) ->
+            mediator.removeByName(name)
+        }
+    }
+
+    /**
+     * Find the first plugin of type [T] across all plugin layers, or null if
+     * none match.
+     */
+    inline fun <reified T : Plugin> findPlugin(): T? {
+        var match: T? = null
+        applyClosure { plugin ->
+            if (match == null && plugin is T) match = plugin
+        }
+        return match
     }
 
     // Applies a closure on all registered plugins

--- a/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
@@ -1,0 +1,977 @@
+package com.amplitude.core.platform
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.utils.FakeAmplitude
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Phase 0 Plugin contract for unified blades — interface additions, wiring,
+ * dedup, and lookup helpers.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class PluginContractTest {
+    private val amplitude: Amplitude get() = FakeAmplitude()
+
+    @Nested
+    inner class StateCallbacks {
+        @Test
+        fun `setUserId fires onUserIdChanged on every timeline plugin`() {
+            val a = amplitude
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            a.setUserId("user-1")
+
+            assertEquals(listOf<String?>("user-1"), recorder.userIds)
+        }
+
+        @Test
+        fun `setDeviceId fires onDeviceIdChanged on every timeline plugin`() {
+            val a = amplitude
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            a.setDeviceId("device-1")
+
+            assertEquals(listOf<String?>("device-1"), recorder.deviceIds)
+        }
+
+        @Test
+        fun `setting optOut fires onOptOutChanged on every plugin`() {
+            val a = amplitude
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            a.optOut = true
+
+            assertEquals(listOf(true), recorder.optOuts)
+        }
+
+        @Test
+        fun `reset fires one bundled identity change plus onReset, not two separate identity changes`() {
+            val a = amplitude
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            a.reset()
+
+            // Exactly one userId observation (null) and one deviceId observation (the new id),
+            // not interleaved double-fires.
+            assertEquals(1, recorder.userIds.size, "expected one userId callback, saw ${recorder.userIds}")
+            assertEquals(1, recorder.deviceIds.size, "expected one deviceId callback, saw ${recorder.deviceIds}")
+            assertNull(recorder.userIds.single())
+            assertEquals(1, recorder.resets)
+        }
+
+        @Test
+        fun `ObservePlugins also receive onOptOutChanged and onReset`() {
+            // Finding 2 resolution: ObservePlugins are notified for state callbacks too.
+            val a = amplitude
+            val observer = RecordingObservePlugin()
+            a.add(observer)
+
+            a.optOut = true
+            a.reset()
+
+            assertEquals(listOf(true), observer.optOuts)
+            assertEquals(1, observer.resets)
+        }
+
+        @Test
+        fun `a throwing plugin in notify fan-out does not stop subsequent plugins`() {
+            // High-severity Codex finding: a plugin throwing from a state callback
+            // (e.g. onSessionIdChanged) must not propagate out of notifyAllPlugins,
+            // because the Android event loop relies on these callbacks completing
+            // normally. Other registered plugins still receive the notification.
+            val a = amplitude
+            val thrower = ThrowingObservePlugin()
+            val recorder = RecordingObservePlugin()
+            a.add(thrower)
+            a.add(recorder)
+
+            a.optOut = true
+            a.reset()
+
+            assertEquals(listOf(true), recorder.optOuts)
+            assertEquals(1, recorder.resets)
+        }
+
+        @Test
+        fun `a throwing ObservePlugin in setUserId does not stop subsequent plugins`() {
+            // Hazard: State.userId setter iterates state.plugins directly to fire
+            // onUserIdChanged. If a customer ObservePlugin throws, the exception
+            // propagates out of setUserId() — crashing the call site or
+            // terminating the coroutine that triggered the identity change.
+            // Same isolation contract as notifyAllPlugins.
+            val a = amplitude
+            val thrower = ThrowingObservePlugin(throwOnUserId = true)
+            val recorder = RecordingObservePlugin()
+            a.add(thrower)
+            a.add(recorder)
+
+            a.setUserId("new-user")
+
+            assertEquals(listOf<String?>("new-user"), recorder.userIds)
+            assertEquals("new-user", a.store.userId)
+        }
+
+        @Test
+        fun `a throwing ObservePlugin in setDeviceId does not stop subsequent plugins`() {
+            val a = amplitude
+            val thrower = ThrowingObservePlugin(throwOnDeviceId = true)
+            val recorder = RecordingObservePlugin()
+            a.add(thrower)
+            a.add(recorder)
+
+            a.setDeviceId("new-device")
+
+            assertEquals(listOf<String?>("new-device"), recorder.deviceIds)
+            assertEquals("new-device", a.store.deviceId)
+        }
+
+        @Test
+        fun `a throwing ObservePlugin in reset (setIdentity) does not stop subsequent plugins`() {
+            // reset() routes through State.setIdentity, which fires both
+            // onUserIdChanged and onDeviceIdChanged on each ObservePlugin.
+            // Both callbacks must be isolated.
+            val a = amplitude
+            val thrower =
+                ThrowingObservePlugin(
+                    throwOnUserId = true,
+                    throwOnDeviceId = true,
+                    throwOnReset = false,
+                    throwOnOptOut = false,
+                )
+            val recorder = RecordingObservePlugin()
+            a.add(thrower)
+            a.add(recorder)
+
+            a.reset()
+
+            assertEquals(1, recorder.userIds.size)
+            assertNull(recorder.userIds.single())
+            assertEquals(1, recorder.deviceIds.size)
+            assertEquals(1, recorder.resets)
+        }
+
+        @Test
+        fun `notifyAllPlugins snapshots the observe store so callbacks can register new plugins safely`() {
+            // Codex finding 3: notifyAllPlugins iterates state.plugins (a plain
+            // MutableList). If a callback calls amplitude.add(...) we'd hit
+            // ConcurrentModificationException. The fix snapshots before
+            // iterating; newly added plugins do NOT receive the in-progress
+            // notification.
+            val a = amplitude
+            val late = RecordingObservePlugin()
+            val mutator =
+                object : ObservePlugin() {
+                    override val name: String = "mutator"
+                    override lateinit var amplitude: Amplitude
+
+                    override fun onUserIdChanged(userId: String?) {}
+
+                    override fun onDeviceIdChanged(deviceId: String?) {}
+
+                    override fun onReset() {
+                        amplitude.add(late)
+                    }
+                }
+            a.add(mutator)
+
+            // Should not throw CME.
+            a.reset()
+
+            // Snapshot semantics: the plugin added during onReset does NOT
+            // receive the in-progress onReset.
+            assertEquals(0, late.resets)
+        }
+
+        @Test
+        fun `ObservePlugin receives exactly one userId and deviceId callback after reset`() {
+            // ObservePlugin (not a timeline plugin) must also see exactly one
+            // onUserIdChanged(null) and one onDeviceIdChanged(newId) after reset().
+            // State.setIdentity calls notifyObservePlugins twice — once per field —
+            // so each callback fires exactly once, not interleaved or doubled.
+            val a = amplitude
+            val observer = RecordingObservePlugin()
+            a.add(observer)
+
+            a.reset()
+
+            assertEquals(1, observer.userIds.size, "expected one userId callback, saw ${observer.userIds}")
+            assertEquals(1, observer.deviceIds.size, "expected one deviceId callback, saw ${observer.deviceIds}")
+            assertNull(observer.userIds.single())
+        }
+
+        @Test
+        fun `remove(observePlugin) calls teardown`() {
+            // Verifies the bug fix: amplitude.remove() on an ObservePlugin must
+            // route through State.remove() which calls teardown().
+            val a = amplitude
+            val observer = NamedObservePlugin("teardown-target")
+            a.add(observer)
+
+            a.remove(observer)
+
+            assertTrue(observer.tornDown, "teardown() should be called when an ObservePlugin is removed")
+        }
+
+        @Test
+        fun `a throwing timeline plugin (non-ObservePlugin) does not stop notification fan-out`() {
+            // A plain Plugin with type=Before whose onUserIdChanged throws must
+            // not prevent subsequent plugins from receiving the notification.
+            // Same isolation contract as ThrowingObservePlugin, but for a
+            // timeline (non-ObservePlugin) path.
+            val a = amplitude
+            val thrower = ThrowingPlugin()
+            val recorder = RecordingPlugin()
+            a.add(thrower)
+            a.add(recorder)
+
+            a.setUserId("after-throw")
+
+            assertEquals(listOf<String?>("after-throw"), recorder.userIds)
+        }
+
+        @Test
+        fun `notifyAllPlugins with empty store does not crash`() {
+            // Calling optOut or reset on an Amplitude instance with no plugins
+            // registered should be a silent no-op, not a crash. The empty
+            // snapshot path in notifyAllPlugins / State.notifyObservePlugins
+            // must handle zero plugins gracefully.
+            val a = FakeAmplitude()
+
+            // Neither of these should throw.
+            a.optOut = true
+            a.reset()
+        }
+
+        @Test
+        fun `setIdentity isolates userId and deviceId callbacks per plugin`() {
+            // CX-4 fix: State.setIdentity calls notifyObservePlugins separately
+            // for userId and deviceId. If a plugin's onUserIdChanged throws, that
+            // plugin must still receive onDeviceIdChanged in the same reset().
+            val a = amplitude
+            val throwOnUserId = RecordingObservePluginThrowingOnUserId()
+            a.add(throwOnUserId)
+
+            a.reset()
+
+            // The plugin threw on userId — but it must still record the deviceId.
+            assertEquals(
+                1,
+                throwOnUserId.deviceIds.size,
+                "plugin should still receive onDeviceIdChanged after its own onUserIdChanged threw",
+            )
+        }
+
+        @Test
+        fun `State setUserId snapshots the observe store so callbacks can register new plugins safely`() {
+            // Same snapshot guarantee as notifyAllPlugins, but for the
+            // State.setIdentity / setUserId iteration path. A callback that
+            // calls amplitude.add() during onUserIdChanged must not trigger
+            // ConcurrentModificationException.
+            val a = amplitude
+            val late = RecordingObservePlugin()
+            val mutator =
+                object : ObservePlugin() {
+                    override val name: String = "state-mutator"
+                    override lateinit var amplitude: Amplitude
+
+                    override fun onUserIdChanged(userId: String?) {
+                        amplitude.add(late)
+                    }
+
+                    override fun onDeviceIdChanged(deviceId: String?) {}
+                }
+            a.add(mutator)
+
+            // Should not throw CME.
+            a.setUserId("new-user")
+
+            // Snapshot semantics: the plugin added during onUserIdChanged does
+            // NOT receive the in-progress notification.
+            assertEquals(0, late.userIds.size)
+        }
+    }
+
+    @Nested
+    inner class Dedup {
+        @Test
+        fun `add with non-null name evicts a previously registered plugin sharing that name`() {
+            val a = amplitude
+            val first = NamedPlugin("shared")
+            val second = NamedPlugin("shared")
+
+            a.add(first)
+            a.add(second)
+
+            assertTrue(first.tornDown, "first plugin should have been torn down on dedup")
+            // second is the surviving instance; findPlugin resolves to it by type
+            assertSame(second, a.findPlugin<NamedPlugin>())
+        }
+
+        @Test
+        fun `add without a name does not deduplicate`() {
+            val a = amplitude
+            val first = NamedPlugin(name = null)
+            val second = NamedPlugin(name = null)
+
+            a.add(first)
+            a.add(second)
+
+            // Neither was evicted; both live in the timeline.
+            assertEquals(false, first.tornDown)
+            assertEquals(false, second.tornDown)
+        }
+
+        @Test
+        fun `dedup teardown throwing does not prevent the replacement plugin from being registered`() {
+            // If the evicted plugin's teardown() throws, the new plugin must
+            // still be wired in. State.removeByName silently swallows teardown
+            // exceptions; this test verifies that contract end-to-end.
+            val a = amplitude
+            val thrower = ThrowingTeardownPlugin("flaky-plugin")
+            val replacement = NamedPlugin("flaky-plugin")
+
+            a.add(thrower)
+            a.add(replacement)
+
+            // replacement is the surviving instance; thrower is a different type
+            // so findPlugin<NamedPlugin> resolves unambiguously to replacement
+            assertSame(replacement, a.findPlugin<NamedPlugin>())
+        }
+
+        @Test
+        fun `dedup also tears down ObservePlugin in the store`() {
+            val a = amplitude
+            val first = NamedObservePlugin("obs-shared")
+            val second = NamedPlugin("obs-shared")
+
+            a.add(first)
+            a.add(second)
+
+            assertTrue(first.tornDown, "ObservePlugin in store should be torn down on dedup")
+            // second (a regular plugin, not ObservePlugin) is the survivor
+            assertSame(second, a.findPlugin<NamedPlugin>())
+        }
+    }
+
+    @Nested
+    inner class FindPlugin {
+        @Test
+        fun `findPlugin returns first plugin matching the type across all timeline layers`() {
+            val a = amplitude
+            val before = TypedPlugin(Plugin.Type.Before)
+            val enrichment = MarkerPlugin(Plugin.Type.Enrichment)
+            val utility = MarkerPlugin(Plugin.Type.Utility)
+
+            a.add(before)
+            a.add(enrichment)
+            a.add(utility)
+
+            val found = a.findPlugin<MarkerPlugin>()
+            // First MarkerPlugin discovered when iterating layers.
+            assertTrue(found === enrichment || found === utility, "expected Enrichment or Utility, got $found")
+        }
+
+        @Test
+        fun `findPlugin returns null when no plugin matches`() {
+            val a = amplitude
+            a.add(TypedPlugin(Plugin.Type.Before))
+
+            assertNull(a.findPlugin<MarkerPlugin>())
+        }
+
+        @Test
+        fun `findPlugin traverses the observe store too`() {
+            // ObservePlugins added via amplitude.add() live in State.plugins, not
+            // the timeline, so findPlugin<T>() must search both stores.
+            val a = amplitude
+            val observe = NamedObservePlugin("observed-by-type")
+
+            a.add(observe)
+
+            assertSame(observe, a.findPlugin<NamedObservePlugin>())
+        }
+    }
+
+    @Nested
+    inner class ObserveTypeTrap {
+        // Finding 1 resolution: a Type.Observe mediator now exists in Timeline,
+        // so a bare Plugin declaring Plugin.Type.Observe lands in the timeline
+        // and receives state callbacks instead of being silently dropped.
+        @Test
+        fun `bare Plugin with Type Observe is wired into the timeline and receives callbacks`() {
+            val a = amplitude
+            val observePlugin =
+                object : Plugin {
+                    override val type: Plugin.Type = Plugin.Type.Observe
+                    override lateinit var amplitude: Amplitude
+                    var receivedUserIds = mutableListOf<String?>()
+
+                    override fun onUserIdChanged(userId: String?) {
+                        receivedUserIds += userId
+                    }
+                }
+
+            a.add(observePlugin)
+            a.setUserId("trap-test")
+
+            assertEquals(listOf<String?>("trap-test"), observePlugin.receivedUserIds)
+            assertSame(observePlugin, a.timeline.findPlugin<Plugin>())
+        }
+    }
+
+    @Nested
+    inner class Concurrency {
+        @RepeatedTest(20)
+        fun `concurrent setUserId calls do not crash or lose notifications`() {
+            val a = amplitude
+            val received = Collections.synchronizedList(mutableListOf<String?>())
+            val observer =
+                object : ObservePlugin() {
+                    override lateinit var amplitude: Amplitude
+
+                    override fun onUserIdChanged(userId: String?) {
+                        received += userId
+                    }
+
+                    override fun onDeviceIdChanged(deviceId: String?) {}
+                }
+            a.add(observer)
+
+            val threads = 10
+            val barrier = CyclicBarrier(threads)
+            val latch = CountDownLatch(threads)
+            repeat(threads) { i ->
+                Thread {
+                    barrier.await()
+                    a.setUserId("user-$i")
+                    latch.countDown()
+                }.start()
+            }
+            latch.await(5, TimeUnit.SECONDS)
+
+            assertEquals(threads, received.size, "every setUserId should produce exactly one notification")
+        }
+
+        @RepeatedTest(20)
+        fun `concurrent add and setUserId do not throw CME`() {
+            val a = amplitude
+            val threads = 10
+            val barrier = CyclicBarrier(threads * 2)
+            val latch = CountDownLatch(threads * 2)
+
+            repeat(threads) { i ->
+                Thread {
+                    barrier.await()
+                    a.add(RecordingObservePlugin())
+                    latch.countDown()
+                }.start()
+                Thread {
+                    barrier.await()
+                    a.setUserId("user-$i")
+                    latch.countDown()
+                }.start()
+            }
+
+            assertTrue(latch.await(5, TimeUnit.SECONDS), "all threads should complete without deadlock")
+        }
+
+        @RepeatedTest(20)
+        fun `concurrent add and remove do not throw CME on observe store`() {
+            val a = amplitude
+            val plugins = (0 until 20).map { NamedObservePlugin("obs-$it") }
+            plugins.forEach { a.add(it) }
+
+            val barrier = CyclicBarrier(2)
+            val latch = CountDownLatch(2)
+
+            Thread {
+                barrier.await()
+                plugins.take(10).forEach { a.remove(it) }
+                latch.countDown()
+            }.start()
+            Thread {
+                barrier.await()
+                (20 until 30).forEach { a.add(NamedObservePlugin("obs-$it")) }
+                latch.countDown()
+            }.start()
+
+            assertTrue(latch.await(5, TimeUnit.SECONDS), "concurrent add+remove should not deadlock or crash")
+        }
+
+        @RepeatedTest(20)
+        fun `concurrent reset and setUserId produce consistent state`() {
+            val a = amplitude
+            val barrier = CyclicBarrier(2)
+            val latch = CountDownLatch(2)
+
+            Thread {
+                barrier.await()
+                a.reset()
+                latch.countDown()
+            }.start()
+            Thread {
+                barrier.await()
+                a.setUserId("concurrent-user")
+                latch.countDown()
+            }.start()
+
+            assertTrue(latch.await(5, TimeUnit.SECONDS), "concurrent reset + setUserId should not deadlock")
+            // After both complete, userId is either null (reset won) or "concurrent-user" (setUserId won).
+            val finalUserId = a.store.userId
+            assertTrue(
+                finalUserId == null || finalUserId == "concurrent-user",
+                "userId should be null or 'concurrent-user', got: $finalUserId",
+            )
+        }
+
+        @RepeatedTest(20)
+        fun `concurrent findPlugin and add do not throw CME`() {
+            val a = amplitude
+            val found = AtomicInteger(0)
+            val threads = 10
+            val barrier = CyclicBarrier(threads * 2)
+            val latch = CountDownLatch(threads * 2)
+
+            repeat(threads) { i ->
+                Thread {
+                    barrier.await()
+                    a.add(NamedObservePlugin("lookup-$i"))
+                    latch.countDown()
+                }.start()
+                Thread {
+                    barrier.await()
+                    if (a.findPlugin<NamedObservePlugin>() != null) found.incrementAndGet()
+                    latch.countDown()
+                }.start()
+            }
+
+            assertTrue(latch.await(5, TimeUnit.SECONDS), "concurrent findPlugin + add should not crash")
+        }
+
+        @RepeatedTest(20)
+        fun `concurrent dedup with same name does not leave duplicates`() {
+            val a = amplitude
+            val threads = 10
+            val barrier = CyclicBarrier(threads)
+            val latch = CountDownLatch(threads)
+
+            repeat(threads) {
+                Thread {
+                    barrier.await()
+                    a.add(NamedPlugin("dedup-race"))
+                    latch.countDown()
+                }.start()
+            }
+
+            assertTrue(latch.await(5, TimeUnit.SECONDS), "concurrent dedup should not deadlock")
+
+            // Count how many plugins named "dedup-race" exist in the timeline.
+            var count = 0
+            a.timeline.applyClosure { if (it.name == "dedup-race") count++ }
+            // Known limitation: without full lock around add(), concurrent dedup can
+            // leave more than one. This test documents the current behavior — it must
+            // never crash, but may leave duplicates under extreme concurrency.
+            assertTrue(count >= 1, "at least one plugin should be registered")
+        }
+
+        @Test
+        fun `dedup teardown and identity callback add do not deadlock`() {
+            val a = amplitude
+            val enteredTeardown = CountDownLatch(1)
+            val callbackReadyToAdd = CountDownLatch(1)
+            val completed = CountDownLatch(2)
+            val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+            val evicted =
+                TeardownSetsUserIdPlugin(
+                    name = "deadlock-target",
+                    enteredTeardown = enteredTeardown,
+                    callbackReadyToAdd = callbackReadyToAdd,
+                    errors = errors,
+                )
+            val identityCallback =
+                object : Plugin {
+                    override val type: Plugin.Type = Plugin.Type.Before
+                    override val name: String = "identity-callback"
+                    override lateinit var amplitude: Amplitude
+
+                    override fun execute(event: BaseEvent): BaseEvent = event
+
+                    override fun onUserIdChanged(userId: String?) {
+                        if (userId != "identity-thread") return
+                        callbackReadyToAdd.countDown()
+                        if (!enteredTeardown.await(5, TimeUnit.SECONDS)) {
+                            errors += AssertionError("dedup teardown did not start")
+                            return
+                        }
+                        amplitude.add(NamedPlugin("callback-add"))
+                    }
+                }
+
+            a.add(evicted)
+            a.add(identityCallback)
+
+            Thread {
+                try {
+                    a.add(NamedPlugin("deadlock-target"))
+                } catch (t: Throwable) {
+                    errors += t
+                } finally {
+                    completed.countDown()
+                }
+            }.apply {
+                isDaemon = true
+                start()
+            }
+            Thread {
+                try {
+                    a.setUserId("identity-thread")
+                } catch (t: Throwable) {
+                    errors += t
+                } finally {
+                    completed.countDown()
+                }
+            }.apply {
+                isDaemon = true
+                start()
+            }
+
+            assertTrue(completed.await(5, TimeUnit.SECONDS), "dedup teardown and identity callback add should not deadlock")
+            assertTrue(errors.isEmpty(), "unexpected concurrency errors: ${errors.joinToString { it.message.orEmpty() }}")
+        }
+
+        @RepeatedTest(20)
+        fun `notification during remove does not crash`() {
+            val a = amplitude
+            val observer = RecordingObservePlugin()
+            a.add(observer)
+
+            val barrier = CyclicBarrier(2)
+            val latch = CountDownLatch(2)
+
+            Thread {
+                barrier.await()
+                repeat(50) { a.setUserId("user-$it") }
+                latch.countDown()
+            }.start()
+            Thread {
+                barrier.await()
+                a.remove(observer)
+                latch.countDown()
+            }.start()
+
+            assertTrue(latch.await(5, TimeUnit.SECONDS), "notification during remove should not crash")
+        }
+
+        @RepeatedTest(20)
+        fun `optOut and setUserId racing do not crash`() {
+            val a = amplitude
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            val barrier = CyclicBarrier(2)
+            val latch = CountDownLatch(2)
+
+            Thread {
+                barrier.await()
+                repeat(50) { a.optOut = it % 2 == 0 }
+                latch.countDown()
+            }.start()
+            Thread {
+                barrier.await()
+                repeat(50) { a.setUserId("user-$it") }
+                latch.countDown()
+            }.start()
+
+            assertTrue(latch.await(5, TimeUnit.SECONDS), "optOut + setUserId racing should not crash")
+        }
+
+        @Test
+        fun `plugin reentrancy in onUserIdChanged does not overwrite inner setUserId value`() {
+            // Reentrancy scenario: a plugin's onUserIdChanged calls amplitude.setUserId("inner").
+            // Before the fix, IdentityCoordinator fired the notification while still holding
+            // its lock. Because synchronized is reentrant on the JVM, the inner call completed
+            // (writing "inner"), then control returned to the outer call which committed its
+            // original value — overwriting "inner" silently.
+            //
+            // After the fix, the notification is fired OUTSIDE the lock. The inner setUserId
+            // fully completes (field write + commit + notification) before the outer call
+            // can do any further work, so "inner" is the final value.
+            val a = amplitude
+            val done = CountDownLatch(1)
+
+            val reentrantPlugin =
+                object : ObservePlugin() {
+                    override lateinit var amplitude: Amplitude
+                    var triggered = false
+
+                    override fun onUserIdChanged(userId: String?) {
+                        if (!triggered && userId == "outer") {
+                            triggered = true
+                            // Re-enter setUserId from within the callback.
+                            amplitude.setUserId("inner")
+                        }
+                        if (userId == "inner") done.countDown()
+                    }
+
+                    override fun onDeviceIdChanged(deviceId: String?) {}
+                }
+            a.add(reentrantPlugin)
+
+            a.setUserId("outer")
+
+            assertTrue(done.await(5, TimeUnit.SECONDS), "inner setUserId callback should complete")
+            // The most recent caller (inner) wins — outer must not overwrite it.
+            assertEquals("inner", a.store.userId, "inner setUserId must not be overwritten by outer call")
+            // No infinite recursion: the plugin guarded its own re-entry with `triggered`.
+        }
+
+        @Test
+        fun `plugin reentrancy in onDeviceIdChanged does not overwrite inner setDeviceId value`() {
+            val a = amplitude
+            val done = CountDownLatch(1)
+
+            val reentrantPlugin =
+                object : ObservePlugin() {
+                    override lateinit var amplitude: Amplitude
+                    var triggered = false
+
+                    override fun onUserIdChanged(userId: String?) {}
+
+                    override fun onDeviceIdChanged(deviceId: String?) {
+                        if (!triggered && deviceId == "device-outer") {
+                            triggered = true
+                            amplitude.setDeviceId("device-inner")
+                        }
+                        if (deviceId == "device-inner") done.countDown()
+                    }
+                }
+            a.add(reentrantPlugin)
+
+            a.setDeviceId("device-outer")
+
+            assertTrue(done.await(5, TimeUnit.SECONDS), "inner setDeviceId callback should complete")
+            assertEquals("device-inner", a.store.deviceId, "inner setDeviceId must not be overwritten by outer call")
+        }
+
+        @Test
+        fun `plugin reentrancy in onUserIdChanged during resetIdentity does not overwrite inner setUserId value`() {
+            val a = amplitude
+            val done = CountDownLatch(1)
+
+            val reentrantPlugin =
+                object : ObservePlugin() {
+                    override lateinit var amplitude: Amplitude
+                    var triggered = false
+
+                    override fun onUserIdChanged(userId: String?) {
+                        if (!triggered && userId == null) {
+                            triggered = true
+                            // Simulate a plugin that re-assigns userId after a reset.
+                            amplitude.setUserId("post-reset-user")
+                        }
+                        if (userId == "post-reset-user") done.countDown()
+                    }
+
+                    override fun onDeviceIdChanged(deviceId: String?) {}
+                }
+            a.add(reentrantPlugin)
+
+            a.reset()
+
+            assertTrue(done.await(5, TimeUnit.SECONDS), "inner setUserId from onUserIdChanged during reset should complete")
+            assertEquals(
+                "post-reset-user",
+                a.store.userId,
+                "userId set inside onUserIdChanged callback must not be overwritten by the reset",
+            )
+        }
+    }
+}
+
+private open class RecordingPlugin(override val name: String? = "recorder") : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+
+    val userIds = mutableListOf<String?>()
+    val deviceIds = mutableListOf<String?>()
+    val optOuts = mutableListOf<Boolean>()
+    var resets: Int = 0
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onUserIdChanged(userId: String?) {
+        userIds += userId
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds += deviceId
+    }
+
+    override fun onOptOutChanged(optOut: Boolean) {
+        optOuts += optOut
+    }
+
+    override fun onReset() {
+        resets += 1
+    }
+}
+
+private class RecordingObservePlugin : ObservePlugin() {
+    override lateinit var amplitude: Amplitude
+    val userIds = mutableListOf<String?>()
+    val deviceIds = mutableListOf<String?>()
+    val optOuts = mutableListOf<Boolean>()
+    var resets: Int = 0
+
+    override fun onUserIdChanged(userId: String?) {
+        userIds += userId
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds += deviceId
+    }
+
+    override fun onOptOutChanged(optOut: Boolean) {
+        optOuts += optOut
+    }
+
+    override fun onReset() {
+        resets += 1
+    }
+}
+
+private class ThrowingObservePlugin(
+    private val throwOnUserId: Boolean = false,
+    private val throwOnDeviceId: Boolean = false,
+    private val throwOnOptOut: Boolean = true,
+    private val throwOnReset: Boolean = true,
+) : ObservePlugin() {
+    override val name: String = "throwing-observe"
+    override lateinit var amplitude: Amplitude
+
+    override fun onUserIdChanged(userId: String?) {
+        if (throwOnUserId) throw RuntimeException("boom: onUserIdChanged")
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        if (throwOnDeviceId) throw RuntimeException("boom: onDeviceIdChanged")
+    }
+
+    override fun onOptOutChanged(optOut: Boolean) {
+        if (throwOnOptOut) throw RuntimeException("boom: onOptOutChanged")
+    }
+
+    override fun onReset() {
+        if (throwOnReset) throw RuntimeException("boom: onReset")
+    }
+}
+
+private class NamedPlugin(override val name: String?) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+    var tornDown: Boolean = false
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        tornDown = true
+    }
+}
+
+private class NamedObservePlugin(override val name: String?) : ObservePlugin() {
+    override lateinit var amplitude: Amplitude
+    var tornDown: Boolean = false
+
+    override fun onUserIdChanged(userId: String?) {}
+
+    override fun onDeviceIdChanged(deviceId: String?) {}
+
+    override fun teardown() {
+        tornDown = true
+    }
+}
+
+private class TypedPlugin(override val type: Plugin.Type) : Plugin {
+    override lateinit var amplitude: Amplitude
+}
+
+private class MarkerPlugin(override val type: Plugin.Type) : Plugin {
+    override lateinit var amplitude: Amplitude
+}
+
+/** A timeline (non-ObservePlugin) whose onUserIdChanged always throws. */
+private class ThrowingPlugin : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override val name: String = "throwing-plugin"
+    override lateinit var amplitude: Amplitude
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onUserIdChanged(userId: String?) {
+        throw RuntimeException("boom: onUserIdChanged from ThrowingPlugin")
+    }
+}
+
+/** An ObservePlugin that throws from onUserIdChanged but records deviceId calls. */
+private class RecordingObservePluginThrowingOnUserId : ObservePlugin() {
+    override lateinit var amplitude: Amplitude
+    val deviceIds = mutableListOf<String?>()
+
+    override fun onUserIdChanged(userId: String?) {
+        throw RuntimeException("boom: onUserIdChanged")
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds += deviceId
+    }
+}
+
+/** A named plugin whose teardown() always throws. */
+private class ThrowingTeardownPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        throw RuntimeException("boom: teardown")
+    }
+}
+
+private class TeardownSetsUserIdPlugin(
+    override val name: String,
+    private val enteredTeardown: CountDownLatch,
+    private val callbackReadyToAdd: CountDownLatch,
+    private val errors: MutableList<Throwable>,
+) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        enteredTeardown.countDown()
+        if (!callbackReadyToAdd.await(5, TimeUnit.SECONDS)) {
+            errors += AssertionError("identity callback did not enter add path")
+            return
+        }
+        amplitude.setUserId("teardown-thread")
+    }
+}


### PR DESCRIPTION
### Describe what this PR is addressing
Blade SDKs (Session Replay, Experiment) need to observe identity/session/optOut
changes on their host Amplitude instance without subclassing `ObservePlugin` or
polling. Currently only `ObservePlugin` gets `onUserIdChanged`/`onDeviceIdChanged`,
and timeline plugins get nothing.

### Describe the solution
- Lifecycle callbacks (`onUserIdChanged`, `onDeviceIdChanged`, `onSessionIdChanged`,
  `onOptOutChanged`, `onReset`) added to `Plugin` with default no-ops — any plugin
  type can opt in.
- `ObservePlugin` overrides `onUserIdChanged`/`onDeviceIdChanged` as abstract
  (backward compat).
- `Plugin.name` for deduplication — same-name plugin replaces the old one (with
  teardown).
- `IdentityCoordinator` handles all identity mutations with notifications dispatched
  outside the synchronized block, eliminating the reentrancy / silent-clobber hazard.
- `State.setIdentity` batches field writes and notifies once.
- `Amplitude.add()` deduplicates by `Plugin.name` (teardown on evict).
- `findPlugin<T>()` searches both timeline and observe store using a snapshot, fixing
  the CME risk.
- `safelyNotify` isolates per-plugin throws in all fan-outs; fatal `Error`s propagate.
- `State.remove()` calls `teardown()`; teardown in dedup is wrapped in try-catch.

### Steps to verify the change
`./gradlew build apiCheck` — 30 plugin contract tests + full suite green.

### Checklist
* [x] Does your PR title have the correct title format?
* [ ] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes identity mutation, reset semantics, and plugin notification ordering across core and Android; public API additions are opt-in restricted but behavior shifts affect all registered plugins.
> 
> **Overview**
> Extends the **plugin contract** so blade SDKs can react to identity, session, opt-out, and reset without subclassing `ObservePlugin` only. Any `Plugin` can implement optional callbacks (`onUserIdChanged`, `onDeviceIdChanged`, `onSessionIdChanged`, `onOptOutChanged`, `onReset`); **`Plugin.name`** enables **dedup on `add()`** (evict same name + `teardown`).
> 
> **Identity and reset behavior** is reworked: `IdentityCoordinator` commits user/device id **under lock** but notifies **after** releasing the lock (fixes reentrant plugin callbacks clobbering inner writes). **`resetIdentity`** / **`reset()`** emit **one bundled** identity notification plus **`onReset`**, not separate userId then deviceId fires. **`notifyAllPlugins`** fans out to timeline plugins and a **snapshotted** observe store, with **`safelyNotify`** so one throwing plugin does not break others.
> 
> **Timeline** gains an **Observe** mediator so `Plugin.Type.Observe` plugins are no longer dropped. **`findPlugin<T>()`** searches timeline and observe store. **Android** wires **`onSessionIdChanged`** when sessions start or restore from storage; **`reset()`** resolves device id via **`AndroidContextPlugin.resolveDeviceId`** before atomic reset.
> 
> Adds **core README**, **apiCheck**-visible APIs, and broad **contract/concurrency tests** (core + Android).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2102bb0cda8ad8c937b778f23f92308a11e1e05d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->