### PR TITLE
fix(autocapture): always persist app version/build at SDK setup

### DIFF
--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -16,8 +16,10 @@ import com.amplitude.android.internal.gestures.WindowCallbackManager
 import com.amplitude.android.utilities.ActivityCallbackType
 import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.android.utilities.DefaultEventUtils
+import com.amplitude.android.utilities.getVersionCode
 import com.amplitude.core.Amplitude
 import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.Storage
 import com.amplitude.core.platform.Plugin
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -48,6 +50,11 @@ class AndroidLifecyclePlugin(
     private var appInBackground = false
     private var trackedAppLifecycleEvent = false
 
+    // Snapshot read synchronously at setup so the state observer doesn't race the async storage write.
+    @Volatile private var previousAppVersion: String? = null
+
+    @Volatile private var previousAppBuild: String? = null
+
     private var stateObserverJob: Job? = null
 
     @VisibleForTesting
@@ -69,6 +76,9 @@ class AndroidLifecyclePlugin(
                 amplitude.logger.error("Cannot find package with application.packageName: " + application.packageName)
                 PackageInfo()
             }
+
+        // Run regardless of appLifecycles so a later flip doesn't fire a spurious Installed.
+        snapshotAndPersistAppVersionInfo()
 
         // Observe autocapture state changes (including the initial value) to
         // enable features at runtime via remote config. Collected on main thread
@@ -222,14 +232,34 @@ class AndroidLifecyclePlugin(
         )
     }
 
-    /**
-     * Fires the one-time app installed/updated event when appLifecycles becomes enabled,
-     * either initially or via remote config. Guarded to fire at most once per SDK lifetime.
-     */
+    private fun snapshotAndPersistAppVersionInfo() {
+        val currentVersion = packageInfo.versionName ?: "Unknown"
+        val currentBuild = packageInfo.getVersionCode().toString()
+        val storage = amplitude.storage
+
+        previousAppVersion = storage.read(Storage.Constants.APP_VERSION)
+        previousAppBuild = storage.read(Storage.Constants.APP_BUILD)
+
+        amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
+            amplitude.isBuilt.await()
+            try {
+                storage.write(Storage.Constants.APP_VERSION, currentVersion)
+                storage.write(Storage.Constants.APP_BUILD, currentBuild)
+            } catch (e: Exception) {
+                amplitude.logger.error("Failed to persist app version/build: $e")
+            }
+        }
+    }
+
     private fun trackAppLifecycleEventIfNeeded() {
         if (trackedAppLifecycleEvent || !autocaptureState.appLifecycles) return
         trackedAppLifecycleEvent = true
-        DefaultEventUtils(androidAmplitude).trackAppUpdatedInstalledEvent(packageInfo)
+        DefaultEventUtils(androidAmplitude).trackAppUpdatedInstalledEvent(
+            currentVersion = packageInfo.versionName ?: "Unknown",
+            currentBuild = packageInfo.getVersionCode().toString(),
+            previousVersion = previousAppVersion,
+            previousBuild = previousAppBuild,
+        )
     }
 
     /**

--- a/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
@@ -12,22 +12,29 @@ import com.amplitude.android.Constants
 import com.amplitude.android.internal.fragments.FragmentActivityHandler.registerFragmentLifecycleCallbacks
 import com.amplitude.android.internal.fragments.FragmentActivityHandler.unregisterFragmentLifecycleCallbacks
 import com.amplitude.core.Storage
-import kotlinx.coroutines.launch
 import com.amplitude.android.Constants.EventProperties as ConstantsEventProperties
 import com.amplitude.android.Constants.EventTypes as ConstantsEventTypes
 
 @Deprecated("This class is deprecated and will be removed in future releases.")
 class DefaultEventUtils(private val amplitude: Amplitude) {
+    /** Superseded by [com.amplitude.android.plugins.AndroidLifecyclePlugin]; no-op after SDK init. */
     fun trackAppUpdatedInstalledEvent(packageInfo: PackageInfo) {
-        // Get current version/build and previously stored version/build information
-        val currentVersion = packageInfo.versionName ?: "Unknown"
-        val currentBuild = packageInfo.getVersionCode().toString()
         val storage = amplitude.storage
-        val previousVersion = storage.read(Storage.Constants.APP_VERSION)
-        val previousBuild = storage.read(Storage.Constants.APP_BUILD)
+        trackAppUpdatedInstalledEvent(
+            currentVersion = packageInfo.versionName ?: "Unknown",
+            currentBuild = packageInfo.getVersionCode().toString(),
+            previousVersion = storage.read(Storage.Constants.APP_VERSION),
+            previousBuild = storage.read(Storage.Constants.APP_BUILD),
+        )
+    }
 
+    internal fun trackAppUpdatedInstalledEvent(
+        currentVersion: String,
+        currentBuild: String,
+        previousVersion: String?,
+        previousBuild: String?,
+    ) {
         if (previousBuild == null) {
-            // No stored build, treat it as fresh installed
             amplitude.track(
                 ConstantsEventTypes.APPLICATION_INSTALLED,
                 mapOf(
@@ -36,7 +43,6 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
                 ),
             )
         } else if (currentBuild != previousBuild) {
-            // Has stored build, but different from current build
             amplitude.track(
                 ConstantsEventTypes.APPLICATION_UPDATED,
                 mapOf(
@@ -46,15 +52,6 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
                     ConstantsEventProperties.BUILD to currentBuild,
                 ),
             )
-        }
-
-        // Write the current version/build into persistent storage
-        amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
-            // wait until it is built before writing to storage
-            amplitude.isBuilt.await()
-
-            storage.write(Storage.Constants.APP_VERSION, currentVersion)
-            storage.write(Storage.Constants.APP_BUILD, currentBuild)
         }
     }
 
@@ -428,7 +425,7 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
     }
 }
 
-private fun PackageInfo.getVersionCode(): Number =
+internal fun PackageInfo.getVersionCode(): Number =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         this.longVersionCode
     } else {

--- a/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
@@ -122,7 +122,7 @@ class AndroidLifecyclePluginTest {
         }
 
     @Test
-    fun `test application installed event is not tracked when disabled`() =
+    fun `test application installed event is not tracked when disabled but storage is still persisted`() =
         runTest {
             every { mockedAmplitude.amplitudeScope } returns this
 
@@ -138,8 +138,62 @@ class AndroidLifecyclePluginTest {
                 )
             }
 
-            coVerify(exactly = 0) { spiedStorage.write(eq(Storage.Constants.APP_VERSION), any()) }
-            coVerify(exactly = 0) { spiedStorage.write(eq(Storage.Constants.APP_BUILD), any()) }
+            coVerify(exactly = 1) { spiedStorage.write(eq(Storage.Constants.APP_VERSION), any()) }
+            coVerify(exactly = 1) { spiedStorage.write(eq(Storage.Constants.APP_BUILD), any()) }
+
+            close()
+        }
+
+    @Test
+    fun `test no spurious installed event when APP_LIFECYCLES is enabled later for an existing device`() =
+        runTest {
+            mockAutocapture(emptySet())
+            every { mockedAmplitude.amplitudeScope } returns this
+
+            plugin.setup(mockedAmplitude)
+            advanceUntilIdle()
+
+            verify(exactly = 0) { mockedAmplitude.track(EventTypes.APPLICATION_INSTALLED, any(), any()) }
+            coVerify(exactly = 1) { spiedStorage.write(eq(Storage.Constants.APP_BUILD), any()) }
+
+            close()
+
+            mockAutocapture(setOf(AutocaptureOption.APP_LIFECYCLES))
+            observer = ActivityLifecycleObserver()
+            plugin = AndroidLifecyclePlugin(observer)
+            plugin.setup(mockedAmplitude)
+            advanceUntilIdle()
+
+            verify(exactly = 0) { mockedAmplitude.track(EventTypes.APPLICATION_INSTALLED, any(), any()) }
+            verify(exactly = 0) { mockedAmplitude.track(EventTypes.APPLICATION_UPDATED, any(), any()) }
+
+            close()
+        }
+
+    @Test
+    fun `test updated event fires when APP_LIFECYCLES is enabled later and build changed`() =
+        runTest {
+            mockAutocapture(emptySet())
+            every { mockedAmplitude.amplitudeScope } returns this
+            plugin.setup(mockedAmplitude)
+            advanceUntilIdle()
+            close()
+
+            val updatedPackageInfo =
+                PackageInfo().apply {
+                    versionCode = 777
+                    versionName = "7.0.0"
+                }
+            every { mockedPackageManager.getPackageInfo(any<String>(), any<Int>()) } returns updatedPackageInfo
+
+            mockAutocapture(setOf(AutocaptureOption.APP_LIFECYCLES))
+            observer = ActivityLifecycleObserver()
+            plugin = AndroidLifecyclePlugin(observer)
+            plugin.setup(mockedAmplitude)
+            advanceUntilIdle()
+
+            verify(exactly = 0) { mockedAmplitude.track(EventTypes.APPLICATION_INSTALLED, any(), any()) }
+            verify(exactly = 1) { mockedAmplitude.track(EventTypes.APPLICATION_UPDATED, any(), any()) }
 
             close()
         }
@@ -173,7 +227,7 @@ class AndroidLifecyclePluginTest {
         }
 
     @Test
-    fun `test application updated event is not tracked when disabled`() =
+    fun `test application updated event is not tracked when disabled but storage is still persisted`() =
         runTest {
             every { mockedAmplitude.amplitudeScope } returns this
 
@@ -192,8 +246,8 @@ class AndroidLifecyclePluginTest {
                 )
             }
 
-            coVerify(exactly = 1) { spiedStorage.write(eq(Storage.Constants.APP_VERSION), any()) }
-            coVerify(exactly = 1) { spiedStorage.write(eq(Storage.Constants.APP_BUILD), any()) }
+            coVerify(exactly = 2) { spiedStorage.write(eq(Storage.Constants.APP_VERSION), any()) }
+            coVerify(exactly = 2) { spiedStorage.write(eq(Storage.Constants.APP_BUILD), any()) }
 
             close()
         }


### PR DESCRIPTION
### Describe what this PR is addressing

Devices with `APP_LIFECYCLES` autocapture off never wrote `APP_BUILD`/`APP_VERSION` to storage. When the flag later turned on, `previousBuild == null` fired a spurious `Application Installed` for every existing device.

iOS doesn't have this bug — it persists version/build before the autocapture gate.

### Describe the solution

Persist build/version unconditionally in `AndroidLifecyclePlugin.setup()`. Previous values are read synchronously into `@Volatile` fields before the async write launches, so the Installed/Updated decision always uses pre-write values regardless of dispatcher scheduling.

`DefaultEventUtils.trackAppUpdatedInstalledEvent` gains an `internal` overload that accepts snapshot values directly. The public deprecated method delegates to it.

### Scope

Fixes the forward path (ship fix → run once with flag off → flip on). Simultaneous SDK-upgrade-and-flag-flip still spikes on first launch (empty storage).

### Steps to verify the change

1. `./gradlew :android:testDebugUnitTest` — 22/22 pass, including two new regression tests.
2. `./gradlew :android:apiCheck` — no public API changes.

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?