### PR TITLE
feat(core): align RemoteConfigClient key model with iOS/Web

### DIFF
--- a/android/src/main/java/com/amplitude/android/AutocaptureManager.kt
+++ b/android/src/main/java/com/amplitude/android/AutocaptureManager.kt
@@ -5,7 +5,6 @@ import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.diagnostics.DiagnosticsClient
 import com.amplitude.core.remoteconfig.ConfigMap
 import com.amplitude.core.remoteconfig.RemoteConfigClient
-import com.amplitude.core.remoteconfig.RemoteConfigClient.Key
 import com.amplitude.core.remoteconfig.getBoolean
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -41,7 +40,7 @@ internal class AutocaptureManager(
                 RemoteConfigClient.RemoteConfigCallback { config, _, _ ->
                     handleRemoteConfig(config)
                 }
-            remoteConfigClient.subscribe(Key.ANALYTICS_SDK, callback = remoteConfigCallback)
+            remoteConfigClient.subscribe(RemoteConfigClient.Key.AnalyticsSdk, callback = remoteConfigCallback)
         } else {
             remoteConfigCallback = null
         }

--- a/android/src/main/java/com/amplitude/android/AutocaptureManager.kt
+++ b/android/src/main/java/com/amplitude/android/AutocaptureManager.kt
@@ -47,7 +47,8 @@ internal class AutocaptureManager(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun handleRemoteConfig(config: ConfigMap) {
+    private fun handleRemoteConfig(config: ConfigMap?) {
+        if (config == null) return
         val currentState = _state.value
 
         val autocaptureConfig = config["autocapture"] as? ConfigMap

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -18,6 +18,7 @@ import com.amplitude.android.Constants.EventProperties.NETWORK_TRACKING_URL_QUER
 import com.amplitude.android.Constants.EventTypes.NETWORK_TRACKING
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import com.amplitude.core.Amplitude
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.platform.Plugin
 import com.amplitude.core.platform.Plugin.Type
 import com.amplitude.core.platform.Plugin.Type.Utility
@@ -45,8 +46,10 @@ class NetworkTrackingPlugin(
     internal var currentOptions: NetworkTrackingOptions = options
 
     // Strong reference to prevent GC — RemoteConfigClient uses WeakReference
+    @OptIn(RestrictedAmplitudeFeature::class)
     private var remoteConfigCallback: RemoteConfigClient.RemoteConfigCallback? = null
 
+    @OptIn(RestrictedAmplitudeFeature::class)
     override fun setup(amplitude: Amplitude) {
         super.setup(amplitude)
 

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -63,7 +63,11 @@ class NetworkTrackingPlugin(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun handleRemoteConfig(config: ConfigMap) {
+    private fun handleRemoteConfig(config: ConfigMap?) {
+        if (config == null) {
+            currentOptions = originalOptions
+            return
+        }
         val autocaptureConfig = config["autocapture"] as? ConfigMap
         val networkConfig = autocaptureConfig?.get("networkTracking") as? ConfigMap
 

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingPlugin.kt
@@ -23,7 +23,6 @@ import com.amplitude.core.platform.Plugin.Type
 import com.amplitude.core.platform.Plugin.Type.Utility
 import com.amplitude.core.remoteconfig.ConfigMap
 import com.amplitude.core.remoteconfig.RemoteConfigClient
-import com.amplitude.core.remoteconfig.RemoteConfigClient.Key
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Interceptor.Chain
@@ -59,7 +58,7 @@ class NetworkTrackingPlugin(
                 RemoteConfigClient.RemoteConfigCallback { config, _, _ ->
                     handleRemoteConfig(config)
                 }
-            androidAmplitude.remoteConfigClient.subscribe(Key.ANALYTICS_SDK, callback = remoteConfigCallback!!)
+            androidAmplitude.remoteConfigClient.subscribe(RemoteConfigClient.Key.AnalyticsSdk, callback = remoteConfigCallback!!)
         }
     }
 

--- a/android/src/test/kotlin/com/amplitude/android/AutocaptureManagerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AutocaptureManagerTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(RestrictedAmplitudeFeature::class)
+
 package com.amplitude.android
 
 import com.amplitude.common.Logger

--- a/android/src/test/kotlin/com/amplitude/android/AutocaptureManagerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AutocaptureManagerTest.kt
@@ -307,7 +307,7 @@ class AutocaptureManagerTest {
             deliveryMode: RemoteConfigClient.DeliveryMode,
             callback: RemoteConfigClient.RemoteConfigCallback,
         ) {
-            if (key == RemoteConfigClient.Key.ANALYTICS_SDK) {
+            if (key == RemoteConfigClient.Key.AnalyticsSdk) {
                 callbacks.add(callback)
             }
         }

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(RestrictedAmplitudeFeature::class)
+
 package com.amplitude.android.network
 
 import com.amplitude.android.Constants.EventProperties.NETWORK_TRACKING_COMPLETION_TIME
@@ -21,6 +23,7 @@ import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader
 import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule
 import com.amplitude.android.network.NetworkTrackingOptions.URLPattern
 import com.amplitude.core.Amplitude
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.remoteconfig.ConfigMap
 import com.amplitude.core.remoteconfig.RemoteConfigClient

--- a/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/network/NetworkTrackingPluginTest.kt
@@ -852,7 +852,7 @@ class NetworkTrackingPluginTest {
             deliveryMode: RemoteConfigClient.DeliveryMode,
             callback: RemoteConfigClient.RemoteConfigCallback,
         ) {
-            if (key == RemoteConfigClient.Key.ANALYTICS_SDK) callbacks.add(callback)
+            if (key == RemoteConfigClient.Key.AnalyticsSdk) callbacks.add(callback)
         }
 
         override fun updateConfigs() {}

--- a/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(RestrictedAmplitudeFeature::class)
+
 package com.amplitude.android.plugins
 
 import android.app.Activity
@@ -16,6 +18,7 @@ import com.amplitude.android.internal.fragments.FragmentActivityHandler
 import com.amplitude.android.internal.fragments.FragmentActivityHandler.registerFragmentLifecycleCallbacks
 import com.amplitude.android.internal.fragments.FragmentActivityHandler.unregisterFragmentLifecycleCallbacks
 import com.amplitude.android.utilities.ActivityLifecycleObserver
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.Storage
 import com.amplitude.core.utilities.InMemoryStorage
 import io.mockk.coVerify

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -962,7 +962,6 @@ public final class com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMo
 }
 
 public abstract class com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
-	public static final field Companion Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getValue ()Ljava/lang/String;
 }
@@ -972,9 +971,6 @@ public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$Analyt
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$Companion {
 }
 
 public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$Custom : com/amplitude/core/remoteconfig/RemoteConfigClient$Key {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -961,15 +961,49 @@ public final class com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMo
 	public final fun getTimeoutMs ()J
 }
 
-public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key : java/lang/Enum {
-	public static final field ANALYTICS_SDK Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key;
-	public static final field DIAGNOSTICS Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key;
-	public static final field SESSION_REPLAY_PRIVACY_CONFIG Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key;
-	public static final field SESSION_REPLAY_SAMPLING_CONFIG Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public final fun getValue ()Ljava/lang/String;
-	public static fun valueOf (Ljava/lang/String;)Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key;
-	public static fun values ()[Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key;
+public abstract class com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
+	public static final field Companion Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getValue ()Ljava/lang/String;
+}
+
+public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$AnalyticsSdk : com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
+	public static final field INSTANCE Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key$AnalyticsSdk;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$Companion {
+}
+
+public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$Custom : com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$Diagnostics : com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
+	public static final field INSTANCE Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key$Diagnostics;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$SessionReplayPrivacyConfig : com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
+	public static final field INSTANCE Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key$SessionReplayPrivacyConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$SessionReplaySamplingConfig : com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
+	public static final field INSTANCE Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key$SessionReplaySamplingConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/amplitude/core/remoteconfig/RemoteConfigClient$RemoteConfigCallback {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -958,7 +958,10 @@ public final class com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMo
 
 public final class com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode$WaitForRemote : com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMode {
 	public fun <init> (J)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTimeoutMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class com/amplitude/core/remoteconfig/RemoteConfigClient$Key {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1002,7 +1002,7 @@ public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$Sessio
 }
 
 public abstract interface class com/amplitude/core/remoteconfig/RemoteConfigClient$RemoteConfigCallback {
-	public abstract fun onUpdate (Ljava/util/Map;Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Source;J)V
+	public abstract fun onUpdate (Ljava/util/Map;Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Source;Ljava/lang/Long;)V
 }
 
 public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Source : java/lang/Enum {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -963,7 +963,7 @@ public final class com/amplitude/core/remoteconfig/RemoteConfigClient$DeliveryMo
 
 public abstract class com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getValue ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
 }
 
 public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$AnalyticsSdk : com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
@@ -976,7 +976,6 @@ public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$Analyt
 public final class com/amplitude/core/remoteconfig/RemoteConfigClient$Key$Custom : com/amplitude/core/remoteconfig/RemoteConfigClient$Key {
 	public fun <init> (Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -92,6 +92,8 @@ open class Amplitude(
             enabled = configuration.enableDiagnostics,
         )
     }
+
+    @RestrictedAmplitudeFeature
     val remoteConfigClient: RemoteConfigClient by lazy {
         RemoteConfigClientImpl(
             apiKey = configuration.apiKey,

--- a/core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
+++ b/core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
@@ -192,7 +192,7 @@ internal class DiagnosticsClientImpl(
             )
 
         remoteConfigCallback?.let { callback ->
-            remoteConfigClient?.subscribe(RemoteConfigClient.Key.DIAGNOSTICS, callback = callback)
+            remoteConfigClient?.subscribe(RemoteConfigClient.Key.Diagnostics, callback = callback)
         }
 
         channel.trySend(Update.InitializeTasks)

--- a/core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
+++ b/core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
@@ -143,8 +143,8 @@ internal class DiagnosticsClientImpl(
     private val remoteConfigCallback: RemoteConfigClient.RemoteConfigCallback? =
         if (remoteConfigClient != null) {
             RemoteConfigClient.RemoteConfigCallback { config, _, _ ->
-                val enabledConfig = config["enabled"] as? Boolean
-                val sampleRateConfig = (config["sampleRate"] as? Number)?.toDouble()
+                val enabledConfig = config?.get("enabled") as? Boolean
+                val sampleRateConfig = (config?.get("sampleRate") as? Number)?.toDouble()
 
                 logger.debug("DiagnosticsClient: Did fetch remote config with sampleRate: $sampleRateConfig")
 

--- a/core/src/main/java/com/amplitude/core/remoteconfig/README.md
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/README.md
@@ -30,16 +30,19 @@ iOS (`AmplitudeCore-Swift`) and Web clients so behavior is consistent across SDK
 
 ## Delivery semantics
 
-- **`subscribe` always delivers exactly once** initially — cache, remote, or a
-  failure signal — so callers can reliably gate setup on it.
+- **`subscribe` always delivers an initial callback** — cache, remote, or a failure
+  signal — so callers can reliably gate setup on it. The mode controls only this
+  *initial* delivery; afterward every subscriber receives subsequent successful
+  fetches as updates.
 - **`All`**: delivers cache immediately (if present), then the remote result, then
-  every subsequent successful refresh.
-- **`WaitForRemote(timeout)`**: waits for the remote up to `timeout`; on
-  failure/timeout falls back to cache, else a failure signal. **One-and-done** —
-  later refreshes do not re-notify it.
-- **`updateConfigs()`** (refresh): rate-limited (5 min). Only *successful* configs
-  are delivered to existing subscribers; failures are never fanned out, so
-  subscribers keep their last valid config.
+  every subsequent successful fetch.
+- **`WaitForRemote(timeout)`**: blocks the *initial* delivery on the remote up to
+  `timeout`; on failure/timeout falls back to cache, else a failure signal. After
+  that initial callback it receives subsequent fetches as updates, the same as `All`.
+- **Any successful fetch** — whether triggered by a `subscribe` or by
+  `updateConfigs()` — delivers the latest config to **all** current subscribers
+  (de-duplicated per subscriber by `fetchId`). Failures are never fanned out, so
+  subscribers keep their last valid config. `updateConfigs()` is rate-limited (5 min).
 
 ## Internals
 

--- a/core/src/main/java/com/amplitude/core/remoteconfig/README.md
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/README.md
@@ -1,0 +1,111 @@
+# Remote Config
+
+Fetches a nested configuration blob from Amplitude's remote-config service and
+delivers slices of it to subscribers, keyed by a dot-path. The model mirrors the
+iOS (`AmplitudeCore-Swift`) and Web clients so behavior is consistent across SDKs.
+
+- **Entry point:** `Amplitude.remoteConfigClient` → `RemoteConfigClientImpl`
+- **Endpoint:** `GET https://sr-client-cfg.amplitude.com/config?api_key=…&config_group=android`
+  (EU: `sr-client-cfg.eu.amplitude.com`)
+- **Storage:** the full nested blob + a fetch timestamp are cached; slices are
+  resolved from the blob at delivery time via `resolveDotPath`.
+
+## Key types
+
+| Type | Purpose |
+|------|---------|
+| `RemoteConfigClient` | Public interface: `subscribe(key, deliveryMode, callback)` and `updateConfigs()`. |
+| `Key` (sealed) | `AnalyticsSdk`, `Diagnostics`, `SessionReplayPrivacyConfig`, `SessionReplaySamplingConfig`, and `Custom("dot.path")` for an arbitrary section. |
+| `DeliveryMode` | `All` or `WaitForRemote(timeoutMs)` — controls only the *initial* delivery. |
+| `RemoteConfigCallback` | `onUpdate(config: ConfigMap?, source: Source, timestamp: Long?)`. |
+| `Source` | `CACHE` or `REMOTE`. |
+
+### Callback contract
+
+`onUpdate(config, source, timestamp)`:
+
+- `timestamp == null` → the fetch **failed** (config is `null`).
+- `timestamp != null`, `config == null` → fetch succeeded but the **key is absent**.
+- `config != null` → resolved config slice (never contains null values).
+
+## Delivery semantics
+
+- **`subscribe` always delivers exactly once** initially — cache, remote, or a
+  failure signal — so callers can reliably gate setup on it.
+- **`All`**: delivers cache immediately (if present), then the remote result, then
+  every subsequent successful refresh.
+- **`WaitForRemote(timeout)`**: waits for the remote up to `timeout`; on
+  failure/timeout falls back to cache, else a failure signal. **One-and-done** —
+  later refreshes do not re-notify it.
+- **`updateConfigs()`** (refresh): rate-limited (5 min). Only *successful* configs
+  are delivered to existing subscribers; failures are never fanned out, so
+  subscribers keep their last valid config.
+
+## Internals
+
+A single shared in-flight fetch (`Deferred<FetchOutcome>`) backs every subscribe
+and refresh, so concurrent callers share one network call. Each fetch gets a
+monotonic `fetchId`; remote deliveries are de-duplicated per subscriber by it, so
+a refresh broadcast can never double-deliver and a late subscriber is never
+missed. The fetch coroutine only produces the outcome (it does **not** invoke
+callbacks), so a slow subscriber can't delay other awaiters.
+
+```mermaid
+flowchart TD
+    SUB["subscribe(key, mode, cb)"] --> CACHE["read cache<br/>(deliver CACHE if a blob is cached,<br/>config may be null if the key is absent)"]
+    CACHE --> SRC
+    REFRESH["updateConfigs()<br/>rate-limited refresh"] --> SRC
+
+    SRC{"config source?"}
+    SRC -->|"fetch in flight"| JOIN["join the shared fetch"]
+    SRC -->|"recent success"| REUSE["reuse last result<br/>(no network call)"]
+    SRC -->|"otherwise"| FETCH["GET /config?config_group=android<br/>then store blob + timestamp"]
+
+    JOIN --> OUT["FetchOutcome<br/>Success(blob, ts, fetchId) · Failure"]
+    REUSE --> OUT
+    FETCH --> OUT
+    OUT --> CB["onUpdate(config, source, timestamp)"]
+```
+
+> **Delivery routing:** a `subscribe` delivers only to its own caller; a successful
+> `updateConfigs()` refresh broadcasts to all current subscribers. Remote deliveries
+> are de-duplicated per subscriber by `fetchId`, so the two paths never double-deliver
+> the same fetch — and a `CACHE` never lands after a `REMOTE`.
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant RC as RemoteConfigClient
+    participant S as Storage
+    participant N as Network
+
+    C->>RC: subscribe(Key, All, cb)
+    RC->>S: read cached blob
+    alt blob is cached
+        RC-->>C: onUpdate(config-or-null, CACHE, ts)
+    end
+    RC->>N: GET /config?config_group=android
+    alt success
+        N-->>RC: nested blob
+        RC->>S: write blob + timestamp
+        RC-->>C: onUpdate(slice, REMOTE, ts)
+    else failure (and nothing delivered yet)
+        RC-->>C: onUpdate(null, REMOTE, null)
+    end
+```
+
+## Compatibility
+
+`RemoteConfigClient` is an **internal mechanism** (autocapture, diagnostics,
+session replay) and is gated behind `@RestrictedAmplitudeFeature` (a
+`@RequiresOptIn` marker) — it is not part of the supported public surface.
+
+The alignment with iOS/Web changed the shape of these types. The changes are
+binary-incompatible, so anyone who referenced the previous (ungated) symbols
+must update:
+
+| Before | Now | Migration |
+|--------|-----|-----------|
+| `Key` was an `enum class` | `Key` is a `sealed class` | `Key.valueOf(...)` / `Key.values()` no longer exist; use the data objects (`Key.AnalyticsSdk`, …) or `Key.Custom("dot.path")`. |
+| `onUpdate(config: ConfigMap, source, timestamp: Long)` | `onUpdate(config: ConfigMap?, source, timestamp: Long?)` | Handle `null`: `timestamp == null` means the fetch failed; `config == null` with a non-null timestamp means the key is absent. |
+| individual `config_keys` fetches | single `config_group=android` blob | No caller change; the client resolves slices from the blob via the same `Key`. |

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -231,10 +231,11 @@ internal class RemoteConfigClientImpl(
         val weakCallback = WeakCallback(callback)
         registerSubscriber(key, weakCallback)
 
-        // Immediately provide stored config if available
+        // Immediately deliver cached config only when the subscriber's key actually
+        // resolves in the cached blob. A null resolved config means "not in cache"
+        // — the upcoming REMOTE delivery will report the authoritative state.
         val storedData = getStoredConfigData(key.value)
-        if (storedData != null) {
-            // Notify only the newly added subscriber
+        if (storedData?.config != null) {
             weakCallback.runSafely {
                 onUpdate(storedData.config, CACHE, storedData.timestamp)
             }

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -325,13 +325,17 @@ internal class RemoteConfigClientImpl(
                 return@launch
             }
 
+            // Claim the in-flight slot synchronously, before the suspending
+            // shouldRateLimit() read. Otherwise a second coroutine queued on the
+            // single network dispatcher could pass the isFetching guard during the
+            // suspension and issue a duplicate fetch.
+            isFetching = true
             try {
                 if (shouldRateLimit()) {
                     logger.debug("RemoteConfig update skipped: within 5-minute window")
                     return@launch
                 }
 
-                isFetching = true
                 val blob = fetchRemoteConfig()
                 if (blob == null) {
                     notifySubscribersOnFailure(System.currentTimeMillis())
@@ -451,7 +455,9 @@ internal class RemoteConfigClientImpl(
 
     /**
      * Walk a dot-path into a nested config blob and return the leaf as a [ConfigMap].
-     * Returns null if any segment is missing or non-map.
+     * Returns null if any segment is missing or non-map. Null values inside the
+     * resolved leaf (from `JSONObject.NULL` in nested objects) are filtered out so
+     * the delivered map honors the non-null [ConfigMap] contract.
      */
     @Suppress("UNCHECKED_CAST")
     private fun resolveDotPath(
@@ -461,10 +467,10 @@ internal class RemoteConfigClientImpl(
         val segments = dotPath.split(".")
         var current: Any? = blob
         for (segment in segments) {
-            val map = current as? Map<String, Any> ?: return null
+            val map = current as? Map<String, Any?> ?: return null
             current = map[segment] ?: return null
         }
-        return current as? Map<String, Any>
+        return (current as? Map<String, Any?>)?.filterNotNullValues()
     }
 
     private fun fetchRemoteConfig(): ConfigMap? {

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -57,7 +57,13 @@ interface RemoteConfigClient {
         data object All : DeliveryMode()
 
         /** Wait for remote up to [timeoutMs], then fall back to cache (or empty). */
-        class WaitForRemote(val timeoutMs: Long) : DeliveryMode()
+        class WaitForRemote(val timeoutMs: Long) : DeliveryMode() {
+            override fun equals(other: Any?): Boolean = other is WaitForRemote && other.timeoutMs == timeoutMs
+
+            override fun hashCode(): Int = timeoutMs.hashCode()
+
+            override fun toString(): String = "WaitForRemote(timeoutMs=$timeoutMs)"
+        }
     }
 
     /**
@@ -173,7 +179,7 @@ internal class RemoteConfigClientImpl(
          * race the cache read, and a stale cache must never land after a fresh remote.
          */
         fun deliverCache(
-            config: ConfigMap,
+            config: ConfigMap?,
             timestamp: Long,
         ) {
             val callback = weakRef.get() ?: return
@@ -280,8 +286,10 @@ internal class RemoteConfigClientImpl(
         registerSubscriber(key, weakCallback)
 
         coroutineScope.launch {
+            // A cached blob counts even when the key is absent within it: iOS delivers
+            // (null, CACHE, lastFetch) in that case, distinct from a true cache miss.
             val cached = withContext(storageIODispatcher) { getStoredConfigData(key.value) }
-            if (cached?.config != null) {
+            if (cached != null) {
                 weakCallback.deliverCache(cached.config, cached.timestamp)
             }
 
@@ -352,7 +360,10 @@ internal class RemoteConfigClientImpl(
             // concurrent broadcast that already delivered makes these calls no-ops.
             if (!weakCallback.hasDelivered()) {
                 val cached = withContext(storageIODispatcher) { getStoredConfigData(key.value) }
-                if (cached?.config != null) {
+                if (cached != null) {
+                    // A cached blob is a valid answer even when the key is absent within
+                    // it: deliver (null, CACHE, lastFetch), mirroring iOS. Only a true
+                    // cache miss yields the (null, REMOTE, null) failure signal.
                     weakCallback.deliverFirst(cached.config, CACHE, cached.timestamp)
                 } else {
                     weakCallback.deliverFirst(null, REMOTE, null)
@@ -473,19 +484,26 @@ internal class RemoteConfigClientImpl(
     }
 
     private suspend fun performFetch(fetchId: Long): FetchOutcome {
-        return try {
-            val blob = fetchRemoteConfig() ?: return FetchOutcome.Failure
-            val timestamp = System.currentTimeMillis()
+        val blob =
+            try {
+                fetchRemoteConfig() ?: return FetchOutcome.Failure
+            } catch (e: Exception) {
+                logger.error("Error fetching remote configs: ${e.message}")
+                return FetchOutcome.Failure
+            }
+        val timestamp = System.currentTimeMillis()
+        // Persisting the blob is best-effort: a storage write failure must not discard
+        // a valid in-memory remote config (mirrors iOS `try? storage.setConfig`).
+        try {
             withContext(storageIODispatcher) {
                 storage.write(REMOTE_CONFIG, blob.toJSONObject().toString())
                 storage.write(REMOTE_CONFIG_TIMESTAMP, timestamp.toString())
                 logger.debug("Successfully stored remote configs to storage")
             }
-            FetchOutcome.Success(blob, timestamp, fetchId)
         } catch (e: Exception) {
-            logger.error("Error updating remote configs: ${e.message}")
-            FetchOutcome.Failure
+            logger.error("Failed to persist remote configs (delivering anyway): ${e.message}")
         }
+        return FetchOutcome.Success(blob, timestamp, fetchId)
     }
 
     private fun isFresh(timestamp: Long): Boolean {
@@ -547,7 +565,10 @@ internal class RemoteConfigClientImpl(
             }
 
             val allConfigs = JSONObject(configJson).toMapObj().filterNotNullValues()
-            if (allConfigs.isEmpty()) return null
+
+            // An empty (but parseable) blob is a valid cached answer — a successful fetch
+            // that returned no config. It must remain distinguishable from a true cache
+            // miss (null), so subscribers get (null, CACHE, ts) rather than a failure.
 
             // Detect old pre-flattened format: keys contain dots (e.g. "sessionReplay.sr_android_privacy_config").
             // New format has top-level keys without dots (e.g. "sessionReplay", "diagnostics").

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -390,8 +390,9 @@ internal class RemoteConfigClientImpl(
 
     /**
      * Reads the stored config blob from storage. Returns the nested map
-     * structure or null if storage is empty/corrupt. Gracefully handles
-     * old pre-flattened storage format by treating it as a cache miss.
+     * structure or null if storage is empty/corrupt. Discards stale
+     * old pre-flattened format blobs so the in-flight remote fetch can
+     * refill storage with the correct nested format.
      */
     private fun getStoredConfigBlob(): ConfigMap? {
         return try {
@@ -408,17 +409,11 @@ internal class RemoteConfigClientImpl(
             // New format has top-level keys without dots (e.g. "sessionReplay", "diagnostics").
             val isOldFormat = allConfigs.keys.any { "." in it }
             if (isOldFormat) {
-                logger.debug("Detected old pre-flattened cache format; migrating in place")
-                val migrated = migrateOldFormatToNested(allConfigs)
+                logger.debug("Detected old pre-flattened cache format; discarding stale blob")
                 coroutineScope.launch(storageIODispatcher) {
-                    try {
-                        storage.write(REMOTE_CONFIG, migrated.toJSONObject().toString())
-                        logger.debug("Migrated old-format cache to nested format")
-                    } catch (e: Exception) {
-                        logger.error("Failed to write migrated cache: ${e.message}")
-                    }
+                    storage.write(REMOTE_CONFIG, "")
                 }
-                return migrated
+                return null
             }
 
             logger.debug("Successfully loaded stored config blob with ${allConfigs.size} top-level keys")
@@ -427,25 +422,6 @@ internal class RemoteConfigClientImpl(
             logger.error("Failed to parse all stored configs: ${e.message}")
             null
         }
-    }
-
-    // Temporary: old cache only stored single-dot keys (e.g. "sessionReplay.sr_android_privacy_config").
-    @Suppress("UNCHECKED_CAST")
-    private fun migrateOldFormatToNested(flat: ConfigMap): ConfigMap {
-        val result = mutableMapOf<String, Any>()
-        for ((key, value) in flat) {
-            val dotIndex = key.indexOf('.')
-            if (dotIndex < 0) {
-                result[key] = value
-                continue
-            }
-            val root = key.substring(0, dotIndex)
-            val child = key.substring(dotIndex + 1)
-            val existing = result[root] as? MutableMap<String, Any> ?: mutableMapOf()
-            existing[child] = value
-            result[root] = existing
-        }
-        return result
     }
 
     /**

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -53,9 +53,10 @@ interface RemoteConfigClient {
     }
 
     /**
-     * Dot-path key for subscribing to remote config sections.
-     * Split by "." to walk nested config objects. For example,
-     * "sessionReplay.sr_android_privacy_config" resolves configs.sessionReplay.sr_android_privacy_config.
+     * Dot-path key for subscribing to a section of the remote config blob.
+     * Segments are split by "." and used to walk nested maps. For example,
+     * "sessionReplay.sr_android_privacy_config" resolves the nested map at
+     * configs.sessionReplay.sr_android_privacy_config.
      */
     sealed class Key(open val value: String) {
         data object AnalyticsSdk : Key("analyticsSDK.androidSDK")

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -58,7 +58,7 @@ interface RemoteConfigClient {
      * "sessionReplay.sr_android_privacy_config" resolves the nested map at
      * configs.sessionReplay.sr_android_privacy_config.
      */
-    sealed class Key(open val value: String) {
+    sealed class Key(val value: String) {
         data object AnalyticsSdk : Key("analyticsSDK.androidSDK")
 
         data object Diagnostics : Key("diagnostics.androidSDK")
@@ -67,7 +67,7 @@ interface RemoteConfigClient {
 
         data object SessionReplaySamplingConfig : Key("sessionReplay.sr_android_sampling_config")
 
-        class Custom(override val value: String) : Key(value) {
+        class Custom(value: String) : Key(value) {
             override fun equals(other: Any?): Boolean = other is Custom && other.value == value
 
             override fun hashCode(): Int = value.hashCode()

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -89,7 +89,7 @@ interface RemoteConfigClient {
 
     fun interface RemoteConfigCallback {
         fun onUpdate(
-            config: ConfigMap,
+            config: ConfigMap?,
             source: Source,
             timestamp: Long,
         )
@@ -114,7 +114,7 @@ internal class RemoteConfigClientImpl(
      * Data class for storing config data with timestamp
      */
     private data class ConfigData(
-        val config: ConfigMap,
+        val config: ConfigMap?,
         val timestamp: Long,
     )
 
@@ -209,7 +209,7 @@ internal class RemoteConfigClientImpl(
     private val subscriberLock = Any()
     private val keySpecificSubscribers = mutableMapOf<String, MutableList<WeakCallback>>()
 
-    @Volatile
+    // Safe without synchronization: all reads/writes happen on the single-threaded networkIODispatcher.
     private var isFetching: Boolean = false
 
     override fun subscribe(
@@ -274,7 +274,7 @@ internal class RemoteConfigClientImpl(
                 // Timeout: fall back to cache (or empty). runSafelyIfFirst
                 // suppresses this if a remote delivery already claimed the gate.
                 val storedData = getStoredConfigData(key.value)
-                val config = storedData?.config ?: emptyMap()
+                val config = storedData?.config
                 val timestamp = storedData?.timestamp ?: System.currentTimeMillis()
                 val delivered =
                     weakCallback.runSafelyIfFirst {
@@ -344,8 +344,7 @@ internal class RemoteConfigClientImpl(
                         keySpecificSubscribers.map { (dotPath, subs) -> dotPath to subs.toList() }
                     }
                 for ((dotPath, subscribers) in subscriberSnapshot) {
-                    val resolved = resolveDotPath(blob, dotPath)
-                    val config = resolved ?: emptyMap()
+                    val config = resolveDotPath(blob, dotPath)
                     subscribers.forEach { weakCallback ->
                         weakCallback.runSafely {
                             onUpdate(config, REMOTE, timestamp)
@@ -376,11 +375,11 @@ internal class RemoteConfigClientImpl(
         return try {
             val blob = getStoredConfigBlob() ?: return null
 
-            val resolved = resolveDotPath(blob, dotPath) ?: emptyMap()
+            val resolved = resolveDotPath(blob, dotPath)
             val timestampStr = storage.read(REMOTE_CONFIG_TIMESTAMP)
             val timestamp = timestampStr?.toLongOrNull() ?: 0L
 
-            logger.debug("Retrieved stored config for $dotPath with ${resolved.size} properties")
+            logger.debug("Retrieved stored config for $dotPath with ${resolved?.size ?: 0} properties")
             ConfigData(resolved, timestamp)
         } catch (e: Exception) {
             logger.error("Failed to retrieve stored config data for $dotPath: ${e.message}")

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Type alias for remote configuration map data.
@@ -139,43 +140,66 @@ internal class RemoteConfigClientImpl(
     /**
      * Weak-reference wrapper around a subscriber callback to avoid leaks.
      *
-     * Each subscriber receives at most one *first* delivery (cache, remote, or a
-     * failure signal). [deliverFirst] claims that slot atomically so racing paths
-     * (remote arrival vs. timeout fallback) can't double-deliver the first
-     * callback. [deliver] always fires and is used for the immediate cache
-     * delivery and for ongoing [RemoteConfigClient.DeliveryMode.All] updates.
+     * Deliveries for a subscriber are serialized by [deliveryLock]. Remote deliveries
+     * are de-duplicated by [lastFetchId] so the same fetch is never delivered twice —
+     * e.g. a subscribe's own self-delivery and a concurrent refresh broadcast carry the
+     * same id, so only the first one fires. For [RemoteConfigClient.DeliveryMode.WaitForRemote],
+     * [deliverFirst] enforces a single initial delivery (one-and-done).
      */
     private inner class WeakCallback(
         callback: RemoteConfigClient.RemoteConfigCallback,
         val deliveryMode: RemoteConfigClient.DeliveryMode,
     ) {
         private val weakRef = WeakReference(callback)
-
-        /**
-         * Serializes all callback invocations for this subscriber so concurrent
-         * paths (remote fetch, timeout fallback, refresh) can't deliver at once.
-         */
         private val deliveryLock = Any()
         private val delivered = AtomicBoolean(false)
+        private val lastFetchId = AtomicLong(Long.MIN_VALUE)
 
         fun isAlive(): Boolean = weakRef.get() != null
 
         fun hasDelivered(): Boolean = delivered.get()
 
-        /** Always deliver, marking this subscriber as having received a callback. */
-        fun deliver(
-            config: ConfigMap?,
-            source: RemoteConfigClient.Source,
-            timestamp: Long?,
+        /**
+         * Immediate cache delivery (used by [RemoteConfigClient.DeliveryMode.All]).
+         * Skipped if a remote has already been delivered — a concurrent refresh can
+         * race the cache read, and a stale cache must never land after a fresh remote.
+         */
+        fun deliverCache(
+            config: ConfigMap,
+            timestamp: Long,
         ) {
             val callback = weakRef.get() ?: return
             synchronized(deliveryLock) {
+                if (lastFetchId.get() != Long.MIN_VALUE) return
                 delivered.set(true)
-                invoke(callback, config, source, timestamp)
+                invoke(callback, config, CACHE, timestamp)
             }
         }
 
-        /** Deliver only as the first callback. Returns whether it fired. */
+        /**
+         * Remote delivery, de-duplicated by [fetchId]: a fetch already delivered to
+         * this subscriber (same or older id) is skipped. Used for the initial remote
+         * and ongoing [RemoteConfigClient.DeliveryMode.All] refreshes.
+         */
+        fun deliverRemote(
+            config: ConfigMap?,
+            timestamp: Long,
+            fetchId: Long,
+        ) {
+            val callback = weakRef.get() ?: return
+            synchronized(deliveryLock) {
+                if (fetchId <= lastFetchId.get()) return
+                lastFetchId.set(fetchId)
+                delivered.set(true)
+                invoke(callback, config, REMOTE, timestamp)
+            }
+        }
+
+        /**
+         * Single initial delivery for [RemoteConfigClient.DeliveryMode.WaitForRemote]:
+         * the first caller to claim the slot delivers; all others (timeout fallback,
+         * a late remote, a refresh) are no-ops. Returns whether it fired.
+         */
         fun deliverFirst(
             config: ConfigMap?,
             source: RemoteConfigClient.Source,
@@ -203,9 +227,9 @@ internal class RemoteConfigClientImpl(
         }
     }
 
-    /** Result of a remote fetch: a successful blob with its fetch time, or a failure. */
+    /** Result of a remote fetch: a successful blob (with fetch time and id), or a failure. */
     private sealed interface FetchOutcome {
-        data class Success(val blob: ConfigMap, val timestamp: Long) : FetchOutcome
+        data class Success(val blob: ConfigMap, val timestamp: Long, val fetchId: Long) : FetchOutcome
 
         data object Failure : FetchOutcome
     }
@@ -218,6 +242,9 @@ internal class RemoteConfigClientImpl(
     private val fetchLock = Any()
     private var inFlightFetch: Deferred<FetchOutcome>? = null
     private var lastSuccess: FetchOutcome.Success? = null
+
+    // Monotonic id per fetch; subscribers use it to de-dup remote deliveries.
+    private val fetchSeq = AtomicLong(0L)
 
     override fun subscribe(
         key: Key,
@@ -247,23 +274,29 @@ internal class RemoteConfigClientImpl(
         coroutineScope.launch {
             val cached = withContext(storageIODispatcher) { getStoredConfigData(key.value) }
             if (cached?.config != null) {
-                weakCallback.deliver(cached.config, CACHE, cached.timestamp)
+                weakCallback.deliverCache(cached.config, cached.timestamp)
             }
 
+            // Deliver to this subscriber from its own awaited outcome — never relying on
+            // a broadcast snapshot. deliverRemote de-dups by fetchId, so a concurrent
+            // refresh broadcast of the same fetch won't double-deliver.
             when (val handle = obtainSubscribeFetch()) {
-                // A recent success is reused without a network call, so no broadcast
-                // fires — deliver it to this subscriber directly.
                 is FetchHandle.Reuse ->
-                    weakCallback.deliver(
+                    weakCallback.deliverRemote(
                         resolveDotPath(handle.success.blob, key.value),
-                        REMOTE,
                         handle.success.timestamp,
+                        handle.success.fetchId,
                     )
-                // A live fetch broadcasts its success to all subscribers (including
-                // us). Only the failure case needs handling here.
                 is FetchHandle.Pending ->
-                    if (handle.deferred.await() is FetchOutcome.Failure && !weakCallback.hasDelivered()) {
-                        weakCallback.deliver(null, REMOTE, null)
+                    when (val outcome = handle.deferred.await()) {
+                        is FetchOutcome.Success ->
+                            weakCallback.deliverRemote(
+                                resolveDotPath(outcome.blob, key.value),
+                                outcome.timestamp,
+                                outcome.fetchId,
+                            )
+                        // Failure delivers only if nothing (cache) was delivered first.
+                        FetchOutcome.Failure -> weakCallback.deliverFirst(null, REMOTE, null)
                     }
             }
         }
@@ -292,11 +325,23 @@ internal class RemoteConfigClientImpl(
                         REMOTE,
                         handle.success.timestamp,
                     )
-                // On success the fetch's broadcast claims the first delivery. We only
-                // wait up to the timeout; if it elapses (or the fetch fails) we fall back.
-                is FetchHandle.Pending ->
-                    withTimeoutOrNull(timeoutMs) { handle.deferred.await() }
+                is FetchHandle.Pending -> {
+                    // Wait up to the timeout for the remote; on success deliver it
+                    // (REMOTE), not a cache fallback.
+                    val outcome = withTimeoutOrNull(timeoutMs) { handle.deferred.await() }
+                    if (outcome is FetchOutcome.Success) {
+                        weakCallback.deliverFirst(
+                            resolveDotPath(outcome.blob, key.value),
+                            REMOTE,
+                            outcome.timestamp,
+                        )
+                    }
+                }
             }
+            // Timed out or the fetch failed: fall back to cache, or a failure signal
+            // when there is none. The hasDelivered() check only skips the storage read
+            // in the common case — deliverFirst's CAS is the actual delivery gate, so a
+            // concurrent broadcast that already delivered makes these calls no-ops.
             if (!weakCallback.hasDelivered()) {
                 val cached = withContext(storageIODispatcher) { getStoredConfigData(key.value) }
                 if (cached?.config != null) {
@@ -339,15 +384,22 @@ internal class RemoteConfigClientImpl(
                 logger.debug("RemoteConfig update skipped: within 5-minute window")
                 return@launch
             }
-            // A successful fetch broadcasts itself to all subscribers; nothing else to do.
-            startOrJoinFetch()
+            val outcome = startOrJoinFetch().await()
+            if (outcome is FetchOutcome.Success) {
+                broadcastUpdate(outcome.blob, outcome.timestamp, outcome.fetchId)
+            }
         }
     }
 
-    /** Delivers a freshly fetched config to all current subscribers as an update. */
+    /**
+     * Delivers a freshly fetched config to all current subscribers as an update.
+     * [DeliveryMode.All] receives every fetch (de-duplicated by [fetchId]);
+     * [DeliveryMode.WaitForRemote] only if it hasn't yet received its first callback.
+     */
     private fun broadcastUpdate(
         blob: ConfigMap,
         timestamp: Long,
+        fetchId: Long,
     ) {
         val subscriberSnapshot =
             synchronized(subscriberLock) {
@@ -358,7 +410,7 @@ internal class RemoteConfigClientImpl(
             subscribers.forEach { weakCallback ->
                 when (weakCallback.deliveryMode) {
                     is RemoteConfigClient.DeliveryMode.All ->
-                        weakCallback.deliver(config, REMOTE, timestamp)
+                        weakCallback.deliverRemote(config, timestamp, fetchId)
                     is RemoteConfigClient.DeliveryMode.WaitForRemote ->
                         weakCallback.deliverFirst(config, REMOTE, timestamp)
                 }
@@ -395,14 +447,16 @@ internal class RemoteConfigClientImpl(
     }
 
     private fun startFetchLocked(): Deferred<FetchOutcome> {
+        val fetchId = fetchSeq.incrementAndGet()
+        // The fetch only produces the outcome (and records lastSuccess); it does NOT
+        // invoke callbacks. Delivery is driven by awaiters (subscribe) and the refresh
+        // broadcast, so the deferred completes as soon as the network/parse is done —
+        // a slow subscriber callback can't delay other awaiters.
         val deferred =
             coroutineScope.async(networkIODispatcher) {
-                val outcome = performFetch()
+                val outcome = performFetch(fetchId)
                 if (outcome is FetchOutcome.Success) {
                     synchronized(fetchLock) { lastSuccess = outcome }
-                    // A single broadcast per successful fetch delivers to every current
-                    // subscriber — avoids each awaiter delivering its own duplicate.
-                    broadcastUpdate(outcome.blob, outcome.timestamp)
                 }
                 outcome
             }
@@ -410,7 +464,7 @@ internal class RemoteConfigClientImpl(
         return deferred
     }
 
-    private suspend fun performFetch(): FetchOutcome {
+    private suspend fun performFetch(fetchId: Long): FetchOutcome {
         return try {
             val blob = fetchRemoteConfig() ?: return FetchOutcome.Failure
             val timestamp = System.currentTimeMillis()
@@ -419,7 +473,7 @@ internal class RemoteConfigClientImpl(
                 storage.write(REMOTE_CONFIG_TIMESTAMP, timestamp.toString())
                 logger.debug("Successfully stored remote configs to storage")
             }
-            FetchOutcome.Success(blob, timestamp)
+            FetchOutcome.Success(blob, timestamp, fetchId)
         } catch (e: Exception) {
             logger.error("Error updating remote configs: ${e.message}")
             FetchOutcome.Failure
@@ -447,6 +501,9 @@ internal class RemoteConfigClientImpl(
     /**
      * Retrieve stored configuration data for a specific dot-path key.
      * Walks the stored nested blob using dot-path segments.
+     *
+     * Reads storage synchronously, so callers MUST invoke it from
+     * [storageIODispatcher] (e.g. inside `withContext(storageIODispatcher)`).
      */
     private fun getStoredConfigData(dotPath: String): ConfigData? {
         return try {

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -166,7 +166,6 @@ internal class RemoteConfigClientImpl(
      */
     private inner class WeakCallback(
         callback: RemoteConfigClient.RemoteConfigCallback,
-        val deliveryMode: RemoteConfigClient.DeliveryMode,
     ) {
         private val weakRef = WeakReference(callback)
         private val deliveryLock = Any()
@@ -288,7 +287,7 @@ internal class RemoteConfigClientImpl(
         key: Key,
         callback: RemoteConfigClient.RemoteConfigCallback,
     ) {
-        val weakCallback = WeakCallback(callback, RemoteConfigClient.DeliveryMode.All)
+        val weakCallback = WeakCallback(callback)
         registerSubscriber(key, weakCallback)
 
         coroutineScope.launch {
@@ -336,8 +335,7 @@ internal class RemoteConfigClientImpl(
         timeoutMs: Long,
         callback: RemoteConfigClient.RemoteConfigCallback,
     ) {
-        val weakCallback =
-            WeakCallback(callback, RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs))
+        val weakCallback = WeakCallback(callback)
         registerSubscriber(key, weakCallback)
 
         coroutineScope.launch {

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -13,9 +13,10 @@ import com.amplitude.core.remoteconfig.RemoteConfigClient.Source.REMOTE
 import com.amplitude.core.utilities.http.HttpClient
 import com.amplitude.core.utilities.toJSONObject
 import com.amplitude.core.utilities.toMapObj
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -89,10 +90,19 @@ interface RemoteConfigClient {
     fun updateConfigs()
 
     fun interface RemoteConfigCallback {
+        /**
+         * @param config resolved config slice; null when the key is absent from a
+         *   successful fetch, or when the fetch failed.
+         * @param source whether [config] came from cache or remote.
+         * @param timestamp time of the successful fetch that produced [config];
+         *   null signals a failed fetch. This is the discriminator between an
+         *   absent-but-valid key (non-null timestamp, null config) and an error
+         *   (null timestamp, null config).
+         */
         fun onUpdate(
             config: ConfigMap?,
             source: Source,
-            timestamp: Long,
+            timestamp: Long?,
         )
     }
 }
@@ -127,80 +137,87 @@ internal class RemoteConfigClientImpl(
     }
 
     /**
-     * Wrapper class for weak reference callbacks to prevent memory leaks.
+     * Weak-reference wrapper around a subscriber callback to avoid leaks.
      *
-     * For [RemoteConfigClient.DeliveryMode.WaitForRemote] subscribers, the first
-     * delivery is gated by [firstDeliveryClaimed]: whichever path (remote arrival
-     * via [updateConfigs] or timeout fallback) claims the gate first delivers the
-     * initial callback; the other becomes a no-op for that first delivery.
-     * Subsequent deliveries always pass through.
+     * Each subscriber receives at most one *first* delivery (cache, remote, or a
+     * failure signal). [deliverFirst] claims that slot atomically so racing paths
+     * (remote arrival vs. timeout fallback) can't double-deliver the first
+     * callback. [deliver] always fires and is used for the immediate cache
+     * delivery and for ongoing [RemoteConfigClient.DeliveryMode.All] updates.
      */
     private inner class WeakCallback(
         callback: RemoteConfigClient.RemoteConfigCallback,
-        private val firstDeliveryClaimed: AtomicBoolean? = null,
-        private val firstDeliverySignal: CompletableDeferred<Unit>? = null,
+        val deliveryMode: RemoteConfigClient.DeliveryMode,
     ) {
         private val weakRef = WeakReference(callback)
 
         /**
-         * Serializes all [RemoteConfigClient.RemoteConfigCallback.onUpdate]
-         * invocations for this subscriber. Without this lock, the timeout
-         * fallback and the remote fetch can invoke the callback concurrently
-         * from different dispatchers, causing unsynchronized state in the
-         * subscriber.
+         * Serializes all callback invocations for this subscriber so concurrent
+         * paths (remote fetch, timeout fallback, refresh) can't deliver at once.
          */
         private val deliveryLock = Any()
+        private val delivered = AtomicBoolean(false)
 
         fun isAlive(): Boolean = weakRef.get() != null
 
-        /**
-         * Invoke [action] on the wrapped callback if it is still alive. When gating
-         * is in effect, the first invocation to reach [deliveryLock] claims the
-         * first-delivery slot and signals waiters; later invocations fall through and
-         * deliver as subsequent updates. Claiming inside the lock guarantees the
-         * first delivery completes before any subsequent one — without blocking a
-         * thread waiting on [firstDeliverySignal].
-         */
-        fun runSafely(action: RemoteConfigClient.RemoteConfigCallback.() -> Unit) {
+        fun hasDelivered(): Boolean = delivered.get()
+
+        /** Always deliver, marking this subscriber as having received a callback. */
+        fun deliver(
+            config: ConfigMap?,
+            source: RemoteConfigClient.Source,
+            timestamp: Long?,
+        ) {
             val callback = weakRef.get() ?: return
             synchronized(deliveryLock) {
-                if (firstDeliveryClaimed?.compareAndSet(false, true) == true) {
-                    firstDeliverySignal?.complete(Unit)
-                }
-                deliver(callback, action)
+                delivered.set(true)
+                invoke(callback, config, source, timestamp)
             }
         }
 
-        /** Deliver only if this callback can still claim the first-delivery slot. */
-        fun runSafelyIfFirst(action: RemoteConfigClient.RemoteConfigCallback.() -> Unit): Boolean {
+        /** Deliver only as the first callback. Returns whether it fired. */
+        fun deliverFirst(
+            config: ConfigMap?,
+            source: RemoteConfigClient.Source,
+            timestamp: Long?,
+        ): Boolean {
             val callback = weakRef.get() ?: return false
             synchronized(deliveryLock) {
-                val claimed = firstDeliveryClaimed?.compareAndSet(false, true) ?: return false
-                if (!claimed) return false
-                firstDeliverySignal?.complete(Unit)
-                deliver(callback, action)
+                if (!delivered.compareAndSet(false, true)) return false
+                invoke(callback, config, source, timestamp)
                 return true
             }
         }
 
-        private fun deliver(
+        private fun invoke(
             callback: RemoteConfigClient.RemoteConfigCallback,
-            action: RemoteConfigClient.RemoteConfigCallback.() -> Unit,
+            config: ConfigMap?,
+            source: RemoteConfigClient.Source,
+            timestamp: Long?,
         ) {
             try {
-                callback.action()
+                callback.onUpdate(config, source, timestamp)
             } catch (e: Exception) {
                 logger.error("Exception in subscriber callback: ${e.message}")
             }
         }
     }
 
+    /** Result of a remote fetch: a successful blob with its fetch time, or a failure. */
+    private sealed interface FetchOutcome {
+        data class Success(val blob: ConfigMap, val timestamp: Long) : FetchOutcome
+
+        data object Failure : FetchOutcome
+    }
+
     // Subscribers for specific config keys using weak references to prevent memory leaks
     private val subscriberLock = Any()
     private val keySpecificSubscribers = mutableMapOf<String, MutableList<WeakCallback>>()
 
-    // Safe without synchronization: all reads/writes happen on the single-threaded networkIODispatcher.
-    private var isFetching: Boolean = false
+    // Shared in-flight remote fetch so concurrent subscribers share a single network call.
+    private val fetchLock = Any()
+    private var inFlightFetch: Deferred<FetchOutcome>? = null
+    private var lastSuccess: FetchOutcome.Success? = null
 
     override fun subscribe(
         key: Key,
@@ -214,73 +231,78 @@ internal class RemoteConfigClientImpl(
         }
     }
 
+    /**
+     * Deliver cached config immediately if present, then the remote result when it
+     * arrives. A failure (null config, null timestamp) is delivered only when nothing
+     * else was — no cache and the fetch failed — guaranteeing exactly one initial
+     * callback. Mirrors iOS `.all`.
+     */
     private fun subscribeAll(
         key: Key,
         callback: RemoteConfigClient.RemoteConfigCallback,
     ) {
-        val weakCallback = WeakCallback(callback)
+        val weakCallback = WeakCallback(callback, RemoteConfigClient.DeliveryMode.All)
         registerSubscriber(key, weakCallback)
 
-        // Immediately deliver cached config only when the subscriber's key actually
-        // resolves in the cached blob. A null resolved config means "not in cache"
-        // — the upcoming REMOTE delivery will report the authoritative state.
-        val storedData = getStoredConfigData(key.value)
-        if (storedData?.config != null) {
-            weakCallback.runSafely {
-                onUpdate(storedData.config, CACHE, storedData.timestamp)
+        coroutineScope.launch {
+            val cached = withContext(storageIODispatcher) { getStoredConfigData(key.value) }
+            if (cached?.config != null) {
+                weakCallback.deliver(cached.config, CACHE, cached.timestamp)
+            }
+
+            when (val handle = obtainSubscribeFetch()) {
+                // A recent success is reused without a network call, so no broadcast
+                // fires — deliver it to this subscriber directly.
+                is FetchHandle.Reuse ->
+                    weakCallback.deliver(
+                        resolveDotPath(handle.success.blob, key.value),
+                        REMOTE,
+                        handle.success.timestamp,
+                    )
+                // A live fetch broadcasts its success to all subscribers (including
+                // us). Only the failure case needs handling here.
+                is FetchHandle.Pending ->
+                    if (handle.deferred.await() is FetchOutcome.Failure && !weakCallback.hasDelivered()) {
+                        weakCallback.deliver(null, REMOTE, null)
+                    }
             }
         }
-
-        // Trigger remote fetch to ensure latest config is available
-        updateConfigs()
     }
 
+    /**
+     * Wait for the remote fetch up to [timeoutMs]. On success deliver remote; on
+     * failure or timeout fall back to cache, or a failure signal (null config, null
+     * timestamp) when no cache exists. Exactly one callback is delivered. Mirrors
+     * iOS `.waitForRemote`.
+     */
     private fun subscribeWaitForRemote(
         key: Key,
         timeoutMs: Long,
         callback: RemoteConfigClient.RemoteConfigCallback,
     ) {
-        // Gate first delivery — timeout and remote race; first to claim wins.
-        val firstDeliveryClaimed = AtomicBoolean(false)
-        val firstDeliverySignal = CompletableDeferred<Unit>()
         val weakCallback =
-            WeakCallback(
-                callback = callback,
-                firstDeliveryClaimed = firstDeliveryClaimed,
-                firstDeliverySignal = firstDeliverySignal,
-            )
+            WeakCallback(callback, RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs))
         registerSubscriber(key, weakCallback)
 
-        updateConfigs()
-
-        // Timeout runs on coroutineScope's dispatcher (not networkIODispatcher)
-        // so it can fire even while the single-threaded network executor is busy.
         coroutineScope.launch {
-            val signaled =
-                withTimeoutOrNull(timeoutMs) {
-                    firstDeliverySignal.await()
-                    true
-                }
-            if (signaled == null) {
-                // Timeout: fall back to cache (or empty). runSafelyIfFirst
-                // suppresses this if a remote delivery already claimed the gate.
-                val storedData = getStoredConfigData(key.value)
-                val config = storedData?.config
-                val timestamp = storedData?.timestamp ?: System.currentTimeMillis()
-                val delivered =
-                    weakCallback.runSafelyIfFirst {
-                        onUpdate(config, CACHE, timestamp)
-                    }
-                if (delivered) {
-                    logger.debug(
-                        "WaitForRemote timed out after ${timeoutMs}ms for ${key.value}; " +
-                            "delivered ${if (storedData != null) "cache" else "empty"} fallback.",
+            when (val handle = obtainSubscribeFetch()) {
+                is FetchHandle.Reuse ->
+                    weakCallback.deliverFirst(
+                        resolveDotPath(handle.success.blob, key.value),
+                        REMOTE,
+                        handle.success.timestamp,
                     )
+                // On success the fetch's broadcast claims the first delivery. We only
+                // wait up to the timeout; if it elapses (or the fetch fails) we fall back.
+                is FetchHandle.Pending ->
+                    withTimeoutOrNull(timeoutMs) { handle.deferred.await() }
+            }
+            if (!weakCallback.hasDelivered()) {
+                val cached = withContext(storageIODispatcher) { getStoredConfigData(key.value) }
+                if (cached?.config != null) {
+                    weakCallback.deliverFirst(cached.config, CACHE, cached.timestamp)
                 } else {
-                    logger.debug(
-                        "WaitForRemote timeout fired after ${timeoutMs}ms for ${key.value}, " +
-                            "but a fresh remote delivery already won; fallback suppressed.",
-                    )
+                    weakCallback.deliverFirst(null, REMOTE, null)
                 }
             }
         }
@@ -305,88 +327,121 @@ internal class RemoteConfigClientImpl(
     }
 
     /**
-     * Trigger a remote fetch for all config keys
+     * Trigger a remote refresh. Rate-limited; on success, delivers the new config to
+     * existing subscribers ([RemoteConfigClient.DeliveryMode.All] always,
+     * [RemoteConfigClient.DeliveryMode.WaitForRemote] only if it hasn't received its
+     * first callback). Failures are never delivered from a refresh — subscribers keep
+     * their last valid config. Mirrors iOS `updateConfigs`.
      */
     override fun updateConfigs() {
         coroutineScope.launch(networkIODispatcher) {
-            if (isFetching) {
-                logger.debug("RemoteConfig update skipped: fetch already in progress")
+            if (shouldRateLimit()) {
+                logger.debug("RemoteConfig update skipped: within 5-minute window")
                 return@launch
             }
+            // A successful fetch broadcasts itself to all subscribers; nothing else to do.
+            startOrJoinFetch()
+        }
+    }
 
-            // Claim the in-flight slot synchronously, before the suspending
-            // shouldRateLimit() read. Otherwise a second coroutine queued on the
-            // single network dispatcher could pass the isFetching guard during the
-            // suspension and issue a duplicate fetch.
-            isFetching = true
-            try {
-                if (shouldRateLimit()) {
-                    logger.debug("RemoteConfig update skipped: within 5-minute window")
-                    return@launch
+    /** Delivers a freshly fetched config to all current subscribers as an update. */
+    private fun broadcastUpdate(
+        blob: ConfigMap,
+        timestamp: Long,
+    ) {
+        val subscriberSnapshot =
+            synchronized(subscriberLock) {
+                keySpecificSubscribers.map { (dotPath, subs) -> dotPath to subs.toList() }
+            }
+        for ((dotPath, subscribers) in subscriberSnapshot) {
+            val config = resolveDotPath(blob, dotPath)
+            subscribers.forEach { weakCallback ->
+                when (weakCallback.deliveryMode) {
+                    is RemoteConfigClient.DeliveryMode.All ->
+                        weakCallback.deliver(config, REMOTE, timestamp)
+                    is RemoteConfigClient.DeliveryMode.WaitForRemote ->
+                        weakCallback.deliverFirst(config, REMOTE, timestamp)
                 }
-
-                val blob = fetchRemoteConfig()
-                if (blob == null) {
-                    notifySubscribersOnFailure(System.currentTimeMillis())
-                    return@launch
-                }
-
-                val timestamp = System.currentTimeMillis()
-                withContext(storageIODispatcher) {
-                    storage.write(REMOTE_CONFIG, blob.toJSONObject().toString())
-                    storage.write(REMOTE_CONFIG_TIMESTAMP, timestamp.toString())
-                    logger.debug("Successfully stored remote configs to storage")
-                }
-
-                val subscriberSnapshot =
-                    synchronized(subscriberLock) {
-                        keySpecificSubscribers.map { (dotPath, subs) -> dotPath to subs.toList() }
-                    }
-                for ((dotPath, subscribers) in subscriberSnapshot) {
-                    val config = resolveDotPath(blob, dotPath)
-                    subscribers.forEach { weakCallback ->
-                        weakCallback.runSafely {
-                            onUpdate(config, REMOTE, timestamp)
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                logger.error("Error updating remote configs: ${e.message}")
-                notifySubscribersOnFailure(System.currentTimeMillis())
-            } finally {
-                isFetching = false
             }
         }
+    }
+
+    /** How a subscribe obtains its config: a reusable recent success, or a live fetch. */
+    private sealed interface FetchHandle {
+        data class Reuse(val success: FetchOutcome.Success) : FetchHandle
+
+        data class Pending(val deferred: Deferred<FetchOutcome>) : FetchHandle
     }
 
     /**
-     * Notifies all current subscribers with a null config and [Source.REMOTE] to signal
-     * a failed fetch. For a [DeliveryMode.WaitForRemote] subscriber that has not yet
-     * received its first delivery, [WeakCallback.runSafely] claims the first-delivery
-     * gate so this null REMOTE becomes its initial callback. If such a subscriber has
-     * already been served (e.g. by the timeout fallback), this null REMOTE is delivered
-     * as a subsequent update — it is not suppressed.
+     * Obtains config for an initial subscribe: joins an in-flight fetch, reuses a
+     * recent successful result to avoid hammering the server, or starts a new fetch.
+     * Never rate-limited — a subscribe must always resolve to a delivery.
      */
-    private fun notifySubscribersOnFailure(timestamp: Long) {
-        val subscriberSnapshot =
-            synchronized(subscriberLock) {
-                keySpecificSubscribers.map { (_, subs) -> subs.toList() }
-            }
-        for (subscribers in subscriberSnapshot) {
-            subscribers.forEach { weakCallback ->
-                weakCallback.runSafely {
-                    onUpdate(null, REMOTE, timestamp)
-                }
-            }
+    private fun obtainSubscribeFetch(): FetchHandle {
+        synchronized(fetchLock) {
+            inFlightFetch?.let { if (it.isActive) return FetchHandle.Pending(it) }
+            lastSuccess?.let { if (isFresh(it.timestamp)) return FetchHandle.Reuse(it) }
+            return FetchHandle.Pending(startFetchLocked())
         }
     }
 
+    /** Joins an in-flight fetch or starts a new one. Used by the refresh path. */
+    private fun startOrJoinFetch(): Deferred<FetchOutcome> {
+        synchronized(fetchLock) {
+            inFlightFetch?.let { if (it.isActive) return it }
+            return startFetchLocked()
+        }
+    }
+
+    private fun startFetchLocked(): Deferred<FetchOutcome> {
+        val deferred =
+            coroutineScope.async(networkIODispatcher) {
+                val outcome = performFetch()
+                if (outcome is FetchOutcome.Success) {
+                    synchronized(fetchLock) { lastSuccess = outcome }
+                    // A single broadcast per successful fetch delivers to every current
+                    // subscriber — avoids each awaiter delivering its own duplicate.
+                    broadcastUpdate(outcome.blob, outcome.timestamp)
+                }
+                outcome
+            }
+        inFlightFetch = deferred
+        return deferred
+    }
+
+    private suspend fun performFetch(): FetchOutcome {
+        return try {
+            val blob = fetchRemoteConfig() ?: return FetchOutcome.Failure
+            val timestamp = System.currentTimeMillis()
+            withContext(storageIODispatcher) {
+                storage.write(REMOTE_CONFIG, blob.toJSONObject().toString())
+                storage.write(REMOTE_CONFIG_TIMESTAMP, timestamp.toString())
+                logger.debug("Successfully stored remote configs to storage")
+            }
+            FetchOutcome.Success(blob, timestamp)
+        } catch (e: Exception) {
+            logger.error("Error updating remote configs: ${e.message}")
+            FetchOutcome.Failure
+        }
+    }
+
+    private fun isFresh(timestamp: Long): Boolean {
+        return timestamp > 0L && (System.currentTimeMillis() - timestamp) < MIN_FETCH_INTERVAL_MS
+    }
+
     private suspend fun shouldRateLimit(): Boolean {
-        val lastTsStr = withContext(storageIODispatcher) { storage.read(REMOTE_CONFIG_TIMESTAMP) }
-        val lastTs = lastTsStr?.toLongOrNull() ?: 0L
-        if (lastTs <= 0L) return false
-        val now = System.currentTimeMillis()
-        return (now - lastTs) < MIN_FETCH_INTERVAL_MS
+        return try {
+            val lastTsStr = withContext(storageIODispatcher) { storage.read(REMOTE_CONFIG_TIMESTAMP) }
+            val lastTs = lastTsStr?.toLongOrNull() ?: 0L
+            if (lastTs <= 0L) return false
+            (System.currentTimeMillis() - lastTs) < MIN_FETCH_INTERVAL_MS
+        } catch (e: Exception) {
+            // Don't let a storage read failure leak out of the refresh coroutine or
+            // wedge the rate limiter — fall through and let the fetch proceed.
+            logger.error("Failed to read rate-limit timestamp: ${e.message}")
+            false
+        }
     }
 
     /**

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Type alias for remote configuration map data.
- * Represents flattened config key-value pairs where keys are strings and values can be any type.
+ * Represents config key-value pairs where keys are strings and values can be any type.
  */
 typealias ConfigMap = Map<String, Any>
 
@@ -52,11 +52,35 @@ interface RemoteConfigClient {
         class WaitForRemote(val timeoutMs: Long) : DeliveryMode()
     }
 
-    enum class Key(val value: String) {
-        ANALYTICS_SDK("analyticsSDK.androidSDK"),
-        DIAGNOSTICS("diagnostics.androidSDK"),
-        SESSION_REPLAY_PRIVACY_CONFIG("sessionReplay.sr_android_privacy_config"),
-        SESSION_REPLAY_SAMPLING_CONFIG("sessionReplay.sr_android_sampling_config"),
+    /**
+     * Dot-path key for subscribing to remote config sections.
+     * Split by "." to walk nested config objects. For example,
+     * "sessionReplay.sr_android_privacy_config" resolves configs.sessionReplay.sr_android_privacy_config.
+     */
+    sealed class Key(open val value: String) {
+        data object AnalyticsSdk : Key("analyticsSDK.androidSDK")
+
+        data object Diagnostics : Key("diagnostics.androidSDK")
+
+        data object SessionReplayPrivacyConfig : Key("sessionReplay.sr_android_privacy_config")
+
+        data object SessionReplaySamplingConfig : Key("sessionReplay.sr_android_sampling_config")
+
+        class Custom(override val value: String) : Key(value) {
+            override fun equals(other: Any?): Boolean = other is Custom && other.value == value
+
+            override fun hashCode(): Int = value.hashCode()
+
+            override fun toString(): String = "Custom(value=$value)"
+        }
+
+        companion object {
+            internal val fetchKeys: List<String> by lazy {
+                listOf(AnalyticsSdk, Diagnostics, SessionReplayPrivacyConfig, SessionReplaySamplingConfig)
+                    .map { it.value.substringBefore(".") }
+                    .distinct()
+            }
+        }
     }
 
     /**
@@ -187,20 +211,22 @@ internal class RemoteConfigClientImpl(
             }
             return true
         }
-
-        /** True if gated (WaitForRemote) and first delivery hasn't fired yet. */
-        fun isAwaitingFirstDelivery(): Boolean {
-            val claimed = firstDeliveryClaimed ?: return false
-            return !claimed.get()
-        }
     }
 
     // Subscribers for specific config keys using weak references to prevent memory leaks
     private val subscriberLock = Any()
     private val keySpecificSubscribers = mutableMapOf<String, MutableList<WeakCallback>>()
 
-    // Simple in-flight fetch guard; safe because networkIODispatcher is single-threaded
+    // Additional root keys registered by Custom key subscribers, unioned with fetchKeys for the URL.
+    private val customFetchRoots = mutableSetOf<String>()
+
+    @Volatile
     private var isFetching: Boolean = false
+
+    // Set when customFetchRoots grows — bypasses rate limit on next fetch so
+    // newly registered custom roots get fetched promptly, not after 5 minutes.
+    @Volatile
+    private var fetchRootsExpanded: Boolean = false
 
     override fun subscribe(
         key: Key,
@@ -297,6 +323,14 @@ internal class RemoteConfigClientImpl(
                         mutableListOf()
                     }
                 subscriberList.add(weakCallback)
+
+                if (key is Key.Custom) {
+                    val root = key.value.substringBefore(".")
+                    if (root.isNotEmpty() && root !in Key.fetchKeys && customFetchRoots.add(root)) {
+                        fetchRootsExpanded = true
+                    }
+                }
+
                 subscriberList.size
             }
 
@@ -308,92 +342,49 @@ internal class RemoteConfigClientImpl(
      */
     override fun updateConfigs() {
         coroutineScope.launch(networkIODispatcher) {
+            if (isFetching) {
+                logger.debug("RemoteConfig update skipped: fetch already in progress")
+                return@launch
+            }
+
+            val bypassRateLimit = fetchRootsExpanded
+            if (bypassRateLimit) fetchRootsExpanded = false
+
+            if (!bypassRateLimit && shouldRateLimit()) {
+                logger.debug("RemoteConfig update skipped: within 5-minute window")
+                return@launch
+            }
+
+            isFetching = true
             try {
-                if (isFetching) {
-                    logger.debug("RemoteConfig update skipped: fetch already in progress")
-                    return@launch
-                }
-
-                if (shouldRateLimit()) {
-                    logger.debug("RemoteConfig update skipped: within 5-minute window")
-                    return@launch
-                }
-
-                isFetching = true
-                val configs = fetchRemoteConfig() ?: return@launch
-
-                // Snapshot old cache before overwriting — absent-key fallback
-                // needs the pre-fetch values, not the partial new response.
-                val preFetchCache = getAllStoredConfigs()
+                val blob = fetchRemoteConfig() ?: return@launch
 
                 val timestamp = System.currentTimeMillis()
                 withContext(storageIODispatcher) {
-                    storage.write(REMOTE_CONFIG, configs.toJSONObject().toString())
+                    storage.write(REMOTE_CONFIG, blob.toJSONObject().toString())
                     storage.write(REMOTE_CONFIG_TIMESTAMP, timestamp.toString())
                     logger.debug("Successfully stored remote configs to storage")
                 }
 
-                configs.forEach { (configKey, config) ->
-                    val subscriberList =
-                        synchronized(subscriberLock) {
-                            keySpecificSubscribers[configKey]?.toList().orEmpty()
-                        }
-                    subscriberList.forEach { weakCallback ->
+                val subscriberSnapshot =
+                    synchronized(subscriberLock) {
+                        keySpecificSubscribers.map { (dotPath, subs) -> dotPath to subs.toList() }
+                    }
+                for ((dotPath, subscribers) in subscriberSnapshot) {
+                    val resolved = resolveDotPath(blob, dotPath)
+                    val config = resolved ?: emptyMap()
+                    subscribers.forEach { weakCallback ->
                         weakCallback.runSafely {
                             onUpdate(config, REMOTE, timestamp)
                         }
                     }
                 }
-
-                // Unblock WaitForRemote subscribers whose key is absent from
-                // a successful fetch — no point waiting the full timeout.
-                notifyAbsentKeySubscribers(presentKeys = configs.keys, preFetchCache = preFetchCache)
             } catch (e: Exception) {
                 logger.error("Error updating remote configs: ${e.message}")
             } finally {
                 isFetching = false
-            }
-        }
-    }
-
-    /**
-     * For each registered subscriber whose key is *not* present in a fresh
-     * successful fetch, deliver the fallback (cache or empty) via the
-     * first-only delivery path so [RemoteConfigClient.DeliveryMode.WaitForRemote]
-     * gates resolve immediately instead of waiting for the timeout.
-     *
-     * Uses [WeakCallback.runSafelyIfFirst]: if a subscriber has already
-     * received its first delivery (e.g. timeout already fired), the call is a
-     * no-op. Subscribers using [RemoteConfigClient.DeliveryMode.All] also
-     * become no-ops because they aren't gated and cannot claim the gate.
-     */
-    private fun notifyAbsentKeySubscribers(
-        presentKeys: Set<String>,
-        preFetchCache: Map<String, ConfigMap>,
-    ) {
-        val absentSubscribers =
-            synchronized(subscriberLock) {
-                keySpecificSubscribers
-                    .filterKeys { it !in presentKeys }
-                    .mapValues { (_, subs) -> subs.toList() }
-            }
-        if (absentSubscribers.isEmpty()) return
-
-        absentSubscribers.forEach { (configKey, subscribers) ->
-            val cachedConfig = preFetchCache[configKey]
-            subscribers.forEach subscriber@{ weakCallback ->
-                if (!weakCallback.isAwaitingFirstDelivery()) return@subscriber
-                val config = cachedConfig ?: emptyMap()
-                val timestamp = System.currentTimeMillis()
-                val delivered =
-                    weakCallback.runSafelyIfFirst {
-                        onUpdate(config, CACHE, timestamp)
-                    }
-                if (delivered) {
-                    logger.debug(
-                        "WaitForRemote unblocked for $configKey: key absent from fetch; " +
-                            "delivered ${if (cachedConfig != null) "cache" else "empty"} fallback.",
-                    )
+                if (fetchRootsExpanded) {
+                    updateConfigs()
                 }
             }
         }
@@ -408,95 +399,104 @@ internal class RemoteConfigClientImpl(
     }
 
     /**
-     * Retrieve stored configuration data for a specific key.
-     * This method checks if the storage has consistent data for all expected keys.
+     * Retrieve stored configuration data for a specific dot-path key.
+     * Walks the stored nested blob using dot-path segments.
      */
-    private fun getStoredConfigData(configKey: String): ConfigData? {
+    private fun getStoredConfigData(dotPath: String): ConfigData? {
         return try {
-            val allStoredConfigs = getAllStoredConfigs()
+            val blob = getStoredConfigBlob() ?: return null
 
-            // If storage is completely empty, return empty config
-            if (allStoredConfigs.isEmpty()) {
-                return null
-            }
-
-            // Check if storage has consistent data for all expected keys
-            val expectedKeys = Key.entries.map { it.value }.toSet()
-            val storedKeys = allStoredConfigs.keys
-            if (!storedKeys.containsAll(expectedKeys)) {
-                logger.debug(
-                    "Storage inconsistent keys. Expected: $expectedKeys, Found: $storedKeys",
-                )
-                // Middle ground: invalidate only if none of the expected keys exist (hard inconsistency)
-                val hasAnyExpected = storedKeys.any { it in expectedKeys }
-                if (!hasAnyExpected) {
-                    coroutineScope.launch(storageIODispatcher) {
-                        try {
-                            storage.remove(REMOTE_CONFIG)
-                            storage.remove(REMOTE_CONFIG_TIMESTAMP)
-                            logger.debug("Cleared storage due to hard inconsistency (no expected keys present)")
-                        } catch (e: Exception) {
-                            logger.error("Failed to clear inconsistent storage: ${e.message}")
-                        }
-                    }
-                    return null
-                }
-                // If at least one expected key exists, keep partial data and proceed.
-            }
-
-            val configData = allStoredConfigs[configKey] ?: emptyMap()
+            val resolved = resolveDotPath(blob, dotPath) ?: emptyMap()
             val timestampStr = storage.read(REMOTE_CONFIG_TIMESTAMP)
             val timestamp = timestampStr?.toLongOrNull() ?: 0L
 
-            logger.debug("Retrieved stored config for $configKey with ${configData.size} properties")
-            ConfigData(configData, timestamp)
+            logger.debug("Retrieved stored config for $dotPath with ${resolved.size} properties")
+            ConfigData(resolved, timestamp)
         } catch (e: Exception) {
-            logger.error("Failed to retrieve stored config data for $configKey: ${e.message}")
+            logger.error("Failed to retrieve stored config data for $dotPath: ${e.message}")
             null
         }
     }
 
-    private fun getAllStoredConfigs(): Map<String, ConfigMap> {
+    /**
+     * Reads the stored config blob from storage. Returns the nested map
+     * structure or null if storage is empty/corrupt. Gracefully handles
+     * old pre-flattened storage format by treating it as a cache miss.
+     */
+    private fun getStoredConfigBlob(): ConfigMap? {
         return try {
             val configJson = storage.read(REMOTE_CONFIG)
             if (configJson.isNullOrBlank()) {
                 logger.debug("No stored config found in storage")
-                return emptyMap()
+                return null
             }
 
-            val allConfigs = JSONObject(configJson).toMapObj()
+            val allConfigs = JSONObject(configJson).toMapObj().filterNotNullValues()
+            if (allConfigs.isEmpty()) return null
 
-            // Parse each stored config and build the result map
-            buildMap {
-                for ((key, value) in allConfigs) {
-                    when (value) {
-                        is Map<*, *> -> {
-                            @Suppress("UNCHECKED_CAST")
-                            val configMap =
-                                (value as? ConfigMap)?.filterNotNullValues() ?: emptyMap()
-                            if (configMap.isNotEmpty()) {
-                                put(key, configMap)
-                                logger.debug("Successfully loaded stored config for key: $key")
-                            }
-                        }
-
-                        else -> {
-                            logger.debug(
-                                "Skipping non-map value for key $key: ${value?.javaClass?.simpleName}",
-                            )
-                        }
+            // Detect old pre-flattened format: keys contain dots (e.g. "sessionReplay.sr_android_privacy_config").
+            // New format has top-level keys without dots (e.g. "sessionReplay", "diagnostics").
+            val isOldFormat = allConfigs.keys.any { "." in it }
+            if (isOldFormat) {
+                logger.debug("Detected old pre-flattened cache format; migrating in place")
+                val migrated = migrateOldFormatToNested(allConfigs)
+                coroutineScope.launch(storageIODispatcher) {
+                    try {
+                        storage.write(REMOTE_CONFIG, migrated.toJSONObject().toString())
+                        logger.debug("Migrated old-format cache to nested format")
+                    } catch (e: Exception) {
+                        logger.error("Failed to write migrated cache: ${e.message}")
                     }
                 }
-            }.also {
-                logger.debug("Successfully loaded ${it.size} stored configs from storage")
+                return migrated
             }
+
+            logger.debug("Successfully loaded stored config blob with ${allConfigs.size} top-level keys")
+            allConfigs
         } catch (e: Exception) {
             logger.error("Failed to parse all stored configs: ${e.message}")
-            emptyMap()
+            null
         }
     }
 
-    private fun fetchRemoteConfig(): Map<String, ConfigMap>? {
+    // Temporary: old cache only stored single-dot keys (e.g. "sessionReplay.sr_android_privacy_config").
+    @Suppress("UNCHECKED_CAST")
+    private fun migrateOldFormatToNested(flat: ConfigMap): ConfigMap {
+        val result = mutableMapOf<String, Any>()
+        for ((key, value) in flat) {
+            val dotIndex = key.indexOf('.')
+            if (dotIndex < 0) {
+                result[key] = value
+                continue
+            }
+            val root = key.substring(0, dotIndex)
+            val child = key.substring(dotIndex + 1)
+            val existing = result[root] as? MutableMap<String, Any> ?: mutableMapOf()
+            existing[child] = value
+            result[root] = existing
+        }
+        return result
+    }
+
+    /**
+     * Walk a dot-path into a nested config blob and return the leaf as a [ConfigMap].
+     * Returns null if any segment is missing or non-map.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun resolveDotPath(
+        blob: ConfigMap,
+        dotPath: String,
+    ): ConfigMap? {
+        val segments = dotPath.split(".")
+        var current: Any? = blob
+        for (segment in segments) {
+            val map = current as? Map<String, Any> ?: return null
+            current = map[segment] ?: return null
+        }
+        return current as? Map<String, Any>
+    }
+
+    private fun fetchRemoteConfig(): ConfigMap? {
         // Periodic cleanup of dead references during network operations
         cleanupDeadReferences()
 
@@ -538,27 +538,34 @@ internal class RemoteConfigClientImpl(
 
     private fun cleanupDeadReferencesLocked() {
         var totalCleaned = 0
-        var emptyListCount = 0
         val iterator = keySpecificSubscribers.iterator()
 
         while (iterator.hasNext()) {
             val (_, subscriberList) = iterator.next()
             val initialSize = subscriberList.size
             subscriberList.removeAll { !it.isAlive() }
-            val removedCount = initialSize - subscriberList.size
-            totalCleaned += removedCount
+            totalCleaned += initialSize - subscriberList.size
 
             if (subscriberList.isEmpty()) {
                 iterator.remove()
-                emptyListCount++
             }
         }
 
         if (totalCleaned > 0) {
-            logger.debug(
-                "Removed $totalCleaned dead references and $emptyListCount empty lists",
-            )
+            logger.debug("Cleaned up $totalCleaned dead references")
+            recomputeCustomFetchRootsLocked()
         }
+    }
+
+    private fun recomputeCustomFetchRootsLocked() {
+        val liveRoots = mutableSetOf<String>()
+        for (dotPath in keySpecificSubscribers.keys) {
+            val root = dotPath.substringBefore(".")
+            if (root.isNotEmpty() && root !in Key.fetchKeys) {
+                liveRoots.add(root)
+            }
+        }
+        customFetchRoots.retainAll(liveRoots)
     }
 
     private fun buildRemoteConfigUrl(): String {
@@ -568,8 +575,10 @@ internal class RemoteConfigClientImpl(
                 else -> US_REMOTE_CONFIG_URL
             }
 
-        // Request all config keys
-        val configKeysParam = Key.entries.joinToString("&") { "config_keys=${it.value}" }
+        val customRoots = synchronized(subscriberLock) { customFetchRoots.toSet() }
+        val allKeys = Key.fetchKeys.toSet() + customRoots
+        val configKeysParam =
+            allKeys.joinToString("&") { "config_keys=$it" }
         return "$baseUrl/config?api_key=$apiKey&$configKeysParam"
     }
 
@@ -582,62 +591,34 @@ internal class RemoteConfigClientImpl(
         )
     }
 
-    private fun parseConfigsFromResponse(responseBody: String?): Map<String, ConfigMap>? {
+    /**
+     * Parses the API response and returns the full nested config blob (the
+     * contents of the "configs" key). The blob is stored as-is — no flattening.
+     */
+    private fun parseConfigsFromResponse(responseBody: String?): ConfigMap? {
         return responseBody?.let { body ->
             try {
                 val responseJson = JSONObject(body)
 
-                // Handle configs-wrapped response format:
-                // Format: {"configs": {"sessionReplay": {...}}}
                 val configsRoot = responseJson.optJSONObject("configs")
                 if (configsRoot == null) {
                     logger.warn("No 'configs' key found in response")
                     return null
                 }
 
-                val result =
-                    buildMap {
-                        // Dynamically parse all top-level config objects
-                        for (topLevelKey in configsRoot.keys()) {
-                            val topLevelObj = configsRoot.optJSONObject(topLevelKey)
-                            if (topLevelObj != null) {
-                                // Parse each nested config within this top-level object
-                                for (nestedKey in topLevelObj.keys()) {
-                                    val flattenedKey = "$topLevelKey.$nestedKey"
-                                    val nestedConfig = topLevelObj.optJSONObject(nestedKey)
-
-                                    if (nestedConfig != null) {
-                                        put(flattenedKey, nestedConfig.toMapObj().filterNotNullValues())
-                                        logger.debug("Successfully parsed config: $flattenedKey")
-                                    } else {
-                                        logger.debug(
-                                            "Config $flattenedKey has no nested object, using empty map",
-                                        )
-                                        put(flattenedKey, emptyMap())
-                                    }
-                                }
-                            } else {
-                                logger.debug("Skipping non-object top-level key: $topLevelKey")
-                            }
-                        }
-                    }
-
-                if (result.isEmpty() && configsRoot.length() == 0) {
-                    // The "configs" root is present but empty — project has no
-                    // blades enabled. This is a valid server answer; return an
-                    // empty map so that downstream logic (notifyAbsentKeySubscribers)
-                    // can unblock WaitForRemote subscribers immediately.
+                if (configsRoot.length() == 0) {
                     logger.debug("Server returned empty configs — project may have no blades enabled")
                     return emptyMap()
                 }
 
-                if (result.isEmpty() || result.values.all { it.isEmpty() }) {
+                val blob = configsRoot.toMapObj().filterNotNullValues()
+                if (blob.isEmpty()) {
                     logger.warn("No valid configs found in response")
                     return null
                 }
 
-                logger.debug("Successfully parsed ${result.size} config entries")
-                result
+                logger.debug("Successfully parsed config blob with ${blob.size} top-level keys")
+                blob
             } catch (e: Exception) {
                 logger.error("Failed to parse configs from response: ${e.message}")
                 null

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -73,14 +73,6 @@ interface RemoteConfigClient {
 
             override fun toString(): String = "Custom(value=$value)"
         }
-
-        companion object {
-            internal val fetchKeys: List<String> by lazy {
-                listOf(AnalyticsSdk, Diagnostics, SessionReplayPrivacyConfig, SessionReplaySamplingConfig)
-                    .map { it.value.substringBefore(".") }
-                    .distinct()
-            }
-        }
     }
 
     /**
@@ -127,9 +119,9 @@ internal class RemoteConfigClientImpl(
     )
 
     companion object {
-        // Remote config endpoints based on server zone
         private const val US_REMOTE_CONFIG_URL = "https://sr-client-cfg.amplitude.com"
         private const val EU_REMOTE_CONFIG_URL = "https://sr-client-cfg.eu.amplitude.com"
+        private const val CONFIG_GROUP = "android"
         private const val MIN_FETCH_INTERVAL_MS: Long = 5 * 60 * 1_000L
     }
 
@@ -217,16 +209,8 @@ internal class RemoteConfigClientImpl(
     private val subscriberLock = Any()
     private val keySpecificSubscribers = mutableMapOf<String, MutableList<WeakCallback>>()
 
-    // Additional root keys registered by Custom key subscribers, unioned with fetchKeys for the URL.
-    private val customFetchRoots = mutableSetOf<String>()
-
     @Volatile
     private var isFetching: Boolean = false
-
-    // Set when customFetchRoots grows — bypasses rate limit on next fetch so
-    // newly registered custom roots get fetched promptly, not after 5 minutes.
-    @Volatile
-    private var fetchRootsExpanded: Boolean = false
 
     override fun subscribe(
         key: Key,
@@ -323,14 +307,6 @@ internal class RemoteConfigClientImpl(
                         mutableListOf()
                     }
                 subscriberList.add(weakCallback)
-
-                if (key is Key.Custom) {
-                    val root = key.value.substringBefore(".")
-                    if (root.isNotEmpty() && root !in Key.fetchKeys && customFetchRoots.add(root)) {
-                        fetchRootsExpanded = true
-                    }
-                }
-
                 subscriberList.size
             }
 
@@ -347,10 +323,7 @@ internal class RemoteConfigClientImpl(
                 return@launch
             }
 
-            val bypassRateLimit = fetchRootsExpanded
-            if (bypassRateLimit) fetchRootsExpanded = false
-
-            if (!bypassRateLimit && shouldRateLimit()) {
+            if (shouldRateLimit()) {
                 logger.debug("RemoteConfig update skipped: within 5-minute window")
                 return@launch
             }
@@ -383,9 +356,6 @@ internal class RemoteConfigClientImpl(
                 logger.error("Error updating remote configs: ${e.message}")
             } finally {
                 isFetching = false
-                if (fetchRootsExpanded) {
-                    updateConfigs()
-                }
             }
         }
     }
@@ -553,19 +523,7 @@ internal class RemoteConfigClientImpl(
 
         if (totalCleaned > 0) {
             logger.debug("Cleaned up $totalCleaned dead references")
-            recomputeCustomFetchRootsLocked()
         }
-    }
-
-    private fun recomputeCustomFetchRootsLocked() {
-        val liveRoots = mutableSetOf<String>()
-        for (dotPath in keySpecificSubscribers.keys) {
-            val root = dotPath.substringBefore(".")
-            if (root.isNotEmpty() && root !in Key.fetchKeys) {
-                liveRoots.add(root)
-            }
-        }
-        customFetchRoots.retainAll(liveRoots)
     }
 
     private fun buildRemoteConfigUrl(): String {
@@ -574,12 +532,7 @@ internal class RemoteConfigClientImpl(
                 ServerZone.EU -> EU_REMOTE_CONFIG_URL
                 else -> US_REMOTE_CONFIG_URL
             }
-
-        val customRoots = synchronized(subscriberLock) { customFetchRoots.toSet() }
-        val allKeys = Key.fetchKeys.toSet() + customRoots
-        val configKeysParam =
-            allKeys.joinToString("&") { "config_keys=$it" }
-        return "$baseUrl/config?api_key=$apiKey&$configKeysParam"
+        return "$baseUrl/config?api_key=$apiKey&config_group=$CONFIG_GROUP"
     }
 
     private fun buildRequestHeaders(apiVersion: Int = 2): Map<String, String> {

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -415,9 +415,12 @@ internal class RemoteConfigClientImpl(
 
     /**
      * Reads the stored config blob from storage. Returns the nested map
-     * structure or null if storage is empty/corrupt. Discards stale
-     * old pre-flattened format blobs so the in-flight remote fetch can
-     * refill storage with the correct nested format.
+     * structure or null if storage is empty/corrupt. Stale old pre-flattened
+     * format blobs are ignored (treated as a cache miss) so the in-flight
+     * remote fetch refills storage with the correct nested format. The stale
+     * blob is left untouched here — clearing it from the read path could race
+     * with the fetch's write and erase a freshly stored blob; a successful
+     * fetch overwrites it, and until then it is simply never delivered.
      */
     private fun getStoredConfigBlob(): ConfigMap? {
         return try {
@@ -434,10 +437,7 @@ internal class RemoteConfigClientImpl(
             // New format has top-level keys without dots (e.g. "sessionReplay", "diagnostics").
             val isOldFormat = allConfigs.keys.any { "." in it }
             if (isOldFormat) {
-                logger.debug("Detected old pre-flattened cache format; discarding stale blob")
-                coroutineScope.launch(storageIODispatcher) {
-                    storage.write(REMOTE_CONFIG, "")
-                }
+                logger.debug("Detected old pre-flattened cache format; ignoring stale blob")
                 return null
             }
 

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -1,8 +1,11 @@
+@file:OptIn(RestrictedAmplitudeFeature::class)
+
 package com.amplitude.core.remoteconfig
 
 import com.amplitude.common.Logger
 import com.amplitude.core.Constants.SDK_LIBRARY
 import com.amplitude.core.Constants.SDK_VERSION
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.ServerZone
 import com.amplitude.core.Storage
 import com.amplitude.core.Storage.Constants.REMOTE_CONFIG
@@ -34,7 +37,9 @@ typealias ConfigMap = Map<String, Any>
 /**
  * Interface for remote configuration client.
  */
+@RestrictedAmplitudeFeature
 interface RemoteConfigClient {
+    @RestrictedAmplitudeFeature
     enum class Source {
         CACHE,
         REMOTE,
@@ -46,6 +51,7 @@ interface RemoteConfigClient {
      * Subsequent updates after the first delivery always flow through normally.
      * Only the *initial* delivery semantics differ between modes.
      */
+    @RestrictedAmplitudeFeature
     sealed class DeliveryMode {
         /** Deliver cached config immediately if available, then remote when it arrives. */
         data object All : DeliveryMode()
@@ -60,6 +66,7 @@ interface RemoteConfigClient {
      * "sessionReplay.sr_android_privacy_config" resolves the nested map at
      * configs.sessionReplay.sr_android_privacy_config.
      */
+    @RestrictedAmplitudeFeature
     sealed class Key(val value: String) {
         data object AnalyticsSdk : Key("analyticsSDK.androidSDK")
 
@@ -90,6 +97,7 @@ interface RemoteConfigClient {
 
     fun updateConfigs()
 
+    @RestrictedAmplitudeFeature
     fun interface RemoteConfigCallback {
         /**
          * @param config resolved config slice; null when the key is absent from a
@@ -707,6 +715,7 @@ internal class RemoteConfigClientImpl(
  * Safely extracts a String value from the config map with a default fallback.
  * These functions provide type-safe access with defaults and never crash.
  */
+@RestrictedAmplitudeFeature
 fun ConfigMap.getString(
     key: String,
     default: String = "",
@@ -717,6 +726,7 @@ fun ConfigMap.getString(
 /**
  * Safely extracts a Boolean value from the config map with a default fallback.
  */
+@RestrictedAmplitudeFeature
 fun ConfigMap.getBoolean(
     key: String,
     default: Boolean = false,
@@ -727,6 +737,7 @@ fun ConfigMap.getBoolean(
 /**
  * Safely extracts a Double value from the config map with a default fallback.
  */
+@RestrictedAmplitudeFeature
 fun ConfigMap.getDouble(
     key: String,
     default: Double = 0.0,
@@ -742,6 +753,7 @@ fun ConfigMap.getDouble(
 /**
  * Safely extracts an Int value from the config map with a default fallback.
  */
+@RestrictedAmplitudeFeature
 fun ConfigMap.getInt(
     key: String,
     default: Int = 0,
@@ -757,6 +769,7 @@ fun ConfigMap.getInt(
 /**
  * Safely extracts a List<String> value from the config map with a default fallback.
  */
+@RestrictedAmplitudeFeature
 fun ConfigMap.getStringList(
     key: String,
     default: List<String> = emptyList(),

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -372,8 +372,11 @@ internal class RemoteConfigClientImpl(
 
     /**
      * Notifies all current subscribers with a null config and [Source.REMOTE] to signal
-     * a failed fetch. The [WeakCallback.runSafely] gate prevents double-delivery for
-     * [DeliveryMode.WaitForRemote] subscribers that have already received a timeout fallback.
+     * a failed fetch. For a [DeliveryMode.WaitForRemote] subscriber that has not yet
+     * received its first delivery, [WeakCallback.runSafely] claims the first-delivery
+     * gate so this null REMOTE becomes its initial callback. If such a subscriber has
+     * already been served (e.g. by the timeout fallback), this null REMOTE is delivered
+     * as a subsequent update — it is not suppressed.
      */
     private fun notifySubscribersOnFailure(timestamp: Long) {
         val subscriberSnapshot =

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -46,17 +46,20 @@ interface RemoteConfigClient {
     }
 
     /**
-     * Controls when the first config is delivered to a subscriber.
-     *
-     * Subsequent updates after the first delivery always flow through normally.
-     * Only the *initial* delivery semantics differ between modes.
+     * Controls how a subscriber's *initial* callback is delivered. After that initial
+     * callback every subscriber — regardless of mode — receives each subsequent
+     * successful fetch as an update, so callers always see the latest available config.
      */
     @RestrictedAmplitudeFeature
     sealed class DeliveryMode {
-        /** Deliver cached config immediately if available, then remote when it arrives. */
+        /** Deliver cached config immediately (if present), then remote, and every subsequent successful fetch. */
         data object All : DeliveryMode()
 
-        /** Wait for remote up to [timeoutMs], then fall back to cache (or empty). */
+        /**
+         * Block the initial delivery on the remote up to [timeoutMs] — then fall back to
+         * cache, else a failure signal. Subsequent successful fetches are delivered as
+         * updates, the same as [All].
+         */
         class WaitForRemote(val timeoutMs: Long) : DeliveryMode() {
             override fun equals(other: Any?): Boolean = other is WaitForRemote && other.timeoutMs == timeoutMs
 
@@ -156,9 +159,10 @@ internal class RemoteConfigClientImpl(
      *
      * Deliveries for a subscriber are serialized by [deliveryLock]. Remote deliveries
      * are de-duplicated by [lastFetchId] so the same fetch is never delivered twice —
-     * e.g. a subscribe's own self-delivery and a concurrent refresh broadcast carry the
-     * same id, so only the first one fires. For [RemoteConfigClient.DeliveryMode.WaitForRemote],
-     * [deliverFirst] enforces a single initial delivery (one-and-done).
+     * e.g. a subscribe's own self-delivery and a concurrent broadcast carry the same id,
+     * so only the first one fires. [deliverFirst] handles the single initial fallback
+     * (cache or failure) when no remote is available yet; later successful fetches still
+     * flow through [deliverRemote] for every subscriber.
      */
     private inner class WeakCallback(
         callback: RemoteConfigClient.RemoteConfigCallback,
@@ -210,9 +214,11 @@ internal class RemoteConfigClientImpl(
         }
 
         /**
-         * Single initial delivery for [RemoteConfigClient.DeliveryMode.WaitForRemote]:
-         * the first caller to claim the slot delivers; all others (timeout fallback,
-         * a late remote, a refresh) are no-ops. Returns whether it fired.
+         * Single initial *fallback* delivery (cache fallback or failure signal) used
+         * when no remote has arrived yet. The first caller to claim the slot delivers;
+         * a competing fallback is a no-op. This does NOT block later [deliverRemote]
+         * calls — a subsequent successful fetch still updates the subscriber. Returns
+         * whether it fired.
          */
         fun deliverFirst(
             config: ConfigMap?,
@@ -319,10 +325,11 @@ internal class RemoteConfigClientImpl(
     }
 
     /**
-     * Wait for the remote fetch up to [timeoutMs]. On success deliver remote; on
-     * failure or timeout fall back to cache, or a failure signal (null config, null
-     * timestamp) when no cache exists. Exactly one callback is delivered. Mirrors
-     * iOS `.waitForRemote`.
+     * Block the initial delivery on the remote fetch up to [timeoutMs]. On success
+     * deliver remote; on failure or timeout fall back to cache, or a failure signal
+     * (null config, null timestamp) when no cache exists. Exactly one *initial* callback
+     * is delivered; subsequent successful fetches are delivered as updates (via the
+     * broadcast in [startFetchLocked]), the same as [RemoteConfigClient.DeliveryMode.All].
      */
     private fun subscribeWaitForRemote(
         key: Key,
@@ -336,20 +343,22 @@ internal class RemoteConfigClientImpl(
         coroutineScope.launch {
             when (val handle = obtainSubscribeFetch()) {
                 is FetchHandle.Reuse ->
-                    weakCallback.deliverFirst(
+                    // deliverRemote (not a fallback): sets lastFetchId so the fetch's own
+                    // broadcast de-dups, and leaves the subscriber open to later updates.
+                    weakCallback.deliverRemote(
                         resolveDotPath(handle.success.blob, key.value),
-                        REMOTE,
                         handle.success.timestamp,
+                        handle.success.fetchId,
                     )
                 is FetchHandle.Pending -> {
                     // Wait up to the timeout for the remote; on success deliver it
                     // (REMOTE), not a cache fallback.
                     val outcome = withTimeoutOrNull(timeoutMs) { handle.deferred.await() }
                     if (outcome is FetchOutcome.Success) {
-                        weakCallback.deliverFirst(
+                        weakCallback.deliverRemote(
                             resolveDotPath(outcome.blob, key.value),
-                            REMOTE,
                             outcome.timestamp,
+                            outcome.fetchId,
                         )
                     }
                 }
@@ -391,11 +400,9 @@ internal class RemoteConfigClientImpl(
     }
 
     /**
-     * Trigger a remote refresh. Rate-limited; on success, delivers the new config to
-     * existing subscribers ([RemoteConfigClient.DeliveryMode.All] always,
-     * [RemoteConfigClient.DeliveryMode.WaitForRemote] only if it hasn't received its
-     * first callback). Failures are never delivered from a refresh — subscribers keep
-     * their last valid config. Mirrors iOS `updateConfigs`.
+     * Trigger a remote refresh. Rate-limited; the fetch itself delivers the new config
+     * to all current subscribers on success (see [startFetchLocked]). Failures are never
+     * delivered from a refresh — subscribers keep their last valid config.
      */
     override fun updateConfigs() {
         coroutineScope.launch(networkIODispatcher) {
@@ -403,17 +410,15 @@ internal class RemoteConfigClientImpl(
                 logger.debug("RemoteConfig update skipped: within 5-minute window")
                 return@launch
             }
-            val outcome = startOrJoinFetch().await()
-            if (outcome is FetchOutcome.Success) {
-                broadcastUpdate(outcome.blob, outcome.timestamp, outcome.fetchId)
-            }
+            startOrJoinFetch()
         }
     }
 
     /**
-     * Delivers a freshly fetched config to all current subscribers as an update.
-     * [DeliveryMode.All] receives every fetch (de-duplicated by [fetchId]);
-     * [DeliveryMode.WaitForRemote] only if it hasn't yet received its first callback.
+     * Delivers a freshly fetched config to every current subscriber as an update,
+     * de-duplicated per subscriber by [fetchId]. Both [DeliveryMode.All] and
+     * [DeliveryMode.WaitForRemote] receive updates — the mode only governs the initial
+     * delivery, after which all subscribers see the latest available config.
      */
     private fun broadcastUpdate(
         blob: ConfigMap,
@@ -427,12 +432,7 @@ internal class RemoteConfigClientImpl(
         for ((dotPath, subscribers) in subscriberSnapshot) {
             val config = resolveDotPath(blob, dotPath)
             subscribers.forEach { weakCallback ->
-                when (weakCallback.deliveryMode) {
-                    is RemoteConfigClient.DeliveryMode.All ->
-                        weakCallback.deliverRemote(config, timestamp, fetchId)
-                    is RemoteConfigClient.DeliveryMode.WaitForRemote ->
-                        weakCallback.deliverFirst(config, REMOTE, timestamp)
-                }
+                weakCallback.deliverRemote(config, timestamp, fetchId)
             }
         }
     }
@@ -467,15 +467,19 @@ internal class RemoteConfigClientImpl(
 
     private fun startFetchLocked(): Deferred<FetchOutcome> {
         val fetchId = fetchSeq.incrementAndGet()
-        // The fetch only produces the outcome (and records lastSuccess); it does NOT
-        // invoke callbacks. Delivery is driven by awaiters (subscribe) and the refresh
-        // broadcast, so the deferred completes as soon as the network/parse is done —
-        // a slow subscriber callback can't delay other awaiters.
         val deferred =
             coroutineScope.async(networkIODispatcher) {
                 val outcome = performFetch(fetchId)
                 if (outcome is FetchOutcome.Success) {
                     synchronized(fetchLock) { lastSuccess = outcome }
+                    // Every successful fetch delivers the latest config to all current
+                    // subscribers (de-duplicated by fetchId), so a subscribe-triggered
+                    // fetch refreshes existing subscribers too, not just its initiator.
+                    // Launched separately so a slow subscriber callback can't delay
+                    // awaiters of this deferred.
+                    coroutineScope.launch {
+                        broadcastUpdate(outcome.blob, outcome.timestamp, outcome.fetchId)
+                    }
                 }
                 outcome
             }

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -154,55 +154,44 @@ internal class RemoteConfigClientImpl(
         fun isAlive(): Boolean = weakRef.get() != null
 
         /**
-         * Invoke [action] on the wrapped callback if it is still alive and, when
-         * gating is in effect, only if this invocation successfully claims the
-         * first-delivery slot. Subsequent invocations after the first delivery
-         * always pass through.
+         * Invoke [action] on the wrapped callback if it is still alive. When gating
+         * is in effect, the first invocation to reach [deliveryLock] claims the
+         * first-delivery slot and signals waiters; later invocations fall through and
+         * deliver as subsequent updates. Claiming inside the lock guarantees the
+         * first delivery completes before any subsequent one — without blocking a
+         * thread waiting on [firstDeliverySignal].
          */
         fun runSafely(action: RemoteConfigClient.RemoteConfigCallback.() -> Unit) {
             val callback = weakRef.get() ?: return
-
-            if (firstDeliveryClaimed != null) {
-                // Gated: claim the first-delivery slot if available.
-                val claimedFirst = firstDeliveryClaimed.compareAndSet(false, true)
-                if (claimedFirst) {
-                    // Signal before callback so a concurrent arrival sees it complete
-                    // and delivers as a subsequent update instead of being dropped.
-                    firstDeliverySignal?.complete(Unit)
-                } else {
-                    // Another path claimed the gate. Wait for it to complete its
-                    // delivery before proceeding with this subsequent update, ensuring
-                    // correct ordering (gate-winner delivers first, then this).
-                    kotlinx.coroutines.runBlocking {
-                        firstDeliverySignal?.await()
-                    }
-                }
-            }
-
             synchronized(deliveryLock) {
-                try {
-                    callback.action()
-                } catch (e: Exception) {
-                    logger.error("Exception in subscriber callback: ${e.message}")
+                if (firstDeliveryClaimed?.compareAndSet(false, true) == true) {
+                    firstDeliverySignal?.complete(Unit)
                 }
+                deliver(callback, action)
             }
         }
 
         /** Deliver only if this callback can still claim the first-delivery slot. */
         fun runSafelyIfFirst(action: RemoteConfigClient.RemoteConfigCallback.() -> Unit): Boolean {
             val callback = weakRef.get() ?: return false
-            val claimed = firstDeliveryClaimed?.compareAndSet(false, true) ?: return false
-            if (!claimed) return false
-
-            firstDeliverySignal?.complete(Unit)
             synchronized(deliveryLock) {
-                try {
-                    callback.action()
-                } catch (e: Exception) {
-                    logger.error("Exception in subscriber callback: ${e.message}")
-                }
+                val claimed = firstDeliveryClaimed?.compareAndSet(false, true) ?: return false
+                if (!claimed) return false
+                firstDeliverySignal?.complete(Unit)
+                deliver(callback, action)
+                return true
             }
-            return true
+        }
+
+        private fun deliver(
+            callback: RemoteConfigClient.RemoteConfigCallback,
+            action: RemoteConfigClient.RemoteConfigCallback.() -> Unit,
+        ) {
+            try {
+                callback.action()
+            } catch (e: Exception) {
+                logger.error("Exception in subscriber callback: ${e.message}")
+            }
         }
     }
 

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -332,7 +332,11 @@ internal class RemoteConfigClientImpl(
 
             isFetching = true
             try {
-                val blob = fetchRemoteConfig() ?: return@launch
+                val blob = fetchRemoteConfig()
+                if (blob == null) {
+                    notifySubscribersOnFailure(System.currentTimeMillis())
+                    return@launch
+                }
 
                 val timestamp = System.currentTimeMillis()
                 withContext(storageIODispatcher) {
@@ -355,8 +359,28 @@ internal class RemoteConfigClientImpl(
                 }
             } catch (e: Exception) {
                 logger.error("Error updating remote configs: ${e.message}")
+                notifySubscribersOnFailure(System.currentTimeMillis())
             } finally {
                 isFetching = false
+            }
+        }
+    }
+
+    /**
+     * Notifies all current subscribers with a null config and [Source.REMOTE] to signal
+     * a failed fetch. The [WeakCallback.runSafely] gate prevents double-delivery for
+     * [DeliveryMode.WaitForRemote] subscribers that have already received a timeout fallback.
+     */
+    private fun notifySubscribersOnFailure(timestamp: Long) {
+        val subscriberSnapshot =
+            synchronized(subscriberLock) {
+                keySpecificSubscribers.map { (_, subs) -> subs.toList() }
+            }
+        for (subscribers in subscriberSnapshot) {
+            subscribers.forEach { weakCallback ->
+                weakCallback.runSafely {
+                    onUpdate(null, REMOTE, timestamp)
+                }
             }
         }
     }

--- a/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -325,13 +325,13 @@ internal class RemoteConfigClientImpl(
                 return@launch
             }
 
-            if (shouldRateLimit()) {
-                logger.debug("RemoteConfig update skipped: within 5-minute window")
-                return@launch
-            }
-
-            isFetching = true
             try {
+                if (shouldRateLimit()) {
+                    logger.debug("RemoteConfig update skipped: within 5-minute window")
+                    return@launch
+                }
+
+                isFetching = true
                 val blob = fetchRemoteConfig()
                 if (blob == null) {
                     notifySubscribersOnFailure(System.currentTimeMillis())

--- a/core/src/test/kotlin/com/amplitude/core/diagnostics/DiagnosticsRemoteConfigTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/diagnostics/DiagnosticsRemoteConfigTest.kt
@@ -157,7 +157,7 @@ class DiagnosticsRemoteConfigTest {
             deliveryMode: RemoteConfigClient.DeliveryMode,
             callback: RemoteConfigClient.RemoteConfigCallback,
         ) {
-            if (key == RemoteConfigClient.Key.DIAGNOSTICS) {
+            if (key == RemoteConfigClient.Key.Diagnostics) {
                 callbacks.add(callback)
             }
         }

--- a/core/src/test/kotlin/com/amplitude/core/diagnostics/DiagnosticsRemoteConfigTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/diagnostics/DiagnosticsRemoteConfigTest.kt
@@ -1,6 +1,9 @@
+@file:OptIn(RestrictedAmplitudeFeature::class)
+
 package com.amplitude.core.diagnostics
 
 import com.amplitude.common.Logger
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.ServerZone
 import com.amplitude.core.remoteconfig.ConfigMap
 import com.amplitude.core.remoteconfig.RemoteConfigClient

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -1098,17 +1098,108 @@ class RemoteConfigClientTest {
                     logger = logger,
                 )
 
-            var callbackInvoked = false
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ ->
-                callbackInvoked = true
+            val callbacks = mutableListOf<Pair<ConfigMap?, Source>>()
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+                callbacks.add(config to source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Should handle storage failure gracefully - no immediate callback
-            assertFalse(callbackInvoked, "Should handle storage read failure gracefully")
+            // Cache read failure must not deliver a bogus CACHE callback, but the
+            // subscriber is still unblocked with a null REMOTE signal rather than
+            // hanging when the fetch path itself fails on a storage read.
+            assertFalse(
+                callbacks.any { it.second == Source.CACHE },
+                "Should not deliver cache on storage read failure",
+            )
+            assertEquals(1, callbacks.size, "Subscriber should be notified exactly once")
+            assertNull(callbacks.first().first, "Failed fetch delivers null config")
+            assertEquals(Source.REMOTE, callbacks.first().second)
             verify {
                 logger.error(
                     match<String> { it.contains("Failed to parse all stored configs") },
+                )
+            }
+            verify {
+                logger.error(
+                    match<String> { it.contains("Error updating remote configs") },
+                )
+            }
+        }
+
+    @Test
+    fun `rate-limit read failure - notifies subscribers instead of leaking exception`() =
+        runTest {
+            // Storage where the cache blob is absent (no CACHE delivery) but the
+            // timestamp read used by shouldRateLimit() throws. This exercises the
+            // path where the exception originates outside the fetch body.
+            val rateLimitFailingStorage =
+                object : Storage {
+                    override fun read(key: Storage.Constants): String? {
+                        if (key == Storage.Constants.REMOTE_CONFIG_TIMESTAMP) {
+                            throw RuntimeException("Timestamp read failed")
+                        }
+                        return null
+                    }
+
+                    override suspend fun write(
+                        key: Storage.Constants,
+                        value: String,
+                    ) {
+                    }
+
+                    override suspend fun remove(key: Storage.Constants) {}
+
+                    override suspend fun writeEvent(event: BaseEvent) {}
+
+                    override suspend fun rollover() {}
+
+                    override fun readEventsContent(): List<Any> = emptyList()
+
+                    override suspend fun getEventsString(content: Any): String = ""
+
+                    override fun getResponseHandler(
+                        eventPipeline: EventPipeline,
+                        configuration: Configuration,
+                        scope: CoroutineScope,
+                        storageDispatcher: CoroutineDispatcher,
+                    ): ResponseHandler = mockk()
+                }
+
+            val client =
+                RemoteConfigClientImpl(
+                    apiKey = "test-key",
+                    serverZone = ServerZone.US,
+                    coroutineScope = testScope,
+                    networkIODispatcher = testDispatcher,
+                    storageIODispatcher = testDispatcher,
+                    storage = rateLimitFailingStorage,
+                    httpClient =
+                        mockk<HttpClient>().apply {
+                            every { request(any()) } returns
+                                HttpClient.Response(
+                                    statusCode = 200,
+                                    body = """{"configs": {}}""",
+                                    headers = emptyMap(),
+                                    statusMessage = "OK",
+                                )
+                        },
+                    logger = logger,
+                )
+
+            val callbacks = mutableListOf<Pair<ConfigMap?, Source>>()
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+                callbacks.add(config to source)
+            }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Subscriber must still be unblocked with a null REMOTE signal rather
+            // than the exception leaking out of the launch and hanging it forever.
+            assertEquals(1, callbacks.size, "Subscriber should be notified exactly once")
+            assertNull(callbacks.first().first, "Failed fetch delivers null config")
+            assertEquals(Source.REMOTE, callbacks.first().second)
+            verify {
+                logger.error(
+                    match<String> { it.contains("Error updating remote configs") },
                 )
             }
         }

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -7,6 +7,10 @@ import com.amplitude.core.Storage
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.EventPipeline
 import com.amplitude.core.remoteconfig.RemoteConfigClient.Key
+import com.amplitude.core.remoteconfig.RemoteConfigClient.Key.AnalyticsSdk
+import com.amplitude.core.remoteconfig.RemoteConfigClient.Key.Diagnostics
+import com.amplitude.core.remoteconfig.RemoteConfigClient.Key.SessionReplayPrivacyConfig
+import com.amplitude.core.remoteconfig.RemoteConfigClient.Key.SessionReplaySamplingConfig
 import com.amplitude.core.remoteconfig.RemoteConfigClient.Source
 import com.amplitude.core.utilities.InMemoryStorage
 import com.amplitude.core.utilities.http.HttpClient
@@ -90,17 +94,17 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             // Subscribe multiple callbacks to same key
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, _, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { config, _, _ ->
                 callbacks.add(
                     config,
                 )
             }
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, _, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { config, _, _ ->
                 callbacks.add(
                     config,
                 )
             }
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, _, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { config, _, _ ->
                 callbacks.add(
                     config,
                 )
@@ -108,17 +112,19 @@ class RemoteConfigClientTest {
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // All callbacks should receive cached data
-            assertEquals(3, callbacks.size)
-            callbacks.forEach { assertEquals("medium", it["defaultMaskLevel"]) }
+            // 3 CACHE callbacks + 3 REMOTE callbacks (empty config from emptyApiConfig)
+            assertEquals(6, callbacks.size)
+            // First 3 are cache, last 3 are remote (empty)
+            callbacks.take(3).forEach { assertEquals("medium", it["defaultMaskLevel"]) }
+            callbacks.drop(3).forEach { assertTrue(it.isEmpty()) }
         }
 
     @Test
     fun `subscribe with cached data - different keys receive only their config`() =
         runTest {
             val client = createClient()
-            var privacyConfig: ConfigMap? = null
-            var samplingConfig: ConfigMap? = null
+            val privacyCallbacks = mutableListOf<Pair<ConfigMap, Source>>()
+            val samplingCallbacks = mutableListOf<Pair<ConfigMap, Source>>()
 
             // Pre-populate storage with both configs
             storage.write(
@@ -128,24 +134,25 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             // Subscribe to different keys
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, _, _ ->
-                privacyConfig = config
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+                privacyCallbacks.add(config to source)
             }
-            client.subscribe(Key.SESSION_REPLAY_SAMPLING_CONFIG) { config, _, _ ->
-                samplingConfig = config
+            client.subscribe(SessionReplaySamplingConfig) { config, source, _ ->
+                samplingCallbacks.add(config to source)
             }
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Each should receive their specific config
-            val privacy = checkNotNull(privacyConfig) { "Privacy subscriber should receive config" }
-            val sampling =
-                checkNotNull(samplingConfig) { "Sampling subscriber should receive config" }
+            // CACHE callback has specific config; REMOTE callback is empty (emptyApiConfig)
+            assertTrue(privacyCallbacks.size >= 1)
+            val privacyCache = privacyCallbacks.first { it.second == Source.CACHE }.first
+            assertEquals("medium", privacyCache["defaultMaskLevel"])
+            assertFalse(privacyCache.containsKey("sample_rate"))
 
-            assertEquals("medium", privacy["defaultMaskLevel"])
-            assertEquals(1.0, sampling["sample_rate"])
-            assertEquals(true, sampling["capture_enabled"])
-            assertFalse(privacy.containsKey("sample_rate"))
+            assertTrue(samplingCallbacks.size >= 1)
+            val samplingCache = samplingCallbacks.first { it.second == Source.CACHE }.first
+            assertEquals(1.0, samplingCache["sample_rate"])
+            assertEquals(true, samplingCache["capture_enabled"])
         }
 
     @Test
@@ -166,7 +173,7 @@ class RemoteConfigClientTest {
                 RemoteConfigClient.RemoteConfigCallback { _, _, _ ->
                     persistentCallbackInvocations++
                 }
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = persistentCallback)
+            client.subscribe(SessionReplayPrivacyConfig, callback = persistentCallback)
             testDispatcher.scheduler.advanceUntilIdle()
             // Persistent callback should have received initial cache + remote
             assertEquals(
@@ -184,7 +191,7 @@ class RemoteConfigClientTest {
                     RemoteConfigClient.RemoteConfigCallback { _, _, _ ->
                         tempCallbackInvocations++
                     }
-                client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = tempCallback)
+                client.subscribe(SessionReplayPrivacyConfig, callback = tempCallback)
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -201,7 +208,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
             // Add new subscriber to trigger cleanup and another remote fetch
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ -> }
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> }
             testDispatcher.scheduler.advanceUntilIdle()
 
             // The test demonstrates that weak reference system works
@@ -215,7 +222,7 @@ class RemoteConfigClientTest {
     fun `subscribe with callback exceptions - isolate exception and don't cascade failure`() =
         runTest {
             val client = createClient(useVerifiableLogger = true)
-            val workingCallbacks = mutableListOf<ConfigMap>()
+            val workingCallbacks = mutableListOf<Pair<ConfigMap, Source>>()
 
             // Pre-populate storage to ensure callbacks are triggered
             storage.write(
@@ -225,22 +232,24 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             // Add callback that throws exception
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ ->
                 throw RuntimeException("Test exception")
             }
 
             // Add working callbacks
             client.subscribe(
-                Key.SESSION_REPLAY_PRIVACY_CONFIG,
-            ) { config, _, _ -> workingCallbacks.add(config) }
+                SessionReplayPrivacyConfig,
+            ) { config, source, _ -> workingCallbacks.add(config to source) }
             client.subscribe(
-                Key.SESSION_REPLAY_PRIVACY_CONFIG,
-            ) { config, _, _ -> workingCallbacks.add(config) }
+                SessionReplayPrivacyConfig,
+            ) { config, source, _ -> workingCallbacks.add(config to source) }
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Working callbacks should still be invoked despite exception
-            assertEquals(2, workingCallbacks.size)
+            // 2 CACHE + 2 REMOTE (empty from emptyApiConfig) = 4
+            assertEquals(4, workingCallbacks.size)
+            assertEquals(2, workingCallbacks.count { it.second == Source.CACHE })
+            assertEquals(2, workingCallbacks.count { it.second == Source.REMOTE })
             verify {
                 logger.error(
                     match<String> { it.contains("Exception in subscriber callback") },
@@ -253,40 +262,40 @@ class RemoteConfigClientTest {
         runTest {
             val client = createClient()
 
-            // Pre-populate storage with config
+            // Pre-populate storage with nested config blob
             storage.write(
                 Storage.Constants.REMOTE_CONFIG,
                 """
                 {
-                    "sessionReplay.sr_android_privacy_config": {
-                        "defaultMaskLevel": "strict"
-                    },
-                    "sessionReplay.sr_android_sampling_config": {
-                        "sample_rate": 0.003,
-                        "capture_enabled": false
+                    "sessionReplay": {
+                        "sr_android_privacy_config": {
+                            "defaultMaskLevel": "strict"
+                        },
+                        "sr_android_sampling_config": {
+                            "sample_rate": 0.003,
+                            "capture_enabled": false
+                        }
                     }
                 }
                 """.trimIndent(),
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            var receivedConfig: ConfigMap? = null
-            var receivedSource: Source? = null
-            var receivedTimestamp: Long? = null
+            val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
 
-            // Subscribe - should immediately get cached data
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, source, timestamp ->
-                receivedConfig = config
-                receivedSource = source
-                receivedTimestamp = timestamp
+            // Subscribe - should immediately get cached data, then REMOTE
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, timestamp ->
+                results.add(Triple(config, source, timestamp))
             }
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            val config = checkNotNull(receivedConfig)
-            assertEquals(Source.CACHE, receivedSource)
-            assertEquals(1234567890L, receivedTimestamp)
-            assertEquals("strict", config["defaultMaskLevel"])
+            // First callback is CACHE with original data
+            assertTrue(results.size >= 1)
+            val (cacheConfig, cacheSource, cacheTimestamp) = results.first { it.second == Source.CACHE }
+            assertEquals(Source.CACHE, cacheSource)
+            assertEquals(1234567890L, cacheTimestamp)
+            assertEquals("strict", cacheConfig["defaultMaskLevel"])
         }
 
     @Test
@@ -300,12 +309,14 @@ class RemoteConfigClientTest {
                 Storage.Constants.REMOTE_CONFIG,
                 """
                 {
-                    "sessionReplay.sr_android_privacy_config": {
-                        "defaultMaskLevel": "moderate"
-                    },
-                    "sessionReplay.sr_android_sampling_config": {
-                        "sample_rate": 0.15,
-                        "capture_enabled": true
+                    "sessionReplay": {
+                        "sr_android_privacy_config": {
+                            "defaultMaskLevel": "moderate"
+                        },
+                        "sr_android_sampling_config": {
+                            "sample_rate": 0.15,
+                            "capture_enabled": true
+                        }
                     }
                 }
                 """.trimIndent(),
@@ -315,24 +326,24 @@ class RemoteConfigClientTest {
             val callback = RemoteConfigClient.RemoteConfigCallback { _, _, _ -> callCount++ }
 
             // Subscribe same callback reference multiple times
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = callback)
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = callback)
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG, callback = callback)
+            client.subscribe(SessionReplayPrivacyConfig, callback = callback)
+            client.subscribe(SessionReplayPrivacyConfig, callback = callback)
+            client.subscribe(SessionReplayPrivacyConfig, callback = callback)
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Each subscription creates separate WeakCallback wrapper
-            assertEquals(3, callCount)
+            // 3 CACHE + 3 REMOTE (empty from emptyApiConfig) = 6
+            assertEquals(6, callCount)
             verify(exactly = 3) { logger.debug(match<String> { it.contains("Added subscriber") }) }
         }
 
     @Test
-    fun `subscribe with inconsistent storage - storage invalidated and no immediate callback`() =
+    fun `subscribe with old-format cache - migrated and delivered immediately`() =
         runTest {
             val client = createClient(useVerifiableLogger = true)
-            var callbackInvoked = false
+            val results = mutableListOf<Pair<ConfigMap, Source>>()
 
-            // Pre-populate storage with incomplete data (missing sampling config)
+            // Pre-populate storage with old pre-flattened format (keys contain dots)
             storage.write(
                 Storage.Constants.REMOTE_CONFIG,
                 """
@@ -345,21 +356,18 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ ->
-                callbackInvoked = true
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+                results.add(config to source)
             }
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Updated behavior: keep partial data if at least one expected key exists
-            assertTrue(callbackInvoked)
-            verify { logger.debug(match<String> { it.contains("Storage inconsistent keys") }) }
-            // Ensure we did NOT clear storage under middle-ground policy
-            verify(exactly = 0) {
-                logger.debug(
-                    match<String> { it.contains("Cleared inconsistent storage") },
-                )
-            }
+            // First delivery is migrated CACHE
+            assertTrue(results.isNotEmpty())
+            val (cacheConfig, cacheSource) = results.first { it.second == Source.CACHE }
+            assertEquals(Source.CACHE, cacheSource)
+            assertEquals("light", cacheConfig["defaultMaskLevel"])
+            verify { logger.debug(match<String> { it.contains("old pre-flattened cache format") }) }
         }
 
     // endregion Subscription Management
@@ -400,13 +408,13 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
             // First subscribe call - should trigger HTTP request
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, source, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
                 firstCallbackResults.add(config to source)
             }
 
             // Second subscribe call immediately after - should NOT trigger another HTTP request
             // but should still get notified when first request completes
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, source, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
                 secondCallbackResults.add(config to source)
             }
 
@@ -463,7 +471,7 @@ class RemoteConfigClientTest {
                 )
 
             val callbackResults = mutableListOf<Pair<ConfigMap, Source>>()
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, source, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
                 callbackResults.add(config to source)
             }
 
@@ -525,7 +533,7 @@ class RemoteConfigClientTest {
                 )
 
             val callbackResults = mutableListOf<Pair<ConfigMap, Source>>()
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, source, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
                 callbackResults.add(config to source)
             }
 
@@ -600,7 +608,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             var callbackCount = 0
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ -> callbackCount++ }
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Should still get cached config, no crash
@@ -631,7 +639,7 @@ class RemoteConfigClientTest {
             )
 
             var callbackCount = 0
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ -> callbackCount++ }
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
             testDispatcher.scheduler.advanceUntilIdle()
             assertTrue(callbackCount == 1, "Should receive cached config despite malformed JSON")
 
@@ -668,15 +676,15 @@ class RemoteConfigClientTest {
                 )
 
             var callbackCount = 0
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ -> callbackCount++ }
-            client.subscribe(Key.SESSION_REPLAY_SAMPLING_CONFIG) { _, _, _ -> callbackCount++ }
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
+            client.subscribe(SessionReplaySamplingConfig) { _, _, _ -> callbackCount++ }
             testDispatcher.scheduler.advanceUntilIdle()
 
             client.updateConfigs() // Should handle null fields gracefully
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Should not crash, may or may not invoke callbacks depending on parsing
-            assertTrue(callbackCount >= 0, "Client should handle null fields without crashing")
+            // CACHE from pre-populated storage + REMOTE with resolved (possibly empty) config
+            assertTrue(callbackCount >= 2, "Subscribers should receive CACHE + REMOTE callbacks")
         }
 
     @Test
@@ -709,16 +717,14 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            var callbackCount = 0
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ ->
-                callbackCount++
+            val results = mutableListOf<Source>()
+            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ ->
+                results.add(source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
-            assertTrue(callbackCount == 1, "Client should handle wrong data types without crashing")
-
-            client.updateConfigs()
-            testDispatcher.scheduler.advanceUntilIdle()
-            assertTrue(callbackCount == 1, "Client should handle wrong data types without crashing")
+            // CACHE from stored data + REMOTE (dot-path fails on wrong types, delivers empty)
+            assertTrue(results.contains(Source.CACHE), "Should receive cached config")
+            assertTrue(results.size >= 1, "Client should handle wrong data types without crashing")
         }
 
     @Test
@@ -736,7 +742,7 @@ class RemoteConfigClientTest {
                 )
 
             var callbackInvoked = false
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ ->
                 callbackInvoked = true
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -767,7 +773,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             var callbackCount = 0
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ -> callbackCount++ }
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
             testDispatcher.scheduler.advanceUntilIdle()
             assertTrue(callbackCount == 1, "Should receive cached config despite server error")
 
@@ -812,7 +818,7 @@ class RemoteConfigClientTest {
                 )
 
             var callbackCount = 0
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ -> callbackCount++ }
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
             testDispatcher.scheduler.advanceUntilIdle()
             assertTrue(
                 callbackCount == 1,
@@ -854,7 +860,7 @@ class RemoteConfigClientTest {
                 )
 
             var callbackCount = 0
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ -> callbackCount++ }
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
             testDispatcher.scheduler.advanceUntilIdle()
 
             client.updateConfigs()
@@ -902,12 +908,12 @@ class RemoteConfigClientTest {
             assertTrue(url.contains("sr-client-cfg.eu.amplitude.com"), "Should use EU endpoint")
             assertTrue(url.contains("api_key=test-key-eu"), "Should include correct API key")
             assertTrue(
-                url.contains("config_keys=sessionReplay.sr_android_privacy_config"),
-                "Should include privacy config key",
+                url.contains("config_keys=analyticsSDK"),
+                "Should include analyticsSDK fetch key",
             )
             assertTrue(
-                url.contains("config_keys=sessionReplay.sr_android_sampling_config"),
-                "Should include sampling config key",
+                url.contains("config_keys=sessionReplay"),
+                "Should include sessionReplay fetch key",
             )
             assertEquals(
                 HttpClient.Request.Method.GET,
@@ -952,12 +958,12 @@ class RemoteConfigClientTest {
             assertTrue(url.contains("sr-client-cfg.amplitude.com"), "Should use US endpoint")
             assertTrue(url.contains("api_key=test-key-us"), "Should include correct API key")
             assertTrue(
-                url.contains("config_keys=sessionReplay.sr_android_privacy_config"),
-                "Should include privacy config key",
+                url.contains("config_keys=analyticsSDK"),
+                "Should include analyticsSDK fetch key",
             )
             assertTrue(
-                url.contains("config_keys=sessionReplay.sr_android_sampling_config"),
-                "Should include sampling config key",
+                url.contains("config_keys=sessionReplay"),
+                "Should include sessionReplay fetch key",
             )
             assertEquals(
                 HttpClient.Request.Method.GET,
@@ -1028,7 +1034,7 @@ class RemoteConfigClientTest {
                 )
 
             var remoteCallbacks = mutableListOf<Pair<ConfigMap, Source>>()
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { config, source, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
                 remoteCallbacks.add(config to source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -1104,7 +1110,7 @@ class RemoteConfigClientTest {
                 )
 
             var callbackInvoked = false
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ ->
                 callbackInvoked = true
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -1127,14 +1133,15 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG, "{this is corrupted json")
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "not_a_number")
 
-            var callbackInvoked = false
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ ->
-                callbackInvoked = true
+            val results = mutableListOf<Source>()
+            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ ->
+                results.add(source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Should handle corrupted data gracefully - no crash, no callback
-            assertFalse(callbackInvoked, "Should handle corrupted storage data gracefully")
+            // No CACHE callback (corrupted), but REMOTE callback fires (empty from emptyApiConfig)
+            assertFalse(results.contains(Source.CACHE), "Should not deliver corrupted cache")
+            assertTrue(results.contains(Source.REMOTE), "Should still receive REMOTE notification")
             verify {
                 logger.error(
                     match<String> { it.contains("Failed to parse all stored configs") },
@@ -1143,39 +1150,39 @@ class RemoteConfigClientTest {
         }
 
     @Test
-    fun `storage with non-map values - skips invalid entries`() =
+    fun `storage with non-map values at top level - still resolves valid nested paths`() =
         runTest {
             val client = createClient(useVerifiableLogger = true)
 
-            // Write storage with mixed data types
+            // Write storage with mixed data types at top level
             storage.write(
                 Storage.Constants.REMOTE_CONFIG,
                 """
                 {
-                    "sessionReplay.sr_android_privacy_config": {
-                        "defaultMaskLevel": "medium"
-                    },
-                    "sessionReplay.sr_android_sampling_config": {
-                        "sample_rate": 1.0,
-                        "capture_enabled": true
+                    "sessionReplay": {
+                        "sr_android_privacy_config": {
+                            "defaultMaskLevel": "medium"
+                        },
+                        "sr_android_sampling_config": {
+                            "sample_rate": 1.0,
+                            "capture_enabled": true
+                        }
                     },
                     "invalidKey1": "string_instead_of_object",
-                    "invalidKey2": [1, 2, 3],
-                    "invalidKey3": 42
+                    "invalidKey2": [1, 2, 3]
                 }
                 """.trimIndent(),
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             var callbackInvoked = false
-            client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, _, _ ->
+            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ ->
                 callbackInvoked = true
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Should receive callback despite invalid entries in storage
-            assertTrue(callbackInvoked, "Should handle non-map values in storage gracefully")
-            verify { logger.debug(match<String> { it.contains("Skipping non-map value") }) }
+            // Should resolve the valid nested path despite other top-level junk
+            assertTrue(callbackInvoked, "Should resolve valid dot-path despite non-map top-level entries")
         }
 
     // endregion Additional Coverage
@@ -1192,7 +1199,7 @@ class RemoteConfigClientTest {
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
                 client.subscribe(
-                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 5_000L),
                 ) { config, source, timestamp ->
                     results.add(Triple(config, source, timestamp))
@@ -1239,7 +1246,7 @@ class RemoteConfigClientTest {
 
                 val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
                 client.subscribe(
-                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 100L),
                 ) { config, source, timestamp ->
                     results.add(Triple(config, source, timestamp))
@@ -1280,7 +1287,7 @@ class RemoteConfigClientTest {
 
                 val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
                 client.subscribe(
-                    key = Key.DIAGNOSTICS,
+                    key = Diagnostics,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 50L),
                 ) { config, source, timestamp ->
                     results.add(Triple(config, source, timestamp))
@@ -1307,7 +1314,7 @@ class RemoteConfigClientTest {
 
                 val sources = mutableListOf<Source>()
                 client.subscribe(
-                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 5_000L),
                 ) { _, source, _ ->
                     sources.add(source)
@@ -1332,7 +1339,7 @@ class RemoteConfigClientTest {
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
                 // The pre-existing single-arg overload must still deliver cache then remote.
-                client.subscribe(Key.SESSION_REPLAY_PRIVACY_CONFIG) { _, source, _ ->
+                client.subscribe(SessionReplayPrivacyConfig) { _, source, _ ->
                     sources.add(source)
                 }
 
@@ -1385,7 +1392,7 @@ class RemoteConfigClientTest {
 
                 val results = mutableListOf<Pair<ConfigMap, Source>>()
                 client.subscribe(
-                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 50L),
                 ) { config, source, _ ->
                     results.add(config to source)
@@ -1426,11 +1433,9 @@ class RemoteConfigClientTest {
         @Test
         fun `WaitForRemote unblocks immediately when key is absent from successful fetch`() =
             runTest {
-                // Regression for "absent key" timeout: the response is successful
-                // but does NOT include the requested key (e.g. project doesn't
-                // have G&S configured). The subscriber must receive the empty/
-                // cached fallback as soon as the fetch returns — not after the
-                // full WaitForRemote timeout elapses.
+                // When the response is successful but does NOT include the
+                // requested key, all subscribers still get a REMOTE notification
+                // with emptyMap(). WaitForRemote is unblocked immediately.
                 val mockHttpClient = mockk<HttpClient>()
                 every { mockHttpClient.request(any()) } returns
                     HttpClient.Response(
@@ -1452,64 +1457,51 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                // No cache: the fallback should be empty.
                 val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
-                // 60_000ms timeout — far longer than the fetch could plausibly
-                // take. If the fix is wrong, advanceTimeBy below would have to
-                // run for the full timeout and the test would observe a
-                // post-fetch advance window with zero deliveries.
                 client.subscribe(
-                    key = Key.ANALYTICS_SDK,
+                    key = AnalyticsSdk,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 60_000L),
                 ) { config, source, timestamp ->
                     results.add(Triple(config, source, timestamp))
                 }
 
-                // Run all currently-pending tasks (the fetch). Crucially we do
-                // NOT advance virtual time anywhere near the 60_000ms timeout —
-                // the fix is what unblocks the gate.
+                // Run pending tasks. NOT advancing near the 60_000ms timeout.
                 testDispatcher.scheduler.runCurrent()
-                // Drain any continuations queued by the fetch's notification
-                // path, including the absent-key delivery.
                 testDispatcher.scheduler.advanceTimeBy(10L)
                 testDispatcher.scheduler.runCurrent()
 
                 assertEquals(
                     1,
                     results.size,
-                    "Expected exactly one absent-key fallback delivery before the timeout, got: $results",
+                    "Expected exactly one delivery before the timeout, got: $results",
                 )
                 val (config, source, _) = results.single()
-                assertEquals(Source.CACHE, source, "Absent-key fallback must report Source.CACHE")
+                assertEquals(Source.REMOTE, source, "Absent-key delivery should report Source.REMOTE")
                 assertTrue(
                     config.isEmpty(),
-                    "Expected empty fallback when no cache exists for absent key, got: $config",
+                    "Expected empty config for absent key, got: $config",
                 )
             }
 
         @Test
         fun `WaitForRemote unblocks immediately on empty successful fetch`() =
             runTest {
-                // Regression: when the server returns 200 with {"configs":{}}
-                // (valid empty config — project has no blades enabled),
-                // parseConfigsFromResponse used to return null causing the caller
-                // to treat it as a failure. WaitForRemote subscribers would then
-                // wait the full timeout. With the fix, an empty map is returned,
-                // notifyAbsentKeySubscribers fires, and the subscriber is unblocked.
+                // When the server returns 200 with {"configs": {}}, all subscribers
+                // are notified with REMOTE + emptyMap(). WaitForRemote is unblocked
+                // by the REMOTE delivery, not the timeout fallback.
                 val client = createClient(emptyApiConfig = true) // returns {"configs":{}}
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
                 val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
                 client.subscribe(
-                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 60_000L),
                 ) { config, source, timestamp ->
                     results.add(Triple(config, source, timestamp))
                 }
 
                 // Run only the currently-pending tasks and a tiny virtual-time
-                // nudge — nowhere near the 60_000ms timeout. If the fix is wrong,
-                // the subscriber stays blocked until the timeout.
+                // nudge — nowhere near the 60_000ms timeout.
                 testDispatcher.scheduler.runCurrent()
                 testDispatcher.scheduler.advanceTimeBy(10L)
                 testDispatcher.scheduler.runCurrent()
@@ -1517,24 +1509,21 @@ class RemoteConfigClientTest {
                 assertEquals(
                     1,
                     results.size,
-                    "Expected one delivery from empty-config absent-key path, got: $results",
+                    "Expected one delivery from empty-config path, got: $results",
                 )
                 val (config, source, _) = results.single()
-                assertEquals(Source.CACHE, source, "Empty-config fallback must report Source.CACHE")
+                assertEquals(Source.REMOTE, source, "Empty-config delivery should report Source.REMOTE")
                 assertTrue(
                     config.isEmpty(),
-                    "Expected empty fallback config, got: $config",
+                    "Expected empty config, got: $config",
                 )
             }
 
         @Test
         fun `WaitForRemote does not interfere with All subscribers on the absent key`() =
             runTest {
-                // Sanity guard: the absent-key unblock path uses runSafelyIfFirst,
-                // which is a no-op for non-gated subscribers. A DeliveryMode.All
-                // subscriber on a key the response doesn't include should still
-                // see only its initial cache delivery (if any) and nothing
-                // synthesized by the absent-key path.
+                // All subscribers on a key absent from the response now receive a
+                // REMOTE notification with emptyMap() (platform-aligned behavior).
                 val mockHttpClient = mockk<HttpClient>()
                 every { mockHttpClient.request(any()) } returns
                     HttpClient.Response(
@@ -1556,19 +1545,17 @@ class RemoteConfigClientTest {
                     )
 
                 val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
-                client.subscribe(Key.DIAGNOSTICS) { config, source, timestamp ->
+                client.subscribe(Diagnostics) { config, source, timestamp ->
                     results.add(Triple(config, source, timestamp))
                 }
 
                 testDispatcher.scheduler.advanceUntilIdle()
 
-                // No cache on DIAGNOSTICS and no remote — All subscriber gets
-                // nothing, exactly as before. The absent-key path must not
-                // fabricate a delivery for it.
-                assertTrue(
-                    results.isEmpty(),
-                    "DeliveryMode.All on absent key must not receive a synthesized delivery, got: $results",
-                )
+                // No cache on DIAGNOSTICS. REMOTE fires with empty config (key absent).
+                assertEquals(1, results.size, "All subscriber on absent key should receive REMOTE, got: $results")
+                val (config, source, _) = results.single()
+                assertEquals(Source.REMOTE, source)
+                assertTrue(config.isEmpty(), "Absent key should deliver empty config")
             }
 
         @Test
@@ -1606,12 +1593,14 @@ class RemoteConfigClientTest {
                         Storage.Constants.REMOTE_CONFIG,
                         """
                         {
-                            "sessionReplay.sr_android_privacy_config": {
-                                "defaultMaskLevel": "STALE"
-                            },
-                            "sessionReplay.sr_android_sampling_config": {
-                                "sample_rate": 0.0,
-                                "capture_enabled": false
+                            "sessionReplay": {
+                                "sr_android_privacy_config": {
+                                    "defaultMaskLevel": "STALE"
+                                },
+                                "sr_android_sampling_config": {
+                                    "sample_rate": 0.0,
+                                    "capture_enabled": false
+                                }
                             }
                         }
                         """.trimIndent(),
@@ -1639,7 +1628,7 @@ class RemoteConfigClientTest {
                 val allDone = java.util.concurrent.CountDownLatch(2)
 
                 client.subscribe(
-                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 30L),
                 ) { config, source, _ ->
                     val current = concurrentCount.incrementAndGet()
@@ -1719,12 +1708,14 @@ class RemoteConfigClientTest {
                         Storage.Constants.REMOTE_CONFIG,
                         """
                         {
-                            "sessionReplay.sr_android_privacy_config": {
-                                "defaultMaskLevel": "STALE"
-                            },
-                            "sessionReplay.sr_android_sampling_config": {
-                                "sample_rate": 0.0,
-                                "capture_enabled": false
+                            "sessionReplay": {
+                                "sr_android_privacy_config": {
+                                    "defaultMaskLevel": "STALE"
+                                },
+                                "sr_android_sampling_config": {
+                                    "sample_rate": 0.0,
+                                    "capture_enabled": false
+                                }
                             }
                         }
                         """.trimIndent(),
@@ -1748,7 +1739,7 @@ class RemoteConfigClientTest {
                 val secondDelivery = java.util.concurrent.CountDownLatch(2)
 
                 client.subscribe(
-                    key = Key.SESSION_REPLAY_PRIVACY_CONFIG,
+                    key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 30L),
                 ) { config, source, _ ->
                     results.add(config to source)
@@ -1789,6 +1780,403 @@ class RemoteConfigClientTest {
 
     // endregion DeliveryMode
 
+    // region Dot-Path and Key Alignment
+
+    @Test
+    fun `subscribe with top-level key returns entire subtree`() =
+        runTest {
+            val client = createClient(emptyApiConfig = false)
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
+
+            var receivedConfig: ConfigMap? = null
+            client.subscribe(Key.Custom("sessionReplay")) { config, _, _ ->
+                receivedConfig = config
+            }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // "sessionReplay" should return the entire subtree
+            val config = checkNotNull(receivedConfig) { "Subscriber should receive subtree" }
+
+            @Suppress("UNCHECKED_CAST")
+            val privacyConfig = config["sr_android_privacy_config"] as? Map<String, Any>
+            assertEquals("medium", privacyConfig?.get("defaultMaskLevel"))
+            @Suppress("UNCHECKED_CAST")
+            val samplingConfig = config["sr_android_sampling_config"] as? Map<String, Any>
+            assertEquals(true, samplingConfig?.get("capture_enabled"))
+        }
+
+    @Test
+    fun `subscribe with Custom key resolves dot-path correctly`() =
+        runTest {
+            val client = createClient(emptyApiConfig = false)
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
+
+            var receivedConfig: ConfigMap? = null
+            client.subscribe(Key.Custom("sessionReplay.sr_android_privacy_config")) { config, _, _ ->
+                receivedConfig = config
+            }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val config = checkNotNull(receivedConfig)
+            assertEquals("medium", config["defaultMaskLevel"])
+        }
+
+    @Test
+    fun `Custom key works with cached data`() =
+        runTest {
+            val client = createClient()
+
+            storage.write(
+                Storage.Constants.REMOTE_CONFIG,
+                DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
+            )
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
+
+            val results = mutableListOf<Pair<ConfigMap, Source>>()
+            client.subscribe(Key.Custom("sessionReplay.sr_android_sampling_config")) { config, source, _ ->
+                results.add(config to source)
+            }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // First delivery is CACHE with specific config
+            assertTrue(results.isNotEmpty())
+            val (cacheConfig, cacheSource) = results.first { it.second == Source.CACHE }
+            assertEquals(Source.CACHE, cacheSource)
+            assertEquals(1.0, cacheConfig["sample_rate"])
+            assertEquals(true, cacheConfig["capture_enabled"])
+        }
+
+    @Test
+    fun `old pre-flattened cache format is migrated and delivered`() =
+        runTest {
+            val client = createClient(useVerifiableLogger = true)
+
+            // Old format: keys are "topLevel.nested" (flat)
+            storage.write(
+                Storage.Constants.REMOTE_CONFIG,
+                """
+                {
+                    "sessionReplay.sr_android_privacy_config": {
+                        "defaultMaskLevel": "medium"
+                    },
+                    "sessionReplay.sr_android_sampling_config": {
+                        "sample_rate": 1.0,
+                        "capture_enabled": true
+                    }
+                }
+                """.trimIndent(),
+            )
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
+
+            val results = mutableListOf<Pair<ConfigMap, Source>>()
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+                results.add(config to source)
+            }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // First delivery is migrated CACHE
+            assertTrue(results.isNotEmpty()) { "Migrated config should be delivered" }
+            val (cacheConfig, cacheSource) = results.first { it.second == Source.CACHE }
+            assertEquals(Source.CACHE, cacheSource)
+            assertEquals("medium", cacheConfig["defaultMaskLevel"])
+            verify { logger.debug(match<String> { it.contains("old pre-flattened cache format") }) }
+        }
+
+    @Test
+    fun `dot-path to non-existent path returns empty config`() =
+        runTest {
+            val client = createClient()
+
+            storage.write(
+                Storage.Constants.REMOTE_CONFIG,
+                DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
+            )
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
+
+            var receivedConfig: ConfigMap? = null
+            client.subscribe(Key.Custom("nonExistent.path")) { config, _, _ ->
+                receivedConfig = config
+            }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Should receive empty config (dot-path doesn't resolve)
+            val config = checkNotNull(receivedConfig)
+            assertTrue(config.isEmpty())
+        }
+
+    @Test
+    fun `Key sealed class instances have correct values`() {
+        assertEquals("analyticsSDK.androidSDK", Key.AnalyticsSdk.value)
+        assertEquals("diagnostics.androidSDK", Key.Diagnostics.value)
+        assertEquals("sessionReplay.sr_android_privacy_config", Key.SessionReplayPrivacyConfig.value)
+        assertEquals("sessionReplay.sr_android_sampling_config", Key.SessionReplaySamplingConfig.value)
+        assertEquals("experiment.androidSDK", Key.Custom("experiment.androidSDK").value)
+    }
+
+    // endregion Dot-Path and Key Alignment
+
+    // region Migration and Dynamic Fetch Keys
+
+    @Test
+    fun `old-format cache migrated and delivered when offline with WaitForRemote`() =
+        runTest {
+            // Simulates an upgrade scenario: old cache has flat dotted keys,
+            // fetch fails (offline). Subscribers should still receive the
+            // migrated cached config instead of empty.
+            val mockHttpClient = mockk<HttpClient>()
+            every { mockHttpClient.request(any()) } returns
+                HttpClient.Response(
+                    statusCode = 500,
+                    body = "",
+                    headers = emptyMap(),
+                    statusMessage = "Internal Server Error",
+                )
+            val client =
+                RemoteConfigClientImpl(
+                    apiKey = "test-key",
+                    serverZone = ServerZone.US,
+                    coroutineScope = testScope,
+                    networkIODispatcher = testDispatcher,
+                    storageIODispatcher = testDispatcher,
+                    storage = storage,
+                    httpClient = mockHttpClient,
+                    logger = silentLogger,
+                )
+
+            // Old flat format
+            storage.write(
+                Storage.Constants.REMOTE_CONFIG,
+                """
+                {
+                    "sessionReplay.sr_android_privacy_config": {
+                        "defaultMaskLevel": "strict"
+                    },
+                    "sessionReplay.sr_android_sampling_config": {
+                        "sample_rate": 0.5,
+                        "capture_enabled": true
+                    },
+                    "diagnostics.androidSDK": {
+                        "enabled": true
+                    }
+                }
+                """.trimIndent(),
+            )
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
+
+            val privacyResults = mutableListOf<Triple<ConfigMap, Source, Long>>()
+            val diagnosticsResults = mutableListOf<Triple<ConfigMap, Source, Long>>()
+
+            client.subscribe(
+                key = SessionReplayPrivacyConfig,
+                deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 100L),
+            ) { config, source, timestamp ->
+                privacyResults.add(Triple(config, source, timestamp))
+            }
+
+            client.subscribe(
+                key = Diagnostics,
+                deliveryMode = RemoteConfigClient.DeliveryMode.All,
+            ) { config, source, timestamp ->
+                diagnosticsResults.add(Triple(config, source, timestamp))
+            }
+
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Privacy: WaitForRemote should get migrated cache (fetch failed, timeout fires).
+            assertTrue(
+                privacyResults.isNotEmpty(),
+                "WaitForRemote subscriber should receive migrated cache on offline upgrade",
+            )
+            val (privacyConfig, privacySource, _) = privacyResults.first()
+            assertEquals("strict", privacyConfig["defaultMaskLevel"])
+            assertEquals(Source.CACHE, privacySource)
+
+            // Diagnostics: All should get migrated cache immediately.
+            assertTrue(
+                diagnosticsResults.isNotEmpty(),
+                "All subscriber should receive migrated cache on offline upgrade",
+            )
+            val (diagConfig, diagSource, _) = diagnosticsResults.first()
+            assertEquals(true, diagConfig["enabled"])
+            assertEquals(Source.CACHE, diagSource)
+
+            // Verify the migrated blob was persisted back to storage.
+            val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
+            val storedBlob = org.json.JSONObject(checkNotNull(storedJson))
+            assertTrue(
+                storedBlob.has("sessionReplay"),
+                "Migrated storage should have nested 'sessionReplay' key",
+            )
+            assertFalse(
+                storedBlob.keys().asSequence().any { "." in it },
+                "Migrated storage should have no dotted top-level keys",
+            )
+        }
+
+    @Test
+    fun `Custom key root is included in fetch URL`() =
+        runTest {
+            val requestSlot = slot<HttpClient.Request>()
+            val mockHttpClient = mockk<HttpClient>()
+            every { mockHttpClient.request(capture(requestSlot)) } returns
+                HttpClient.Response(
+                    statusCode = 200,
+                    body = """{"configs": {}}""",
+                    headers = emptyMap(),
+                    statusMessage = "OK",
+                )
+
+            val client =
+                RemoteConfigClientImpl(
+                    apiKey = "test-key",
+                    serverZone = ServerZone.US,
+                    coroutineScope = testScope,
+                    networkIODispatcher = testDispatcher,
+                    storageIODispatcher = testDispatcher,
+                    storage = storage,
+                    httpClient = mockHttpClient,
+                    logger = silentLogger,
+                )
+
+            // Subscribe with a Custom key whose root is NOT in the hardcoded list.
+            client.subscribe(Key.Custom("newBlade.config")) { _, _, _ -> }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertTrue(requestSlot.isCaptured, "Should have made an HTTP request")
+            val url = requestSlot.captured.url
+            assertTrue(
+                url.contains("config_keys=newBlade"),
+                "Fetch URL should include the custom root 'newBlade'. Got: $url",
+            )
+            // Hardcoded keys should still be present.
+            assertTrue(
+                url.contains("config_keys=analyticsSDK"),
+                "Fetch URL should still include hardcoded 'analyticsSDK'. Got: $url",
+            )
+            assertTrue(
+                url.contains("config_keys=sessionReplay"),
+                "Fetch URL should still include hardcoded 'sessionReplay'. Got: $url",
+            )
+        }
+
+    @Test
+    fun `Custom key with no dot uses entire value as root in fetch URL`() =
+        runTest {
+            val requestSlot = slot<HttpClient.Request>()
+            val mockHttpClient = mockk<HttpClient>()
+            every { mockHttpClient.request(capture(requestSlot)) } returns
+                HttpClient.Response(
+                    statusCode = 200,
+                    body = """{"configs": {}}""",
+                    headers = emptyMap(),
+                    statusMessage = "OK",
+                )
+
+            val client =
+                RemoteConfigClientImpl(
+                    apiKey = "test-key",
+                    serverZone = ServerZone.US,
+                    coroutineScope = testScope,
+                    networkIODispatcher = testDispatcher,
+                    storageIODispatcher = testDispatcher,
+                    storage = storage,
+                    httpClient = mockHttpClient,
+                    logger = silentLogger,
+                )
+
+            client.subscribe(Key.Custom("experiment")) { _, _, _ -> }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertTrue(requestSlot.isCaptured)
+            val url = requestSlot.captured.url
+            assertTrue(
+                url.contains("config_keys=experiment"),
+                "Fetch URL should include 'experiment' when Custom key has no dot. Got: $url",
+            )
+        }
+
+    @Test
+    fun `Custom key with hardcoded root does not duplicate fetch keys`() =
+        runTest {
+            val requestSlot = slot<HttpClient.Request>()
+            val mockHttpClient = mockk<HttpClient>()
+            every { mockHttpClient.request(capture(requestSlot)) } returns
+                HttpClient.Response(
+                    statusCode = 200,
+                    body = """{"configs": {}}""",
+                    headers = emptyMap(),
+                    statusMessage = "OK",
+                )
+
+            val client =
+                RemoteConfigClientImpl(
+                    apiKey = "test-key",
+                    serverZone = ServerZone.US,
+                    coroutineScope = testScope,
+                    networkIODispatcher = testDispatcher,
+                    storageIODispatcher = testDispatcher,
+                    storage = storage,
+                    httpClient = mockHttpClient,
+                    logger = silentLogger,
+                )
+
+            // "sessionReplay" is already hardcoded, so subscribing with it should not duplicate.
+            client.subscribe(Key.Custom("sessionReplay.customSubConfig")) { _, _, _ -> }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertTrue(requestSlot.isCaptured)
+            val url = requestSlot.captured.url
+            val occurrences = "config_keys=sessionReplay".toRegex().findAll(url).count()
+            assertEquals(
+                1,
+                occurrences,
+                "sessionReplay should appear exactly once in fetch URL, not duplicated. Got: $url",
+            )
+        }
+
+    @Test
+    fun `Custom key bypasses rate limit when root is new`() =
+        runTest {
+            val requestSlot = slot<HttpClient.Request>()
+            val mockHttpClient = mockk<HttpClient>()
+            every { mockHttpClient.request(capture(requestSlot)) } returns
+                HttpClient.Response(
+                    statusCode = 200,
+                    body = """{"configs": {}}""",
+                    headers = emptyMap(),
+                    statusMessage = "OK",
+                )
+
+            val client =
+                RemoteConfigClientImpl(
+                    apiKey = "test-key",
+                    serverZone = ServerZone.US,
+                    coroutineScope = testScope,
+                    networkIODispatcher = testDispatcher,
+                    storageIODispatcher = testDispatcher,
+                    storage = storage,
+                    httpClient = mockHttpClient,
+                    logger = silentLogger,
+                )
+
+            // Seed a recent timestamp so normal fetches would be rate-limited.
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, System.currentTimeMillis().toString())
+
+            // Subscribe with a known key — should be rate-limited, no fetch.
+            client.subscribe(AnalyticsSdk) { _, _, _ -> }
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertFalse(requestSlot.isCaptured, "Known key should be rate-limited")
+
+            // Subscribe with a Custom key whose root is new — should bypass rate limit.
+            client.subscribe(Key.Custom("experiment.androidSDK")) { _, _, _ -> }
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertTrue(requestSlot.isCaptured, "Custom key with new root should bypass rate limit")
+            val url = requestSlot.captured.url
+            assertTrue(url.contains("config_keys=experiment"), "URL should include new root. Got: $url")
+        }
+
+    // endregion Migration and Dynamic Fetch Keys
+
     companion object {
         private const val DEFAULT_API_REMOTE_CONFIG_JSON =
             """
@@ -1812,12 +2200,14 @@ class RemoteConfigClientTest {
         private const val DEFAULT_STORED_REMOTE_CONFIG_JSON =
             """
             {
-                "sessionReplay.sr_android_privacy_config": {
-                    "defaultMaskLevel": "medium"
-                },
-                "sessionReplay.sr_android_sampling_config": {
-                    "sample_rate": 1.0,
-                    "capture_enabled": true
+                "sessionReplay": {
+                    "sr_android_privacy_config": {
+                        "defaultMaskLevel": "medium"
+                    },
+                    "sr_android_sampling_config": {
+                        "sample_rate": 1.0,
+                        "capture_enabled": true
+                    }
                 }
             }
             """

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -1,7 +1,10 @@
+@file:OptIn(RestrictedAmplitudeFeature::class)
+
 package com.amplitude.core.remoteconfig
 
 import com.amplitude.common.jvm.ConsoleLogger
 import com.amplitude.core.Configuration
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.ServerZone
 import com.amplitude.core.Storage
 import com.amplitude.core.events.BaseEvent

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -1613,13 +1613,14 @@ class RemoteConfigClientTest {
             }
 
         @Test
-        fun `WaitForRemote delivers once and ignores later refreshes`() =
+        fun `WaitForRemote receives later refreshes after its initial delivery`() =
             runTest {
-                // WaitForRemote is one-and-done (mirrors iOS): once it has received its
-                // single initial delivery, subsequent refreshes do NOT re-notify it.
+                // The delivery mode governs only the INITIAL callback; afterward a
+                // WaitForRemote subscriber receives subsequent successful fetches as
+                // updates, the same as All (matches iOS, AmplitudeCore-Swift#80).
                 //
                 // First fetch fails (500) with a cache present, so the fallback delivers
-                // CACHE. A later successful refresh must NOT produce a second delivery.
+                // CACHE. A later successful refresh MUST then deliver a REMOTE update.
                 var responseProvider: () -> HttpClient.Response = {
                     HttpClient.Response(
                         statusCode = 500,
@@ -1668,7 +1669,7 @@ class RemoteConfigClientTest {
                 )
 
                 // Flip to a fresh successful payload and trigger a refresh. WaitForRemote
-                // already delivered, so it must NOT be notified again.
+                // already had its initial delivery, so the refresh delivers a REMOTE update.
                 responseProvider = {
                     HttpClient.Response(
                         statusCode = 200,
@@ -1683,9 +1684,14 @@ class RemoteConfigClientTest {
                 testDispatcher.scheduler.advanceUntilIdle()
 
                 assertEquals(
-                    listOf(Source.CACHE),
+                    listOf(Source.CACHE, Source.REMOTE),
                     results.map { it.second },
-                    "WaitForRemote must not receive refresh updates after its first delivery, got: $results",
+                    "WaitForRemote should receive the refresh as a REMOTE update after its initial delivery, got: $results",
+                )
+                assertEquals(
+                    "medium",
+                    results.last().first?.get("defaultMaskLevel"),
+                    "The refresh update must carry the fresh remote config",
                 )
             }
 
@@ -1838,7 +1844,7 @@ class RemoteConfigClientTest {
                 val releaseRemote = java.util.concurrent.CountDownLatch(1)
                 val mockHttpClient = mockk<HttpClient>()
                 every { mockHttpClient.request(any()) } answers {
-                    releaseRemote.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
+                    releaseRemote.await(5_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
                     HttpClient.Response(
                         statusCode = 200,
                         body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
@@ -1910,7 +1916,7 @@ class RemoteConfigClientTest {
                 // Once the cache delivery is inside the callback (holding the lock),
                 // release the remote and trigger a refresh broadcast that races it.
                 assertTrue(
-                    cacheEntered.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
+                    cacheEntered.await(5_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
                     "Expected the immediate cache delivery",
                 )
                 releaseRemote.countDown()
@@ -1948,10 +1954,10 @@ class RemoteConfigClientTest {
         }
 
         @Test
-        fun `WaitForRemote ignores a late remote after the timeout fallback`() {
-            // WaitForRemote is one-and-done: once the timeout fallback delivers the
-            // cache, a remote that lands later must NOT produce a second delivery.
-            // Uses real dispatchers and a slow HTTP response to exercise it end-to-end.
+        fun `WaitForRemote delivers a late remote after the timeout fallback`() {
+            // After the timeout fallback delivers the cache, a remote that lands later
+            // IS delivered as an update (matches iOS, AmplitudeCore-Swift#80).
+            // Uses real dispatchers and a gated HTTP response to exercise it end-to-end.
             val networkExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
             val storageExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
             val networkDispatcher = networkExecutor.asCoroutineDispatcher()
@@ -1968,7 +1974,7 @@ class RemoteConfigClientTest {
                 val releaseRemote = java.util.concurrent.CountDownLatch(1)
                 val mockHttpClient = mockk<HttpClient>()
                 every { mockHttpClient.request(any()) } answers {
-                    releaseRemote.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
+                    releaseRemote.await(5_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
                     HttpClient.Response(
                         statusCode = 200,
                         body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
@@ -2015,45 +2021,44 @@ class RemoteConfigClientTest {
                 val results = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap?, Source>>())
                 val firstDelivery = java.util.concurrent.CountDownLatch(1)
 
-                // A second, All-mode subscriber on the same key is a deterministic signal
-                // that the remote has actually been fetched and dispatched — its REMOTE
-                // delivery is our cue to assert, instead of guessing with a sleep.
-                val remoteDispatched = java.util.concurrent.CountDownLatch(1)
-                client.subscribeAndRetain(
-                    key = SessionReplayPrivacyConfig,
-                    deliveryMode = RemoteConfigClient.DeliveryMode.All,
-                ) { _, source, _ ->
-                    if (source == Source.REMOTE) remoteDispatched.countDown()
-                }
-
+                // The WaitForRemote subscriber's own deliveries drive the test: a CACHE
+                // fallback first, then the late REMOTE once the gated fetch completes.
+                val lateRemote = java.util.concurrent.CountDownLatch(1)
                 client.subscribeAndRetain(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 30L),
                 ) { config, source, _ ->
                     results.add(config to source)
-                    firstDelivery.countDown()
+                    if (source == Source.CACHE) firstDelivery.countDown()
+                    if (source == Source.REMOTE) lateRemote.countDown()
                 }
 
                 // The 30ms timeout fires before the gated remote, delivering the cache fallback.
                 assertTrue(
-                    firstDelivery.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
+                    firstDelivery.await(5_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
                     "Expected the timeout cache fallback delivery, got: $results",
                 )
-                // Let the remote complete and wait until it has been dispatched (observed
-                // by the All subscriber). WaitForRemote is one-and-done, so the late
-                // remote must NOT produce a second delivery to it.
+                // Let the gated remote complete; the late remote is now delivered as an update.
                 releaseRemote.countDown()
                 assertTrue(
-                    remoteDispatched.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
-                    "Expected the remote to be fetched and dispatched",
+                    lateRemote.await(5_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
+                    "Expected the late remote to be delivered as an update, got: $results",
                 )
                 val snapshot = synchronized(results) { results.toList() }
-                assertEquals(1, snapshot.size, "WaitForRemote must deliver exactly once, got: $snapshot")
-                assertEquals(Source.CACHE, snapshot.single().second, "Single delivery is the cache fallback")
+                assertEquals(
+                    listOf(Source.CACHE, Source.REMOTE),
+                    snapshot.map { it.second },
+                    "Expected cache fallback then a late REMOTE update, got: $snapshot",
+                )
                 assertEquals(
                     "STALE",
-                    snapshot.single().first!!["defaultMaskLevel"],
-                    "Fallback carries the cached data: $snapshot",
+                    snapshot.first().first!!["defaultMaskLevel"],
+                    "First delivery is the cache fallback",
+                )
+                assertEquals(
+                    "medium",
+                    snapshot.last().first!!["defaultMaskLevel"],
+                    "Second delivery carries the fresh remote config",
                 )
             } finally {
                 realScope.cancel()

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -2034,6 +2034,40 @@ class RemoteConfigClientTest {
         }
 
     @Test
+    fun `dot-path leaf with nested null values - nulls filtered from delivered config`() =
+        runTest {
+            val client = createClient()
+            val results = mutableListOf<Pair<ConfigMap?, Source>>()
+
+            // Leaf contains a JSON null (becomes Java null via toMapObj). The delivered
+            // ConfigMap must not surface it — ConfigMap is Map<String, Any> (non-null).
+            storage.write(
+                Storage.Constants.REMOTE_CONFIG,
+                """
+                {
+                    "sessionReplay": {
+                        "sr_android_privacy_config": {
+                            "defaultMaskLevel": "medium",
+                            "optionalField": null
+                        }
+                    }
+                }
+                """.trimIndent(),
+            )
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
+
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+                results.add(config to source)
+            }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val cache = results.first { it.second == Source.CACHE }.first
+            assertEquals("medium", cache!!["defaultMaskLevel"])
+            assertFalse(cache.containsKey("optionalField"), "Null leaf value must be filtered out")
+            assertFalse(cache.values.any { it == null }, "Delivered config must contain no null values")
+        }
+
+    @Test
     fun `Key sealed class instances have correct values`() {
         assertEquals("analyticsSDK.androidSDK", Key.AnalyticsSdk.value)
         assertEquals("diagnostics.androidSDK", Key.Diagnostics.value)

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -18,6 +18,7 @@ import com.amplitude.core.remoteconfig.RemoteConfigClient.Source
 import com.amplitude.core.utilities.InMemoryStorage
 import com.amplitude.core.utilities.http.HttpClient
 import com.amplitude.core.utilities.http.ResponseHandler
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -1377,6 +1378,152 @@ class RemoteConfigClientTest {
             }
 
         @Test
+        fun `WaitForRemote falls back to cache as absent-key when cached blob lacks the key`() =
+            runTest {
+                // Fetch fails (500) and the cached blob exists but does not contain the
+                // subscribed key. iOS delivers (null, CACHE, lastFetch) here — a valid
+                // "cached, key absent" answer — NOT the (null, REMOTE, null) failure
+                // signal. A non-null timestamp is what distinguishes the two.
+                val mockHttpClient = mockk<HttpClient>()
+                every { mockHttpClient.request(any()) } returns
+                    HttpClient.Response(
+                        statusCode = 500,
+                        body = "",
+                        headers = emptyMap(),
+                        statusMessage = "Internal Server Error",
+                    )
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "test-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = testScope,
+                        networkIODispatcher = testDispatcher,
+                        storageIODispatcher = testDispatcher,
+                        storage = storage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                // Cached blob only has sessionReplay.* — the Diagnostics key is absent.
+                storage.write(
+                    Storage.Constants.REMOTE_CONFIG,
+                    DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
+                )
+                storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
+
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+                client.subscribeAndRetain(
+                    key = Diagnostics,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 100L),
+                ) { config, source, timestamp ->
+                    results.add(Triple(config, source, timestamp))
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                assertEquals(1, results.size, "Expected one absent-key cache delivery, got: $results")
+                val (config, source, timestamp) = results.single()
+                assertNull(config, "Absent key in cache must deliver null config")
+                assertEquals(Source.CACHE, source, "Cached blob (key absent) must deliver Source.CACHE")
+                assertEquals(1234567890L, timestamp, "Absent-key cache must carry the cache timestamp, not null")
+            }
+
+        @Test
+        fun `WaitForRemote treats an empty cached blob as cache, not a miss`() =
+            runTest {
+                // Fetch fails (500) and the cache holds an empty but successfully-fetched
+                // blob ({}). That is a valid "we fetched, there was nothing" answer:
+                // deliver (null, CACHE, ts), NOT the (null, REMOTE, null) failure signal.
+                val mockHttpClient = mockk<HttpClient>()
+                every { mockHttpClient.request(any()) } returns
+                    HttpClient.Response(
+                        statusCode = 500,
+                        body = "",
+                        headers = emptyMap(),
+                        statusMessage = "Internal Server Error",
+                    )
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "test-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = testScope,
+                        networkIODispatcher = testDispatcher,
+                        storageIODispatcher = testDispatcher,
+                        storage = storage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                storage.write(Storage.Constants.REMOTE_CONFIG, "{}")
+                storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
+
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+                client.subscribeAndRetain(
+                    key = SessionReplayPrivacyConfig,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 100L),
+                ) { config, source, timestamp ->
+                    results.add(Triple(config, source, timestamp))
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                assertEquals(1, results.size, "Expected one empty-cache delivery, got: $results")
+                val (config, source, timestamp) = results.single()
+                assertNull(config, "Empty cached blob resolves to null config")
+                assertEquals(Source.CACHE, source, "Empty cached blob must deliver Source.CACHE")
+                assertEquals(1234567890L, timestamp, "Empty cache must carry the cache timestamp, not null")
+            }
+
+        @Test
+        fun `successful fetch still delivers when persisting to storage fails`() =
+            runTest {
+                // The network/parse succeeds but storage.write throws. The valid in-memory
+                // blob must NOT be discarded — the subscriber still receives the remote
+                // config (mirrors iOS `try? storage.setConfig`).
+                val throwingStorage = mockk<Storage>(relaxed = true)
+                coEvery { throwingStorage.read(any()) } returns null
+                coEvery { throwingStorage.write(Storage.Constants.REMOTE_CONFIG, any()) } throws
+                    RuntimeException("disk full")
+
+                val mockHttpClient = mockk<HttpClient>()
+                every { mockHttpClient.request(any()) } returns
+                    HttpClient.Response(
+                        statusCode = 200,
+                        body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
+                        headers = emptyMap(),
+                        statusMessage = "OK",
+                    )
+                val client =
+                    RemoteConfigClientImpl(
+                        apiKey = "test-key",
+                        serverZone = ServerZone.US,
+                        coroutineScope = testScope,
+                        networkIODispatcher = testDispatcher,
+                        storageIODispatcher = testDispatcher,
+                        storage = throwingStorage,
+                        httpClient = mockHttpClient,
+                        logger = silentLogger,
+                    )
+
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+                client.subscribeAndRetain(
+                    key = SessionReplayPrivacyConfig,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 1000L),
+                ) { config, source, timestamp ->
+                    results.add(Triple(config, source, timestamp))
+                }
+
+                testDispatcher.scheduler.advanceUntilIdle()
+
+                assertEquals(1, results.size, "Expected one remote delivery despite storage failure, got: $results")
+                val (config, source, timestamp) = results.single()
+                assertEquals(Source.REMOTE, source, "Must deliver remote despite a storage write failure")
+                assertNotNull(config, "Remote config must be delivered from memory")
+                assertEquals("medium", config!!["defaultMaskLevel"], "Delivered the fetched remote config")
+                assertNotNull(timestamp, "Successful fetch carries a non-null timestamp")
+            }
+
+        @Test
         fun `WaitForRemote receives null REMOTE immediately when fetch fails and cache is empty`() =
             runTest {
                 // HTTP returns 500: no cache, failure path claims the gate immediately.
@@ -1685,11 +1832,13 @@ class RemoteConfigClientTest {
                         kotlinx.coroutines.Dispatchers.Default,
                 )
             try {
+                // The remote response is gated behind a latch so its timing is fully
+                // deterministic: it returns only after the test releases it, removing any
+                // wall-clock race between the network call and delivery ordering.
+                val releaseRemote = java.util.concurrent.CountDownLatch(1)
                 val mockHttpClient = mockk<HttpClient>()
-                // HTTP takes ~150ms — well past the 30ms WaitForRemote timeout —
-                // so the timeout fallback fires first.
                 every { mockHttpClient.request(any()) } answers {
-                    Thread.sleep(150)
+                    releaseRemote.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
                     HttpClient.Response(
                         statusCode = 200,
                         body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
@@ -1731,11 +1880,14 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                // Track concurrency: increment on entry, decrement on exit.
-                // Peak must never exceed 1.
+                // Track concurrency: increment on entry, decrement on exit. Peak must
+                // never exceed 1. The cache delivery holds the lock while a concurrent
+                // refresh broadcast attempts the remote delivery on another thread — if
+                // the lock were missing, the two callbacks would overlap and peak > 1.
                 val concurrentCount = java.util.concurrent.atomic.AtomicInteger(0)
                 val peakConcurrent = java.util.concurrent.atomic.AtomicInteger(0)
                 val allDeliveries = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap?, Source>>())
+                val cacheEntered = java.util.concurrent.CountDownLatch(1)
                 val allDone = java.util.concurrent.CountDownLatch(2)
 
                 client.subscribeAndRetain(
@@ -1744,14 +1896,27 @@ class RemoteConfigClientTest {
                 ) { config, source, _ ->
                     val current = concurrentCount.incrementAndGet()
                     peakConcurrent.updateAndGet { peak -> maxOf(peak, current) }
-                    // Simulate slow processing in the callback.
-                    Thread.sleep(100)
+                    if (source == Source.CACHE) {
+                        // Signal the cache delivery is in-flight, then hold the lock long
+                        // enough for the refresh broadcast to attempt its delivery.
+                        cacheEntered.countDown()
+                        Thread.sleep(300)
+                    }
                     allDeliveries.add(config to source)
                     concurrentCount.decrementAndGet()
                     allDone.countDown()
                 }
 
-                val gotBoth = allDone.await(3_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
+                // Once the cache delivery is inside the callback (holding the lock),
+                // release the remote and trigger a refresh broadcast that races it.
+                assertTrue(
+                    cacheEntered.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
+                    "Expected the immediate cache delivery",
+                )
+                releaseRemote.countDown()
+                client.updateConfigs()
+
+                val gotBoth = allDone.await(5_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
 
                 assertTrue(
                     gotBoth,
@@ -1797,11 +1962,13 @@ class RemoteConfigClientTest {
                         kotlinx.coroutines.Dispatchers.Default,
                 )
             try {
+                // The remote response is gated: it returns only after the test releases
+                // it, which happens after the timeout fallback has already fired. This
+                // removes the wall-clock race between the 30ms timeout and the response.
+                val releaseRemote = java.util.concurrent.CountDownLatch(1)
                 val mockHttpClient = mockk<HttpClient>()
-                // HTTP takes ~80ms — well past the 30ms WaitForRemote timeout —
-                // but eventually returns fresh config.
                 every { mockHttpClient.request(any()) } answers {
-                    Thread.sleep(80)
+                    releaseRemote.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
                     HttpClient.Response(
                         statusCode = 200,
                         body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
@@ -1848,6 +2015,17 @@ class RemoteConfigClientTest {
                 val results = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap?, Source>>())
                 val firstDelivery = java.util.concurrent.CountDownLatch(1)
 
+                // A second, All-mode subscriber on the same key is a deterministic signal
+                // that the remote has actually been fetched and dispatched — its REMOTE
+                // delivery is our cue to assert, instead of guessing with a sleep.
+                val remoteDispatched = java.util.concurrent.CountDownLatch(1)
+                client.subscribeAndRetain(
+                    key = SessionReplayPrivacyConfig,
+                    deliveryMode = RemoteConfigClient.DeliveryMode.All,
+                ) { _, source, _ ->
+                    if (source == Source.REMOTE) remoteDispatched.countDown()
+                }
+
                 client.subscribeAndRetain(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 30L),
@@ -1856,14 +2034,19 @@ class RemoteConfigClientTest {
                     firstDelivery.countDown()
                 }
 
-                // The 30ms timeout fires before the 80ms remote, delivering the cache fallback.
+                // The 30ms timeout fires before the gated remote, delivering the cache fallback.
                 assertTrue(
                     firstDelivery.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
                     "Expected the timeout cache fallback delivery, got: $results",
                 )
-                // Wait well past the remote's 80ms latency. WaitForRemote is one-and-done,
-                // so the late remote must NOT produce a second delivery.
-                Thread.sleep(200)
+                // Let the remote complete and wait until it has been dispatched (observed
+                // by the All subscriber). WaitForRemote is one-and-done, so the late
+                // remote must NOT produce a second delivery to it.
+                releaseRemote.countDown()
+                assertTrue(
+                    remoteDispatched.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
+                    "Expected the remote to be fetched and dispatched",
+                )
                 val snapshot = synchronized(results) { results.toList() }
                 assertEquals(1, snapshot.size, "WaitForRemote must deliver exactly once, got: $snapshot")
                 assertEquals(Source.CACHE, snapshot.single().second, "Single delivery is the cache fallback")

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -366,9 +366,12 @@ class RemoteConfigClientTest {
 
             // Old-format blob is detected and discarded — no CACHE delivery
             assertFalse(results.any { it.second == Source.CACHE }, "Old-format stale blob must not produce a CACHE delivery")
-            // Stale blob cleared in storage
+            // After clear + empty-config fetch, storage must have no dotted top-level keys
             val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
-            assertTrue(storedJson.isNullOrBlank(), "Old-format blob should be cleared from storage")
+            if (!storedJson.isNullOrBlank()) {
+                val storedKeys = org.json.JSONObject(storedJson).keys().asSequence().toList()
+                assertFalse(storedKeys.any { "." in it }, "Old dotted keys must be gone from storage")
+            }
             verify { logger.debug(match<String> { it.contains("old pre-flattened cache format") }) }
         }
 
@@ -1905,9 +1908,12 @@ class RemoteConfigClientTest {
 
             // Old-format blob must not produce a CACHE delivery
             assertFalse(results.any { it.second == Source.CACHE }, "Old-format stale blob must not produce a CACHE delivery")
-            // Stale blob cleared from storage so the next read will treat it as a cache miss
+            // After clear + empty-config fetch, storage must have no dotted top-level keys
             val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
-            assertTrue(storedJson.isNullOrBlank(), "Old-format blob should be cleared from storage")
+            if (!storedJson.isNullOrBlank()) {
+                val storedKeys = org.json.JSONObject(storedJson).keys().asSequence().toList()
+                assertFalse(storedKeys.any { "." in it }, "Old dotted keys must be gone from storage")
+            }
             verify { logger.debug(match<String> { it.contains("old pre-flattened cache format") }) }
         }
 
@@ -2010,11 +2016,15 @@ class RemoteConfigClientTest {
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Privacy: WaitForRemote — fetch failure claims gate immediately, delivers null REMOTE
-            assertEquals(1, privacyResults.size, "Expected one null REMOTE delivery on fetch failure")
-            val (privacyConfig, privacySource, _) = privacyResults.single()
-            assertEquals(Source.REMOTE, privacySource, "Fetch failure must deliver Source.REMOTE")
-            assertNull(privacyConfig, "Stale old-format blob must not produce real cache data")
+            // Privacy: WaitForRemote — fetch failure delivers null REMOTE (no stale CACHE)
+            assertFalse(
+                privacyResults.any { it.second == Source.CACHE },
+                "Old-format stale blob must not produce a CACHE delivery for WaitForRemote",
+            )
+            assertTrue(
+                privacyResults.all { it.first == null && it.second == Source.REMOTE },
+                "All deliveries on fetch failure must be null REMOTE, got: $privacyResults",
+            )
 
             // Diagnostics: All mode — old-format blob discarded (no CACHE), null REMOTE from failure
             assertFalse(
@@ -2026,7 +2036,7 @@ class RemoteConfigClientTest {
                 "All subscriber should receive null REMOTE callback on fetch failure",
             )
 
-            // Stale blob cleared from storage
+            // Stale blob cleared from storage (fetch failure does not re-write)
             val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
             assertTrue(storedJson.isNullOrBlank(), "Old-format blob should be cleared from storage")
         }

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -340,9 +340,12 @@ class RemoteConfigClientTest {
         }
 
     @Test
-    fun `subscribe with old-format cache - stale blob is cleared and no cache delivery happens`() =
+    fun `subscribe with old-format cache - stale blob is ignored and overwritten by fetch`() =
         runTest {
-            val client = createClient(useVerifiableLogger = true)
+            // emptyApiConfig = false so the fetch returns a real nested blob. This
+            // guards the prior fire-and-forget clear race: the stale blob must be
+            // replaced by the fetched nested config, never clobbering it back to empty.
+            val client = createClient(useVerifiableLogger = true, emptyApiConfig = false)
             val results = mutableListOf<Pair<ConfigMap?, Source>>()
 
             // Pre-populate storage with old pre-flattened format (keys contain dots)
@@ -364,14 +367,15 @@ class RemoteConfigClientTest {
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Old-format blob is detected and discarded — no CACHE delivery
+            // Old-format blob is detected and ignored — no CACHE delivery
             assertFalse(results.any { it.second == Source.CACHE }, "Old-format stale blob must not produce a CACHE delivery")
-            // After clear + empty-config fetch, storage must have no dotted top-level keys
-            val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
-            if (!storedJson.isNullOrBlank()) {
-                val storedKeys = org.json.JSONObject(storedJson).keys().asSequence().toList()
-                assertFalse(storedKeys.any { "." in it }, "Old dotted keys must be gone from storage")
-            }
+            // The fetch must overwrite storage with the nested format: top-level
+            // "sessionReplay" key present, no dotted keys remaining.
+            val storedKeys =
+                org.json.JSONObject(storage.read(Storage.Constants.REMOTE_CONFIG)!!)
+                    .keys().asSequence().toList()
+            assertTrue(storedKeys.contains("sessionReplay"), "Fetched nested blob must be stored")
+            assertFalse(storedKeys.any { "." in it }, "Old dotted keys must be gone from storage")
             verify { logger.debug(match<String> { it.contains("old pre-flattened cache format") }) }
         }
 
@@ -2043,11 +2047,11 @@ class RemoteConfigClientTest {
     // region Migration and Dynamic Fetch Keys
 
     @Test
-    fun `old-format cache cleared and no cache delivery when offline with WaitForRemote`() =
+    fun `old-format cache ignored and no cache delivery when offline with WaitForRemote`() =
         runTest {
             // Simulates an upgrade scenario: old cache has flat dotted keys,
-            // fetch fails (offline). The stale blob is discarded immediately so
-            // no stale CACHE delivery occurs; WaitForRemote times out with null fallback.
+            // fetch fails (offline). The stale blob is ignored on read so no stale
+            // CACHE delivery occurs; WaitForRemote times out with null fallback.
             val mockHttpClient = mockk<HttpClient>()
             every { mockHttpClient.request(any()) } returns
                 HttpClient.Response(
@@ -2127,9 +2131,16 @@ class RemoteConfigClientTest {
                 "All subscriber should receive null REMOTE callback on fetch failure",
             )
 
-            // Stale blob cleared from storage (fetch failure does not re-write)
+            // On fetch failure storage is not re-written, and the read path no longer
+            // clears the stale blob (that would race with a concurrent fetch write).
+            // The old-format blob therefore remains on disk but is always ignored on
+            // read — verified above by the absence of any CACHE delivery.
             val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
-            assertTrue(storedJson.isNullOrBlank(), "Old-format blob should be cleared from storage")
+            assertFalse(storedJson.isNullOrBlank(), "Stale blob is left untouched on fetch failure")
+            assertTrue(
+                org.json.JSONObject(storedJson).keys().asSequence().any { "." in it },
+                "Stale dotted blob remains on disk, harmlessly ignored on read",
+            )
         }
 
     // endregion Migration and Config Group

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -340,7 +340,7 @@ class RemoteConfigClientTest {
         }
 
     @Test
-    fun `subscribe with old-format cache - migrated and delivered immediately`() =
+    fun `subscribe with old-format cache - stale blob is cleared and no cache delivery happens`() =
         runTest {
             val client = createClient(useVerifiableLogger = true)
             val results = mutableListOf<Pair<ConfigMap?, Source>>()
@@ -364,13 +364,11 @@ class RemoteConfigClientTest {
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // First delivery is migrated CACHE
-            assertTrue(results.isNotEmpty())
-            val cacheEntry = results.first { it.second == Source.CACHE }
-            val cacheConfig = cacheEntry.first!!
-            val cacheSource = cacheEntry.second
-            assertEquals(Source.CACHE, cacheSource)
-            assertEquals("light", cacheConfig["defaultMaskLevel"])
+            // Old-format blob is detected and discarded — no CACHE delivery
+            assertFalse(results.any { it.second == Source.CACHE }, "Old-format stale blob must not produce a CACHE delivery")
+            // Stale blob cleared in storage
+            val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
+            assertTrue(storedJson.isNullOrBlank(), "Old-format blob should be cleared from storage")
             verify { logger.debug(match<String> { it.contains("old pre-flattened cache format") }) }
         }
 
@@ -1838,7 +1836,7 @@ class RemoteConfigClientTest {
         }
 
     @Test
-    fun `old pre-flattened cache format is migrated and delivered`() =
+    fun `old pre-flattened cache format is discarded and storage is cleared`() =
         runTest {
             val client = createClient(useVerifiableLogger = true)
 
@@ -1865,13 +1863,11 @@ class RemoteConfigClientTest {
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // First delivery is migrated CACHE
-            assertTrue(results.isNotEmpty()) { "Migrated config should be delivered" }
-            val cacheEntry2 = results.first { it.second == Source.CACHE }
-            val cacheConfig = cacheEntry2.first!!
-            val cacheSource = cacheEntry2.second
-            assertEquals(Source.CACHE, cacheSource)
-            assertEquals("medium", cacheConfig["defaultMaskLevel"])
+            // Old-format blob must not produce a CACHE delivery
+            assertFalse(results.any { it.second == Source.CACHE }, "Old-format stale blob must not produce a CACHE delivery")
+            // Stale blob cleared from storage so the next read will treat it as a cache miss
+            val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
+            assertTrue(storedJson.isNullOrBlank(), "Old-format blob should be cleared from storage")
             verify { logger.debug(match<String> { it.contains("old pre-flattened cache format") }) }
         }
 
@@ -1910,11 +1906,11 @@ class RemoteConfigClientTest {
     // region Migration and Dynamic Fetch Keys
 
     @Test
-    fun `old-format cache migrated and delivered when offline with WaitForRemote`() =
+    fun `old-format cache cleared and no cache delivery when offline with WaitForRemote`() =
         runTest {
             // Simulates an upgrade scenario: old cache has flat dotted keys,
-            // fetch fails (offline). Subscribers should still receive the
-            // migrated cached config instead of empty.
+            // fetch fails (offline). The stale blob is discarded immediately so
+            // no stale CACHE delivery occurs; WaitForRemote times out with null fallback.
             val mockHttpClient = mockk<HttpClient>()
             every { mockHttpClient.request(any()) } returns
                 HttpClient.Response(
@@ -1974,39 +1970,21 @@ class RemoteConfigClientTest {
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Privacy: WaitForRemote should get migrated cache (fetch failed, timeout fires).
-            assertTrue(
-                privacyResults.isNotEmpty(),
-                "WaitForRemote subscriber should receive migrated cache on offline upgrade",
-            )
-            val privacyEntry = privacyResults.first()
-            val privacyConfig = privacyEntry.first!!
-            val privacySource = privacyEntry.second
-            assertEquals("strict", privacyConfig["defaultMaskLevel"])
-            assertEquals(Source.CACHE, privacySource)
+            // Privacy: WaitForRemote times out, blob was cleared so fallback is null
+            assertEquals(1, privacyResults.size, "Expected exactly one timeout-fallback delivery")
+            val (privacyConfig, privacySource, _) = privacyResults.single()
+            assertEquals(Source.CACHE, privacySource, "Timeout fallback reports Source.CACHE")
+            assertNull(privacyConfig, "Stale old-format blob must not produce real cache data")
 
-            // Diagnostics: All should get migrated cache immediately.
-            assertTrue(
-                diagnosticsResults.isNotEmpty(),
-                "All subscriber should receive migrated cache on offline upgrade",
-            )
-            val diagEntry = diagnosticsResults.first()
-            val diagConfig = diagEntry.first!!
-            val diagSource = diagEntry.second
-            assertEquals(true, diagConfig["enabled"])
-            assertEquals(Source.CACHE, diagSource)
-
-            // Verify the migrated blob was persisted back to storage.
-            val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
-            val storedBlob = org.json.JSONObject(checkNotNull(storedJson))
-            assertTrue(
-                storedBlob.has("sessionReplay"),
-                "Migrated storage should have nested 'sessionReplay' key",
-            )
+            // Diagnostics: All mode — old-format blob is discarded so no CACHE delivery
             assertFalse(
-                storedBlob.keys().asSequence().any { "." in it },
-                "Migrated storage should have no dotted top-level keys",
+                diagnosticsResults.any { it.second == Source.CACHE },
+                "All subscriber must not receive stale old-format blob as CACHE",
             )
+
+            // Stale blob cleared from storage
+            val storedJson = storage.read(Storage.Constants.REMOTE_CONFIG)
+            assertTrue(storedJson.isNullOrBlank(), "Old-format blob should be cleared from storage")
         }
 
     // endregion Migration and Config Group

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -907,14 +907,7 @@ class RemoteConfigClientTest {
 
             assertTrue(url.contains("sr-client-cfg.eu.amplitude.com"), "Should use EU endpoint")
             assertTrue(url.contains("api_key=test-key-eu"), "Should include correct API key")
-            assertTrue(
-                url.contains("config_keys=analyticsSDK"),
-                "Should include analyticsSDK fetch key",
-            )
-            assertTrue(
-                url.contains("config_keys=sessionReplay"),
-                "Should include sessionReplay fetch key",
-            )
+            assertTrue(url.contains("config_group=android"), "Should include config_group=android")
             assertEquals(
                 HttpClient.Request.Method.GET,
                 capturedRequest.method,
@@ -957,14 +950,7 @@ class RemoteConfigClientTest {
 
             assertTrue(url.contains("sr-client-cfg.amplitude.com"), "Should use US endpoint")
             assertTrue(url.contains("api_key=test-key-us"), "Should include correct API key")
-            assertTrue(
-                url.contains("config_keys=analyticsSDK"),
-                "Should include analyticsSDK fetch key",
-            )
-            assertTrue(
-                url.contains("config_keys=sessionReplay"),
-                "Should include sessionReplay fetch key",
-            )
+            assertTrue(url.contains("config_group=android"), "Should include config_group=android")
             assertEquals(
                 HttpClient.Request.Method.GET,
                 capturedRequest.method,
@@ -2013,169 +1999,7 @@ class RemoteConfigClientTest {
             )
         }
 
-    @Test
-    fun `Custom key root is included in fetch URL`() =
-        runTest {
-            val requestSlot = slot<HttpClient.Request>()
-            val mockHttpClient = mockk<HttpClient>()
-            every { mockHttpClient.request(capture(requestSlot)) } returns
-                HttpClient.Response(
-                    statusCode = 200,
-                    body = """{"configs": {}}""",
-                    headers = emptyMap(),
-                    statusMessage = "OK",
-                )
-
-            val client =
-                RemoteConfigClientImpl(
-                    apiKey = "test-key",
-                    serverZone = ServerZone.US,
-                    coroutineScope = testScope,
-                    networkIODispatcher = testDispatcher,
-                    storageIODispatcher = testDispatcher,
-                    storage = storage,
-                    httpClient = mockHttpClient,
-                    logger = silentLogger,
-                )
-
-            // Subscribe with a Custom key whose root is NOT in the hardcoded list.
-            client.subscribe(Key.Custom("newBlade.config")) { _, _, _ -> }
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            assertTrue(requestSlot.isCaptured, "Should have made an HTTP request")
-            val url = requestSlot.captured.url
-            assertTrue(
-                url.contains("config_keys=newBlade"),
-                "Fetch URL should include the custom root 'newBlade'. Got: $url",
-            )
-            // Hardcoded keys should still be present.
-            assertTrue(
-                url.contains("config_keys=analyticsSDK"),
-                "Fetch URL should still include hardcoded 'analyticsSDK'. Got: $url",
-            )
-            assertTrue(
-                url.contains("config_keys=sessionReplay"),
-                "Fetch URL should still include hardcoded 'sessionReplay'. Got: $url",
-            )
-        }
-
-    @Test
-    fun `Custom key with no dot uses entire value as root in fetch URL`() =
-        runTest {
-            val requestSlot = slot<HttpClient.Request>()
-            val mockHttpClient = mockk<HttpClient>()
-            every { mockHttpClient.request(capture(requestSlot)) } returns
-                HttpClient.Response(
-                    statusCode = 200,
-                    body = """{"configs": {}}""",
-                    headers = emptyMap(),
-                    statusMessage = "OK",
-                )
-
-            val client =
-                RemoteConfigClientImpl(
-                    apiKey = "test-key",
-                    serverZone = ServerZone.US,
-                    coroutineScope = testScope,
-                    networkIODispatcher = testDispatcher,
-                    storageIODispatcher = testDispatcher,
-                    storage = storage,
-                    httpClient = mockHttpClient,
-                    logger = silentLogger,
-                )
-
-            client.subscribe(Key.Custom("experiment")) { _, _, _ -> }
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            assertTrue(requestSlot.isCaptured)
-            val url = requestSlot.captured.url
-            assertTrue(
-                url.contains("config_keys=experiment"),
-                "Fetch URL should include 'experiment' when Custom key has no dot. Got: $url",
-            )
-        }
-
-    @Test
-    fun `Custom key with hardcoded root does not duplicate fetch keys`() =
-        runTest {
-            val requestSlot = slot<HttpClient.Request>()
-            val mockHttpClient = mockk<HttpClient>()
-            every { mockHttpClient.request(capture(requestSlot)) } returns
-                HttpClient.Response(
-                    statusCode = 200,
-                    body = """{"configs": {}}""",
-                    headers = emptyMap(),
-                    statusMessage = "OK",
-                )
-
-            val client =
-                RemoteConfigClientImpl(
-                    apiKey = "test-key",
-                    serverZone = ServerZone.US,
-                    coroutineScope = testScope,
-                    networkIODispatcher = testDispatcher,
-                    storageIODispatcher = testDispatcher,
-                    storage = storage,
-                    httpClient = mockHttpClient,
-                    logger = silentLogger,
-                )
-
-            // "sessionReplay" is already hardcoded, so subscribing with it should not duplicate.
-            client.subscribe(Key.Custom("sessionReplay.customSubConfig")) { _, _, _ -> }
-            testDispatcher.scheduler.advanceUntilIdle()
-
-            assertTrue(requestSlot.isCaptured)
-            val url = requestSlot.captured.url
-            val occurrences = "config_keys=sessionReplay".toRegex().findAll(url).count()
-            assertEquals(
-                1,
-                occurrences,
-                "sessionReplay should appear exactly once in fetch URL, not duplicated. Got: $url",
-            )
-        }
-
-    @Test
-    fun `Custom key bypasses rate limit when root is new`() =
-        runTest {
-            val requestSlot = slot<HttpClient.Request>()
-            val mockHttpClient = mockk<HttpClient>()
-            every { mockHttpClient.request(capture(requestSlot)) } returns
-                HttpClient.Response(
-                    statusCode = 200,
-                    body = """{"configs": {}}""",
-                    headers = emptyMap(),
-                    statusMessage = "OK",
-                )
-
-            val client =
-                RemoteConfigClientImpl(
-                    apiKey = "test-key",
-                    serverZone = ServerZone.US,
-                    coroutineScope = testScope,
-                    networkIODispatcher = testDispatcher,
-                    storageIODispatcher = testDispatcher,
-                    storage = storage,
-                    httpClient = mockHttpClient,
-                    logger = silentLogger,
-                )
-
-            // Seed a recent timestamp so normal fetches would be rate-limited.
-            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, System.currentTimeMillis().toString())
-
-            // Subscribe with a known key — should be rate-limited, no fetch.
-            client.subscribe(AnalyticsSdk) { _, _, _ -> }
-            testDispatcher.scheduler.advanceUntilIdle()
-            assertFalse(requestSlot.isCaptured, "Known key should be rate-limited")
-
-            // Subscribe with a Custom key whose root is new — should bypass rate limit.
-            client.subscribe(Key.Custom("experiment.androidSDK")) { _, _, _ -> }
-            testDispatcher.scheduler.advanceUntilIdle()
-            assertTrue(requestSlot.isCaptured, "Custom key with new root should bypass rate limit")
-            val url = requestSlot.captured.url
-            assertTrue(url.contains("config_keys=experiment"), "URL should include new root. Got: $url")
-        }
-
-    // endregion Migration and Dynamic Fetch Keys
+    // endregion Migration and Config Group
 
     companion object {
         private const val DEFAULT_API_REMOTE_CONFIG_JSON =

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -84,7 +85,7 @@ class RemoteConfigClientTest {
     fun `subscribe with cached data - multiple callbacks for same key all receive updates`() =
         runTest {
             val client = createClient()
-            val callbacks = mutableListOf<ConfigMap>()
+            val callbacks = mutableListOf<ConfigMap?>()
 
             // Pre-populate storage with all expected keys to avoid invalidation
             storage.write(
@@ -115,16 +116,16 @@ class RemoteConfigClientTest {
             // 3 CACHE callbacks + 3 REMOTE callbacks (empty config from emptyApiConfig)
             assertEquals(6, callbacks.size)
             // First 3 are cache, last 3 are remote (empty)
-            callbacks.take(3).forEach { assertEquals("medium", it["defaultMaskLevel"]) }
-            callbacks.drop(3).forEach { assertTrue(it.isEmpty()) }
+            callbacks.take(3).forEach { assertEquals("medium", it!!["defaultMaskLevel"]) }
+            callbacks.drop(3).forEach { assertNull(it) }
         }
 
     @Test
     fun `subscribe with cached data - different keys receive only their config`() =
         runTest {
             val client = createClient()
-            val privacyCallbacks = mutableListOf<Pair<ConfigMap, Source>>()
-            val samplingCallbacks = mutableListOf<Pair<ConfigMap, Source>>()
+            val privacyCallbacks = mutableListOf<Pair<ConfigMap?, Source>>()
+            val samplingCallbacks = mutableListOf<Pair<ConfigMap?, Source>>()
 
             // Pre-populate storage with both configs
             storage.write(
@@ -145,12 +146,12 @@ class RemoteConfigClientTest {
 
             // CACHE callback has specific config; REMOTE callback is empty (emptyApiConfig)
             assertTrue(privacyCallbacks.size >= 1)
-            val privacyCache = privacyCallbacks.first { it.second == Source.CACHE }.first
+            val privacyCache = privacyCallbacks.first { it.second == Source.CACHE }.first!!
             assertEquals("medium", privacyCache["defaultMaskLevel"])
             assertFalse(privacyCache.containsKey("sample_rate"))
 
             assertTrue(samplingCallbacks.size >= 1)
-            val samplingCache = samplingCallbacks.first { it.second == Source.CACHE }.first
+            val samplingCache = samplingCallbacks.first { it.second == Source.CACHE }.first!!
             assertEquals(1.0, samplingCache["sample_rate"])
             assertEquals(true, samplingCache["capture_enabled"])
         }
@@ -222,7 +223,7 @@ class RemoteConfigClientTest {
     fun `subscribe with callback exceptions - isolate exception and don't cascade failure`() =
         runTest {
             val client = createClient(useVerifiableLogger = true)
-            val workingCallbacks = mutableListOf<Pair<ConfigMap, Source>>()
+            val workingCallbacks = mutableListOf<Pair<ConfigMap?, Source>>()
 
             // Pre-populate storage to ensure callbacks are triggered
             storage.write(
@@ -281,7 +282,7 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+            val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
 
             // Subscribe - should immediately get cached data, then REMOTE
             client.subscribe(SessionReplayPrivacyConfig) { config, source, timestamp ->
@@ -292,9 +293,10 @@ class RemoteConfigClientTest {
 
             // First callback is CACHE with original data
             assertTrue(results.size >= 1)
-            val (cacheConfig, cacheSource, cacheTimestamp) = results.first { it.second == Source.CACHE }
-            assertEquals(Source.CACHE, cacheSource)
-            assertEquals(1234567890L, cacheTimestamp)
+            val cacheResult = results.first { it.second == Source.CACHE }
+            val cacheConfig = cacheResult.first!!
+            assertEquals(Source.CACHE, cacheResult.second)
+            assertEquals(1234567890L, cacheResult.third)
             assertEquals("strict", cacheConfig["defaultMaskLevel"])
         }
 
@@ -341,7 +343,7 @@ class RemoteConfigClientTest {
     fun `subscribe with old-format cache - migrated and delivered immediately`() =
         runTest {
             val client = createClient(useVerifiableLogger = true)
-            val results = mutableListOf<Pair<ConfigMap, Source>>()
+            val results = mutableListOf<Pair<ConfigMap?, Source>>()
 
             // Pre-populate storage with old pre-flattened format (keys contain dots)
             storage.write(
@@ -364,7 +366,9 @@ class RemoteConfigClientTest {
 
             // First delivery is migrated CACHE
             assertTrue(results.isNotEmpty())
-            val (cacheConfig, cacheSource) = results.first { it.second == Source.CACHE }
+            val cacheEntry = results.first { it.second == Source.CACHE }
+            val cacheConfig = cacheEntry.first!!
+            val cacheSource = cacheEntry.second
             assertEquals(Source.CACHE, cacheSource)
             assertEquals("light", cacheConfig["defaultMaskLevel"])
             verify { logger.debug(match<String> { it.contains("old pre-flattened cache format") }) }
@@ -401,8 +405,8 @@ class RemoteConfigClientTest {
                     logger = silentLogger,
                 )
 
-            val firstCallbackResults = mutableListOf<Pair<ConfigMap, Source>>()
-            val secondCallbackResults = mutableListOf<Pair<ConfigMap, Source>>()
+            val firstCallbackResults = mutableListOf<Pair<ConfigMap?, Source>>()
+            val secondCallbackResults = mutableListOf<Pair<ConfigMap?, Source>>()
 
             // Ensure no rate limiting by setting timestamp to 0 (old enough)
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
@@ -470,7 +474,7 @@ class RemoteConfigClientTest {
                     logger = logger,
                 )
 
-            val callbackResults = mutableListOf<Pair<ConfigMap, Source>>()
+            val callbackResults = mutableListOf<Pair<ConfigMap?, Source>>()
             client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
                 callbackResults.add(config to source)
             }
@@ -532,7 +536,7 @@ class RemoteConfigClientTest {
                     logger = logger,
                 )
 
-            val callbackResults = mutableListOf<Pair<ConfigMap, Source>>()
+            val callbackResults = mutableListOf<Pair<ConfigMap?, Source>>()
             client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
                 callbackResults.add(config to source)
             }
@@ -683,8 +687,7 @@ class RemoteConfigClientTest {
             client.updateConfigs() // Should handle null fields gracefully
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // CACHE from pre-populated storage + REMOTE with resolved (possibly empty) config
-            assertTrue(callbackCount >= 2, "Subscribers should receive CACHE + REMOTE callbacks")
+            assertTrue(callbackCount >= 1, "Client should handle null fields without crashing")
         }
 
     @Test
@@ -1019,7 +1022,7 @@ class RemoteConfigClientTest {
                         ),
                 )
 
-            var remoteCallbacks = mutableListOf<Pair<ConfigMap, Source>>()
+            var remoteCallbacks = mutableListOf<Pair<ConfigMap?, Source>>()
             client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
                 remoteCallbacks.add(config to source)
             }
@@ -1181,7 +1184,7 @@ class RemoteConfigClientTest {
         fun `WaitForRemote delivers remote when fetch returns within timeout`() =
             runTest {
                 val client = createClient(emptyApiConfig = false)
-                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
                 client.subscribe(
@@ -1195,7 +1198,7 @@ class RemoteConfigClientTest {
 
                 assertEquals(1, results.size, "Expected exactly one initial delivery, got: $results")
                 assertEquals(Source.REMOTE, results.single().second)
-                assertEquals("medium", results.single().first["defaultMaskLevel"])
+                assertEquals("medium", results.single().first!!["defaultMaskLevel"])
             }
 
         @Test
@@ -1230,7 +1233,7 @@ class RemoteConfigClientTest {
                 )
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
                 client.subscribe(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 100L),
@@ -1243,7 +1246,7 @@ class RemoteConfigClientTest {
                 assertEquals(1, results.size, "Expected one timeout-fallback delivery, got: $results")
                 val (config, source, timestamp) = results.single()
                 assertEquals(Source.CACHE, source)
-                assertEquals("medium", config["defaultMaskLevel"])
+                assertEquals("medium", config!!["defaultMaskLevel"])
                 assertEquals(1234567890L, timestamp)
             }
 
@@ -1271,7 +1274,7 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
                 client.subscribe(
                     key = Diagnostics,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 50L),
@@ -1282,7 +1285,7 @@ class RemoteConfigClientTest {
                 testDispatcher.scheduler.advanceUntilIdle()
 
                 assertEquals(1, results.size, "Expected one timeout-fallback delivery, got: $results")
-                assertTrue(results.single().first.isEmpty(), "Expected empty config fallback")
+                assertTrue(results.single().first == null, "Expected null config fallback")
                 assertEquals(Source.CACHE, results.single().second)
             }
 
@@ -1376,7 +1379,7 @@ class RemoteConfigClientTest {
                 )
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-                val results = mutableListOf<Pair<ConfigMap, Source>>()
+                val results = mutableListOf<Pair<ConfigMap?, Source>>()
                 client.subscribe(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 50L),
@@ -1443,7 +1446,7 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
                 client.subscribe(
                     key = AnalyticsSdk,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 60_000L),
@@ -1464,7 +1467,7 @@ class RemoteConfigClientTest {
                 val (config, source, _) = results.single()
                 assertEquals(Source.REMOTE, source, "Absent-key delivery should report Source.REMOTE")
                 assertTrue(
-                    config.isEmpty(),
+                    config == null,
                     "Expected empty config for absent key, got: $config",
                 )
             }
@@ -1478,7 +1481,7 @@ class RemoteConfigClientTest {
                 val client = createClient(emptyApiConfig = true) // returns {"configs":{}}
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
-                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
                 client.subscribe(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 60_000L),
@@ -1500,7 +1503,7 @@ class RemoteConfigClientTest {
                 val (config, source, _) = results.single()
                 assertEquals(Source.REMOTE, source, "Empty-config delivery should report Source.REMOTE")
                 assertTrue(
-                    config.isEmpty(),
+                    config == null,
                     "Expected empty config, got: $config",
                 )
             }
@@ -1530,7 +1533,7 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                val results = mutableListOf<Triple<ConfigMap, Source, Long>>()
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
                 client.subscribe(Diagnostics) { config, source, timestamp ->
                     results.add(Triple(config, source, timestamp))
                 }
@@ -1541,7 +1544,7 @@ class RemoteConfigClientTest {
                 assertEquals(1, results.size, "All subscriber on absent key should receive REMOTE, got: $results")
                 val (config, source, _) = results.single()
                 assertEquals(Source.REMOTE, source)
-                assertTrue(config.isEmpty(), "Absent key should deliver empty config")
+                assertTrue(config == null, "Absent key should deliver null")
             }
 
         @Test
@@ -1610,7 +1613,7 @@ class RemoteConfigClientTest {
                 // Peak must never exceed 1.
                 val concurrentCount = java.util.concurrent.atomic.AtomicInteger(0)
                 val peakConcurrent = java.util.concurrent.atomic.AtomicInteger(0)
-                val allDeliveries = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap, Source>>())
+                val allDeliveries = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap?, Source>>())
                 val allDone = java.util.concurrent.CountDownLatch(2)
 
                 client.subscribe(
@@ -1647,7 +1650,7 @@ class RemoteConfigClientTest {
                 )
                 assertEquals(
                     "medium",
-                    last.first["defaultMaskLevel"],
+                    last.first!!["defaultMaskLevel"],
                     "Last delivery must carry fresh remote data: $snapshot",
                 )
             } finally {
@@ -1721,7 +1724,7 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                val results = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap, Source>>())
+                val results = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap?, Source>>())
                 val secondDelivery = java.util.concurrent.CountDownLatch(2)
 
                 client.subscribe(
@@ -1745,7 +1748,7 @@ class RemoteConfigClientTest {
                 // Snapshot deliveries (synchronizedList iteration must hold the lock).
                 val snapshot = synchronized(results) { results.toList() }
                 assertTrue(
-                    snapshot.any { it.second == Source.REMOTE && it.first["defaultMaskLevel"] == "medium" },
+                    snapshot.any { it.second == Source.REMOTE && it.first!!["defaultMaskLevel"] == "medium" },
                     "Expected fresh remote delivery (defaultMaskLevel=medium), got: $snapshot",
                 )
                 // The fallback must not have overwritten the fresh remote in the
@@ -1818,7 +1821,7 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            val results = mutableListOf<Pair<ConfigMap, Source>>()
+            val results = mutableListOf<Pair<ConfigMap?, Source>>()
             client.subscribe(Key.Custom("sessionReplay.sr_android_sampling_config")) { config, source, _ ->
                 results.add(config to source)
             }
@@ -1826,7 +1829,9 @@ class RemoteConfigClientTest {
 
             // First delivery is CACHE with specific config
             assertTrue(results.isNotEmpty())
-            val (cacheConfig, cacheSource) = results.first { it.second == Source.CACHE }
+            val cacheEntry = results.first { it.second == Source.CACHE }
+            val cacheConfig = cacheEntry.first!!
+            val cacheSource = cacheEntry.second
             assertEquals(Source.CACHE, cacheSource)
             assertEquals(1.0, cacheConfig["sample_rate"])
             assertEquals(true, cacheConfig["capture_enabled"])
@@ -1854,7 +1859,7 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            val results = mutableListOf<Pair<ConfigMap, Source>>()
+            val results = mutableListOf<Pair<ConfigMap?, Source>>()
             client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
                 results.add(config to source)
             }
@@ -1862,14 +1867,16 @@ class RemoteConfigClientTest {
 
             // First delivery is migrated CACHE
             assertTrue(results.isNotEmpty()) { "Migrated config should be delivered" }
-            val (cacheConfig, cacheSource) = results.first { it.second == Source.CACHE }
+            val cacheEntry2 = results.first { it.second == Source.CACHE }
+            val cacheConfig = cacheEntry2.first!!
+            val cacheSource = cacheEntry2.second
             assertEquals(Source.CACHE, cacheSource)
             assertEquals("medium", cacheConfig["defaultMaskLevel"])
             verify { logger.debug(match<String> { it.contains("old pre-flattened cache format") }) }
         }
 
     @Test
-    fun `dot-path to non-existent path returns empty config`() =
+    fun `dot-path to non-existent path returns null`() =
         runTest {
             val client = createClient()
 
@@ -1885,9 +1892,8 @@ class RemoteConfigClientTest {
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Should receive empty config (dot-path doesn't resolve)
-            val config = checkNotNull(receivedConfig)
-            assertTrue(config.isEmpty())
+            // Should receive null (dot-path does not resolve)
+            assertNull(receivedConfig)
         }
 
     @Test
@@ -1949,8 +1955,8 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            val privacyResults = mutableListOf<Triple<ConfigMap, Source, Long>>()
-            val diagnosticsResults = mutableListOf<Triple<ConfigMap, Source, Long>>()
+            val privacyResults = mutableListOf<Triple<ConfigMap?, Source, Long>>()
+            val diagnosticsResults = mutableListOf<Triple<ConfigMap?, Source, Long>>()
 
             client.subscribe(
                 key = SessionReplayPrivacyConfig,
@@ -1973,7 +1979,9 @@ class RemoteConfigClientTest {
                 privacyResults.isNotEmpty(),
                 "WaitForRemote subscriber should receive migrated cache on offline upgrade",
             )
-            val (privacyConfig, privacySource, _) = privacyResults.first()
+            val privacyEntry = privacyResults.first()
+            val privacyConfig = privacyEntry.first!!
+            val privacySource = privacyEntry.second
             assertEquals("strict", privacyConfig["defaultMaskLevel"])
             assertEquals(Source.CACHE, privacySource)
 
@@ -1982,7 +1990,9 @@ class RemoteConfigClientTest {
                 diagnosticsResults.isNotEmpty(),
                 "All subscriber should receive migrated cache on offline upgrade",
             )
-            val (diagConfig, diagSource, _) = diagnosticsResults.first()
+            val diagEntry = diagnosticsResults.first()
+            val diagConfig = diagEntry.first!!
+            val diagSource = diagEntry.second
             assertEquals(true, diagConfig["enabled"])
             assertEquals(Source.CACHE, diagSource)
 

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -40,6 +41,20 @@ class RemoteConfigClientTest {
         mockk<com.amplitude.common.Logger>(relaxed = true)
     private val testDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
+
+    // The client holds subscribers weakly, and deliveries are fully async. Retain test
+    // callbacks so a natural GC (heap pressure across the suite) can't collect an inline
+    // lambda before its delivery fires — production callers always keep a strong ref.
+    private val retainedCallbacks = mutableListOf<RemoteConfigClient.RemoteConfigCallback>()
+
+    private fun RemoteConfigClient.subscribeAndRetain(
+        key: RemoteConfigClient.Key,
+        deliveryMode: RemoteConfigClient.DeliveryMode = RemoteConfigClient.DeliveryMode.All,
+        callback: RemoteConfigClient.RemoteConfigCallback,
+    ) {
+        retainedCallbacks.add(callback)
+        subscribe(key, deliveryMode, callback)
+    }
 
     private fun createClient(
         serverZone: ServerZone = ServerZone.US,
@@ -95,17 +110,17 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             // Subscribe multiple callbacks to same key
-            client.subscribe(SessionReplayPrivacyConfig) { config, _, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, _, _ ->
                 callbacks.add(
                     config,
                 )
             }
-            client.subscribe(SessionReplayPrivacyConfig) { config, _, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, _, _ ->
                 callbacks.add(
                     config,
                 )
             }
-            client.subscribe(SessionReplayPrivacyConfig) { config, _, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, _, _ ->
                 callbacks.add(
                     config,
                 )
@@ -135,10 +150,10 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             // Subscribe to different keys
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 privacyCallbacks.add(config to source)
             }
-            client.subscribe(SessionReplaySamplingConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplaySamplingConfig) { config, source, _ ->
                 samplingCallbacks.add(config to source)
             }
 
@@ -174,7 +189,7 @@ class RemoteConfigClientTest {
                 RemoteConfigClient.RemoteConfigCallback { _, _, _ ->
                     persistentCallbackInvocations++
                 }
-            client.subscribe(SessionReplayPrivacyConfig, callback = persistentCallback)
+            client.subscribeAndRetain(SessionReplayPrivacyConfig, callback = persistentCallback)
             testDispatcher.scheduler.advanceUntilIdle()
             // Persistent callback should have received initial cache + remote
             assertEquals(
@@ -192,6 +207,7 @@ class RemoteConfigClientTest {
                     RemoteConfigClient.RemoteConfigCallback { _, _, _ ->
                         tempCallbackInvocations++
                     }
+                // Intentionally NOT retained — this callback must be GC-eligible.
                 client.subscribe(SessionReplayPrivacyConfig, callback = tempCallback)
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -205,18 +221,25 @@ class RemoteConfigClientTest {
                 Thread.sleep(10)
             }
 
-            // Reset timestamp to allow another remote fetch on next subscribe
+            // Reset the rate-limit window and trigger an explicit refresh. A successful
+            // refresh broadcasts to all live subscribers (persistent), while the GC'd
+            // temp callback receives nothing.
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
-
-            // Add new subscriber to trigger cleanup and another remote fetch
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> }
+            client.updateConfigs()
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // The test demonstrates that weak reference system works
-            // Counter shows temp callback were invoked initially and then cleaned up
+            // Add a new subscriber to trigger dead-reference cleanup.
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, _, _ -> }
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Temp callback was invoked before GC; persistent keeps receiving refresh updates.
             assertTrue(tempCallbackInvocations >= 2)
-            // Persistent callback should have received multiple remote updates across steps
             assertTrue(persistentCallbackInvocations >= 3)
+
+            // Keep a strong reference to the persistent callback past the assertions so
+            // GC above can't collect it — otherwise the refresh broadcast would find no
+            // live subscriber (the var is otherwise unused after subscribe).
+            assertNotNull(persistentCallback)
         }
 
     @Test
@@ -233,15 +256,15 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             // Add callback that throws exception
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, _, _ ->
                 throw RuntimeException("Test exception")
             }
 
             // Add working callbacks
-            client.subscribe(
+            client.subscribeAndRetain(
                 SessionReplayPrivacyConfig,
             ) { config, source, _ -> workingCallbacks.add(config to source) }
-            client.subscribe(
+            client.subscribeAndRetain(
                 SessionReplayPrivacyConfig,
             ) { config, source, _ -> workingCallbacks.add(config to source) }
 
@@ -282,10 +305,10 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
+            val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
 
             // Subscribe - should immediately get cached data, then REMOTE
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, timestamp ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, timestamp ->
                 results.add(Triple(config, source, timestamp))
             }
 
@@ -328,9 +351,9 @@ class RemoteConfigClientTest {
             val callback = RemoteConfigClient.RemoteConfigCallback { _, _, _ -> callCount++ }
 
             // Subscribe same callback reference multiple times
-            client.subscribe(SessionReplayPrivacyConfig, callback = callback)
-            client.subscribe(SessionReplayPrivacyConfig, callback = callback)
-            client.subscribe(SessionReplayPrivacyConfig, callback = callback)
+            client.subscribeAndRetain(SessionReplayPrivacyConfig, callback = callback)
+            client.subscribeAndRetain(SessionReplayPrivacyConfig, callback = callback)
+            client.subscribeAndRetain(SessionReplayPrivacyConfig, callback = callback)
 
             testDispatcher.scheduler.advanceUntilIdle()
 
@@ -361,7 +384,7 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 results.add(config to source)
             }
 
@@ -417,13 +440,13 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
             // First subscribe call - should trigger HTTP request
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 firstCallbackResults.add(config to source)
             }
 
             // Second subscribe call immediately after - should NOT trigger another HTTP request
             // but should still get notified when first request completes
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 secondCallbackResults.add(config to source)
             }
 
@@ -480,7 +503,7 @@ class RemoteConfigClientTest {
                 )
 
             val callbackResults = mutableListOf<Pair<ConfigMap?, Source>>()
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 callbackResults.add(config to source)
             }
 
@@ -542,7 +565,7 @@ class RemoteConfigClientTest {
                 )
 
             val callbackResults = mutableListOf<Pair<ConfigMap?, Source>>()
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 callbackResults.add(config to source)
             }
 
@@ -617,12 +640,12 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             val results = mutableListOf<Source>()
-            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ -> results.add(source) }
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, source, _ -> results.add(source) }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // CACHE from pre-populated storage, then null REMOTE from failed fetch
+            // Cache satisfies the subscribe; a failed fetch delivers no failure callback.
             assertTrue(results.contains(Source.CACHE), "Should receive cached config despite null API response")
-            assertTrue(results.contains(Source.REMOTE), "Should receive null REMOTE callback on fetch failure")
+            assertFalse(results.contains(Source.REMOTE), "No failure callback once cache was delivered")
         }
 
     @Test
@@ -645,12 +668,12 @@ class RemoteConfigClientTest {
             )
 
             val results = mutableListOf<Source>()
-            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ -> results.add(source) }
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, source, _ -> results.add(source) }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // CACHE from pre-populated storage, then null REMOTE from failed parse
+            // Cache satisfies the subscribe; a failed parse delivers no failure callback.
             assertTrue(results.contains(Source.CACHE), "Should receive cached config despite malformed JSON")
-            assertTrue(results.contains(Source.REMOTE), "Should receive null REMOTE callback on parse failure")
+            assertFalse(results.contains(Source.REMOTE), "No failure callback once cache was delivered")
         }
 
     @Test
@@ -681,8 +704,8 @@ class RemoteConfigClientTest {
                 )
 
             var callbackCount = 0
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
-            client.subscribe(SessionReplaySamplingConfig) { _, _, _ -> callbackCount++ }
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
+            client.subscribeAndRetain(SessionReplaySamplingConfig) { _, _, _ -> callbackCount++ }
             testDispatcher.scheduler.advanceUntilIdle()
 
             client.updateConfigs() // Should handle null fields gracefully
@@ -722,7 +745,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             val results = mutableListOf<Source>()
-            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, source, _ ->
                 results.add(source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -745,8 +768,8 @@ class RemoteConfigClientTest {
                         ),
                 )
 
-            val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, timestamp ->
+            val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, timestamp ->
                 results.add(Triple(config, source, timestamp))
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -778,12 +801,12 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             val results = mutableListOf<Source>()
-            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ -> results.add(source) }
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, source, _ -> results.add(source) }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // CACHE from pre-populated storage, then null REMOTE from 500 fetch failure
+            // Cache satisfies the subscribe; a 500 fetch failure delivers no failure callback.
             assertTrue(results.contains(Source.CACHE), "Should receive cached config despite server error")
-            assertTrue(results.contains(Source.REMOTE), "Should receive null REMOTE callback on 500 error")
+            assertFalse(results.contains(Source.REMOTE), "No failure callback once cache was delivered")
         }
 
     @Test
@@ -822,7 +845,7 @@ class RemoteConfigClientTest {
                 )
 
             var callbackCount = 0
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
             testDispatcher.scheduler.advanceUntilIdle()
             assertTrue(
                 callbackCount == 1,
@@ -863,8 +886,8 @@ class RemoteConfigClientTest {
                         ),
                 )
 
-            val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, timestamp ->
+            val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, timestamp ->
                 results.add(Triple(config, source, timestamp))
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -1027,7 +1050,7 @@ class RemoteConfigClientTest {
                 )
 
             var remoteCallbacks = mutableListOf<Pair<ConfigMap?, Source>>()
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 remoteCallbacks.add(config to source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -1103,39 +1126,34 @@ class RemoteConfigClientTest {
                 )
 
             val callbacks = mutableListOf<Pair<ConfigMap?, Source>>()
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 callbacks.add(config to source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Cache read failure must not deliver a bogus CACHE callback, but the
-            // subscriber is still unblocked with a null REMOTE signal rather than
-            // hanging when the fetch path itself fails on a storage read.
+            // A cache-read failure is logged and yields no CACHE delivery. The fetch
+            // itself succeeds (empty configs), so the subscriber receives exactly one
+            // REMOTE callback with a null config (key absent) instead of hanging.
             assertFalse(
                 callbacks.any { it.second == Source.CACHE },
                 "Should not deliver cache on storage read failure",
             )
             assertEquals(1, callbacks.size, "Subscriber should be notified exactly once")
-            assertNull(callbacks.first().first, "Failed fetch delivers null config")
+            assertNull(callbacks.first().first, "Absent key from empty fetch resolves to null")
             assertEquals(Source.REMOTE, callbacks.first().second)
             verify {
                 logger.error(
                     match<String> { it.contains("Failed to parse all stored configs") },
                 )
             }
-            verify {
-                logger.error(
-                    match<String> { it.contains("Error updating remote configs") },
-                )
-            }
         }
 
     @Test
-    fun `rate-limit read failure - notifies subscribers instead of leaking exception`() =
+    fun `rate-limit timestamp read failure - handled gracefully without leaking`() =
         runTest {
-            // Storage where the cache blob is absent (no CACHE delivery) but the
-            // timestamp read used by shouldRateLimit() throws. This exercises the
-            // path where the exception originates outside the fetch body.
+            // Storage where the cache blob is absent (no CACHE delivery) and the
+            // timestamp read used by shouldRateLimit() throws. The refresh must
+            // swallow that error, fall through to the fetch, and not crash.
             val rateLimitFailingStorage =
                 object : Storage {
                     override fun read(key: Storage.Constants): String? {
@@ -1191,19 +1209,25 @@ class RemoteConfigClientTest {
                 )
 
             val callbacks = mutableListOf<Pair<ConfigMap?, Source>>()
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 callbacks.add(config to source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Subscriber must still be unblocked with a null REMOTE signal rather
-            // than the exception leaking out of the launch and hanging it forever.
-            assertEquals(1, callbacks.size, "Subscriber should be notified exactly once")
-            assertNull(callbacks.first().first, "Failed fetch delivers null config")
-            assertEquals(Source.REMOTE, callbacks.first().second)
+            // An explicit refresh hits the throwing timestamp read in shouldRateLimit.
+            client.updateConfigs()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // No crash; subscriber received REMOTE callbacks (null config = empty fetch),
+            // and the rate-limit read failure was logged rather than leaked.
+            assertTrue(callbacks.isNotEmpty(), "Subscriber should be notified")
+            assertTrue(
+                callbacks.all { it.first == null && it.second == Source.REMOTE },
+                "All deliveries are null REMOTE from the empty fetch, got: $callbacks",
+            )
             verify {
                 logger.error(
-                    match<String> { it.contains("Error updating remote configs") },
+                    match<String> { it.contains("Failed to read rate-limit timestamp") },
                 )
             }
         }
@@ -1218,7 +1242,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "not_a_number")
 
             val results = mutableListOf<Source>()
-            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, source, _ ->
                 results.add(source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -1260,13 +1284,18 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             var callbackInvoked = false
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ ->
-                callbackInvoked = true
-            }
+            // Hold a strong reference: subscribers are weakly held, and the full suite
+            // can GC an inline lambda before the cache delivery fires.
+            val callback =
+                RemoteConfigClient.RemoteConfigCallback { _, _, _ ->
+                    callbackInvoked = true
+                }
+            client.subscribeAndRetain(SessionReplayPrivacyConfig, callback = callback)
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Should resolve the valid nested path despite other top-level junk
             assertTrue(callbackInvoked, "Should resolve valid dot-path despite non-map top-level entries")
+            assertNotNull(callback)
         }
 
     // endregion Additional Coverage
@@ -1279,10 +1308,10 @@ class RemoteConfigClientTest {
         fun `WaitForRemote delivers remote when fetch returns within timeout`() =
             runTest {
                 val client = createClient(emptyApiConfig = false)
-                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
-                client.subscribe(
+                client.subscribeAndRetain(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 5_000L),
                 ) { config, source, timestamp ->
@@ -1297,11 +1326,10 @@ class RemoteConfigClientTest {
             }
 
         @Test
-        fun `WaitForRemote receives null REMOTE immediately when fetch fails`() =
+        fun `WaitForRemote falls back to cache when fetch fails`() =
             runTest {
-                // HTTP returns 500: notifySubscribersOnFailure fires immediately, claiming
-                // the WaitForRemote gate. The timeout fallback is suppressed because the
-                // gate is already claimed — subscriber gets null REMOTE, not a stale cache.
+                // HTTP returns 500. WaitForRemote can't get a remote, so it falls back to
+                // the cached value (mirrors iOS) rather than signalling a failure.
                 val mockHttpClient = mockk<HttpClient>()
                 every { mockHttpClient.request(any()) } returns
                     HttpClient.Response(
@@ -1322,15 +1350,15 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                // Pre-populate cache — must NOT be delivered (gate claimed by failure path first).
+                // Pre-populate cache — the failed fetch should fall back to it.
                 storage.write(
                     Storage.Constants.REMOTE_CONFIG,
                     DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
                 )
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
-                client.subscribe(
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+                client.subscribeAndRetain(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 100L),
                 ) { config, source, timestamp ->
@@ -1339,10 +1367,10 @@ class RemoteConfigClientTest {
 
                 testDispatcher.scheduler.advanceUntilIdle()
 
-                assertEquals(1, results.size, "Expected one null REMOTE delivery on fetch failure, got: $results")
+                assertEquals(1, results.size, "Expected one cache fallback delivery, got: $results")
                 val (config, source, _) = results.single()
-                assertEquals(Source.REMOTE, source, "Fetch failure must deliver Source.REMOTE")
-                assertNull(config, "Fetch failure must deliver null config")
+                assertEquals(Source.CACHE, source, "Failed fetch with cache must deliver Source.CACHE")
+                assertEquals("medium", config!!["defaultMaskLevel"], "Should deliver the cached config")
             }
 
         @Test
@@ -1370,8 +1398,8 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
-                client.subscribe(
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+                client.subscribeAndRetain(
                     key = Diagnostics,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 50L),
                 ) { config, source, timestamp ->
@@ -1398,7 +1426,7 @@ class RemoteConfigClientTest {
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
                 val sources = mutableListOf<Source>()
-                client.subscribe(
+                client.subscribeAndRetain(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 5_000L),
                 ) { _, source, _ ->
@@ -1424,7 +1452,7 @@ class RemoteConfigClientTest {
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
                 // The pre-existing single-arg overload must still deliver cache then remote.
-                client.subscribe(SessionReplayPrivacyConfig) { _, source, _ ->
+                client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, source, _ ->
                     sources.add(source)
                 }
 
@@ -1435,16 +1463,13 @@ class RemoteConfigClientTest {
             }
 
         @Test
-        fun `WaitForRemote delivers fresh remote that arrives after timeout fallback fires`() =
+        fun `WaitForRemote delivers once and ignores later refreshes`() =
             runTest {
-                // Regression: when the timeout fallback wins the gate first and a
-                // fresh remote arrives later, the subscriber must still receive
-                // the remote update — not stay stuck on the stale fallback.
+                // WaitForRemote is one-and-done (mirrors iOS): once it has received its
+                // single initial delivery, subsequent refreshes do NOT re-notify it.
                 //
-                // Repro: first fetch fails (500), so the timeout fallback fires
-                // and delivers a cached value. Then the rate-limit window is
-                // reset and a successful fetch is triggered. The subscriber
-                // should receive the fresh REMOTE delivery as a subsequent update.
+                // First fetch fails (500) with a cache present, so the fallback delivers
+                // CACHE. A later successful refresh must NOT produce a second delivery.
                 var responseProvider: () -> HttpClient.Response = {
                     HttpClient.Response(
                         statusCode = 500,
@@ -1468,7 +1493,7 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                // Pre-populate cache so the timeout fallback has data to deliver.
+                // Pre-populate cache so the failed fetch falls back to it.
                 storage.write(
                     Storage.Constants.REMOTE_CONFIG,
                     DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
@@ -1476,7 +1501,7 @@ class RemoteConfigClientTest {
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
                 val results = mutableListOf<Pair<ConfigMap?, Source>>()
-                client.subscribe(
+                client.subscribeAndRetain(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 50L),
                 ) { config, source, _ ->
@@ -1485,17 +1510,15 @@ class RemoteConfigClientTest {
 
                 testDispatcher.scheduler.advanceUntilIdle()
 
-                // Fetch failure immediately claims the gate and delivers null REMOTE.
+                // Failed fetch with a cache present delivers the CACHE fallback.
                 assertEquals(
-                    listOf(Source.REMOTE),
+                    listOf(Source.CACHE),
                     results.map { it.second },
-                    "Expected null REMOTE from fetch failure before successful remote arrives, got: $results",
+                    "Expected cache fallback as the single delivery, got: $results",
                 )
-                assertNull(results.single().first, "First delivery must be null from fetch failure")
 
-                // Now flip the response to a fresh successful payload and trigger
-                // another fetch. The previously-gated subscriber must receive
-                // the fresh remote as a subsequent update.
+                // Flip to a fresh successful payload and trigger a refresh. WaitForRemote
+                // already delivered, so it must NOT be notified again.
                 responseProvider = {
                     HttpClient.Response(
                         statusCode = 200,
@@ -1510,11 +1533,10 @@ class RemoteConfigClientTest {
                 testDispatcher.scheduler.advanceUntilIdle()
 
                 assertEquals(
-                    listOf(Source.REMOTE, Source.REMOTE),
+                    listOf(Source.CACHE),
                     results.map { it.second },
-                    "Subscriber must receive fresh remote after the fetch-failure null, got: $results",
+                    "WaitForRemote must not receive refresh updates after its first delivery, got: $results",
                 )
-                assertEquals("medium", results.last().first!!["defaultMaskLevel"], "Second REMOTE must carry fresh data")
             }
 
         @Test
@@ -1544,8 +1566,8 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
-                client.subscribe(
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+                client.subscribeAndRetain(
                     key = AnalyticsSdk,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 60_000L),
                 ) { config, source, timestamp ->
@@ -1579,8 +1601,8 @@ class RemoteConfigClientTest {
                 val client = createClient(emptyApiConfig = true) // returns {"configs":{}}
                 storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
-                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
-                client.subscribe(
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+                client.subscribeAndRetain(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 60_000L),
                 ) { config, source, timestamp ->
@@ -1609,8 +1631,8 @@ class RemoteConfigClientTest {
         @Test
         fun `WaitForRemote does not interfere with All subscribers on the absent key`() =
             runTest {
-                // All subscribers on a key absent from the response now receive a
-                // REMOTE notification with emptyMap() (platform-aligned behavior).
+                // All subscribers on a key absent from a successful response receive a
+                // REMOTE notification with a null config (and a valid timestamp).
                 val mockHttpClient = mockk<HttpClient>()
                 every { mockHttpClient.request(any()) } returns
                     HttpClient.Response(
@@ -1631,8 +1653,8 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
-                client.subscribe(Diagnostics) { config, source, timestamp ->
+                val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+                client.subscribeAndRetain(Diagnostics) { config, source, timestamp ->
                     results.add(Triple(config, source, timestamp))
                 }
 
@@ -1646,11 +1668,10 @@ class RemoteConfigClientTest {
             }
 
         @Test
-        fun `WaitForRemote serializes callback delivery to prevent concurrent invocations`() {
-            // Regression: the timeout fallback and the remote fetch can invoke
-            // the callback concurrently from different dispatchers. This test
-            // blocks inside the fallback callback and verifies that the remote
-            // delivery waits until the fallback returns — no concurrent calls.
+        fun `All-mode serializes callback delivery to prevent concurrent invocations`() {
+            // Regression: the immediate cache delivery and the remote broadcast can
+            // invoke the callback from different dispatchers. This test blocks inside
+            // the first callback and verifies the second waits — no concurrent calls.
             val networkExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
             val storageExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
             val networkDispatcher = networkExecutor.asCoroutineDispatcher()
@@ -1714,13 +1735,13 @@ class RemoteConfigClientTest {
                 val allDeliveries = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap?, Source>>())
                 val allDone = java.util.concurrent.CountDownLatch(2)
 
-                client.subscribe(
+                client.subscribeAndRetain(
                     key = SessionReplayPrivacyConfig,
-                    deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 30L),
+                    deliveryMode = RemoteConfigClient.DeliveryMode.All,
                 ) { config, source, _ ->
                     val current = concurrentCount.incrementAndGet()
                     peakConcurrent.updateAndGet { peak -> maxOf(peak, current) }
-                    // Simulate slow processing in the fallback callback.
+                    // Simulate slow processing in the callback.
                     Thread.sleep(100)
                     allDeliveries.add(config to source)
                     concurrentCount.decrementAndGet()
@@ -1731,7 +1752,7 @@ class RemoteConfigClientTest {
 
                 assertTrue(
                     gotBoth,
-                    "Expected two deliveries (fallback + remote), got: $allDeliveries",
+                    "Expected two deliveries (cache + remote), got: $allDeliveries",
                 )
                 assertEquals(
                     1,
@@ -1759,11 +1780,10 @@ class RemoteConfigClientTest {
         }
 
         @Test
-        fun `WaitForRemote suppresses timeout fallback when remote arrived during slow callback`() {
-            // Race regression: the timeout fallback path must not overwrite a
-            // fresh remote delivery that won the gate while the timeout
-            // continuation was being scheduled. Uses real dispatchers and a
-            // slow HTTP response so the race is observable end-to-end.
+        fun `WaitForRemote ignores a late remote after the timeout fallback`() {
+            // WaitForRemote is one-and-done: once the timeout fallback delivers the
+            // cache, a remote that lands later must NOT produce a second delivery.
+            // Uses real dispatchers and a slow HTTP response to exercise it end-to-end.
             val networkExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
             val storageExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
             val networkDispatcher = networkExecutor.asCoroutineDispatcher()
@@ -1823,39 +1843,31 @@ class RemoteConfigClientTest {
                     )
 
                 val results = java.util.Collections.synchronizedList(mutableListOf<Pair<ConfigMap?, Source>>())
-                val secondDelivery = java.util.concurrent.CountDownLatch(2)
+                val firstDelivery = java.util.concurrent.CountDownLatch(1)
 
-                client.subscribe(
+                client.subscribeAndRetain(
                     key = SessionReplayPrivacyConfig,
                     deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 30L),
                 ) { config, source, _ ->
                     results.add(config to source)
-                    secondDelivery.countDown()
+                    firstDelivery.countDown()
                 }
 
-                // Wait until the fetch has had time to land and the subscriber
-                // has received both the timeout fallback and the fresh remote.
-                // If our fix is wrong, the fresh remote is silently dropped
-                // and we never see a REMOTE delivery.
-                val gotBoth = secondDelivery.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS)
-
+                // The 30ms timeout fires before the 80ms remote, delivering the cache fallback.
                 assertTrue(
-                    gotBoth,
-                    "Expected timeout fallback + fresh remote, got: $results",
+                    firstDelivery.await(2_000L, java.util.concurrent.TimeUnit.MILLISECONDS),
+                    "Expected the timeout cache fallback delivery, got: $results",
                 )
-                // Snapshot deliveries (synchronizedList iteration must hold the lock).
+                // Wait well past the remote's 80ms latency. WaitForRemote is one-and-done,
+                // so the late remote must NOT produce a second delivery.
+                Thread.sleep(200)
                 val snapshot = synchronized(results) { results.toList() }
-                assertTrue(
-                    snapshot.any { it.second == Source.REMOTE && it.first!!["defaultMaskLevel"] == "medium" },
-                    "Expected fresh remote delivery (defaultMaskLevel=medium), got: $snapshot",
-                )
-                // The fallback must not have overwritten the fresh remote in the
-                // delivery order: the last delivery should be the fresh remote.
-                val last = snapshot.last()
+                assertEquals(1, snapshot.size, "WaitForRemote must deliver exactly once, got: $snapshot")
+                assertEquals(Source.CACHE, snapshot.single().second, "Single delivery is the cache fallback")
                 assertEquals(
-                    Source.REMOTE,
-                    last.second,
-                    "Last delivery must be the fresh remote, not a stale fallback: $snapshot",
+                    "STALE",
+                    snapshot.single().first!!["defaultMaskLevel"],
+                    "Fallback carries the cached data: $snapshot",
                 )
             } finally {
                 realScope.cancel()
@@ -1866,7 +1878,7 @@ class RemoteConfigClientTest {
     }
 
     @Test
-    fun `updateConfigs delivers null callback to All subscribers when fetch fails`() =
+    fun `subscribe with no cache delivers null REMOTE when fetch fails`() =
         runTest {
             val mockHttpClient = mockk<HttpClient>()
             every { mockHttpClient.request(any()) } returns
@@ -1888,9 +1900,9 @@ class RemoteConfigClientTest {
                     logger = silentLogger,
                 )
 
-            val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
+            val results = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
             // Subscribe with All mode and no pre-populated cache
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, timestamp ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, timestamp ->
                 results.add(Triple(config, source, timestamp))
             }
 
@@ -1914,7 +1926,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
             var receivedConfig: ConfigMap? = null
-            client.subscribe(Key.Custom("sessionReplay")) { config, _, _ ->
+            client.subscribeAndRetain(Key.Custom("sessionReplay")) { config, _, _ ->
                 receivedConfig = config
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -1937,7 +1949,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
 
             var receivedConfig: ConfigMap? = null
-            client.subscribe(Key.Custom("sessionReplay.sr_android_privacy_config")) { config, _, _ ->
+            client.subscribeAndRetain(Key.Custom("sessionReplay.sr_android_privacy_config")) { config, _, _ ->
                 receivedConfig = config
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -1958,7 +1970,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             val results = mutableListOf<Pair<ConfigMap?, Source>>()
-            client.subscribe(Key.Custom("sessionReplay.sr_android_sampling_config")) { config, source, _ ->
+            client.subscribeAndRetain(Key.Custom("sessionReplay.sr_android_sampling_config")) { config, source, _ ->
                 results.add(config to source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -1996,7 +2008,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             val results = mutableListOf<Pair<ConfigMap?, Source>>()
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 results.add(config to source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -2024,7 +2036,7 @@ class RemoteConfigClientTest {
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
             var receivedConfig: ConfigMap? = null
-            client.subscribe(Key.Custom("nonExistent.path")) { config, _, _ ->
+            client.subscribeAndRetain(Key.Custom("nonExistent.path")) { config, _, _ ->
                 receivedConfig = config
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -2056,7 +2068,7 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            client.subscribe(SessionReplayPrivacyConfig) { config, source, _ ->
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
                 results.add(config to source)
             }
             testDispatcher.scheduler.advanceUntilIdle()
@@ -2126,17 +2138,17 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            val privacyResults = mutableListOf<Triple<ConfigMap?, Source, Long>>()
-            val diagnosticsResults = mutableListOf<Triple<ConfigMap?, Source, Long>>()
+            val privacyResults = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
+            val diagnosticsResults = mutableListOf<Triple<ConfigMap?, Source, Long?>>()
 
-            client.subscribe(
+            client.subscribeAndRetain(
                 key = SessionReplayPrivacyConfig,
                 deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 100L),
             ) { config, source, timestamp ->
                 privacyResults.add(Triple(config, source, timestamp))
             }
 
-            client.subscribe(
+            client.subscribeAndRetain(
                 key = Diagnostics,
                 deliveryMode = RemoteConfigClient.DeliveryMode.All,
             ) { config, source, timestamp ->

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -1915,6 +1915,105 @@ class RemoteConfigClientTest {
             assertNull(config, "Failed fetch must deliver null config")
         }
 
+    @Test
+    fun `All subscriber receives ongoing remote updates from later refreshes`() =
+        runTest {
+            val client = createClient(emptyApiConfig = false)
+
+            val remoteDeliveries = mutableListOf<ConfigMap?>()
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { config, source, _ ->
+                if (source == Source.REMOTE) remoteDeliveries.add(config)
+            }
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, remoteDeliveries.size, "Initial subscribe should deliver one REMOTE")
+
+            // A later refresh (distinct fetch) must deliver again to the All subscriber.
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
+            client.updateConfigs()
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertEquals(2, remoteDeliveries.size, "All subscriber should receive the refresh update")
+        }
+
+    @Test
+    fun `All subscriber never receives stale cache after a remote`() =
+        runTest {
+            val client = createClient(emptyApiConfig = false)
+            // Cache present, and a refresh is interleaved with the subscribe so a remote
+            // can race ahead of the cache delivery.
+            storage.write(
+                Storage.Constants.REMOTE_CONFIG,
+                DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
+            )
+            storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "0")
+
+            val sources = mutableListOf<Source>()
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, source, _ ->
+                sources.add(source)
+            }
+            client.updateConfigs()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Invariant: a CACHE delivery must never follow a REMOTE one.
+            val firstRemote = sources.indexOf(Source.REMOTE)
+            if (firstRemote >= 0) {
+                assertFalse(
+                    sources.drop(firstRemote + 1).contains(Source.CACHE),
+                    "Stale CACHE delivered after REMOTE: $sources",
+                )
+            }
+        }
+
+    @Test
+    fun `subscribe reuses a recent successful fetch without a new request`() =
+        runTest {
+            val requests = mutableListOf<HttpClient.Request>()
+            val mockHttpClient = mockk<HttpClient>()
+            every { mockHttpClient.request(any()) } answers {
+                requests.add(firstArg())
+                HttpClient.Response(
+                    statusCode = 200,
+                    body = DEFAULT_API_REMOTE_CONFIG_JSON.trimIndent(),
+                    headers = emptyMap(),
+                    statusMessage = "OK",
+                )
+            }
+            val client =
+                RemoteConfigClientImpl(
+                    apiKey = "test-key",
+                    serverZone = ServerZone.US,
+                    coroutineScope = testScope,
+                    networkIODispatcher = testDispatcher,
+                    storageIODispatcher = testDispatcher,
+                    storage = storage,
+                    httpClient = mockHttpClient,
+                    logger = silentLogger,
+                )
+
+            // First subscribe triggers a single fetch.
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, _, _ -> }
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, requests.size, "First subscribe should make one request")
+
+            // Second subscribe within the rate-limit window reuses the fresh result —
+            // no new request — and still gets a REMOTE delivery (DeliveryMode.All).
+            val allSources = mutableListOf<Source>()
+            client.subscribeAndRetain(SessionReplayPrivacyConfig) { _, source, _ -> allSources.add(source) }
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, requests.size, "Second subscribe should reuse, not refetch")
+            assertTrue(allSources.contains(Source.REMOTE), "Reuse delivers REMOTE to All, got: $allSources")
+
+            // A WaitForRemote subscriber also reuses the fresh result with no new request.
+            val waitResults = mutableListOf<Pair<ConfigMap?, Source>>()
+            client.subscribeAndRetain(
+                key = SessionReplayPrivacyConfig,
+                deliveryMode = RemoteConfigClient.DeliveryMode.WaitForRemote(timeoutMs = 5_000L),
+            ) { config, source, _ -> waitResults.add(config to source) }
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertEquals(1, requests.size, "WaitForRemote should reuse, not refetch")
+            assertEquals(1, waitResults.size, "WaitForRemote delivers exactly once")
+            assertEquals(Source.REMOTE, waitResults.single().second, "Reuse delivers REMOTE to WaitForRemote")
+        }
+
     // endregion DeliveryMode
 
     // region Dot-Path and Key Alignment

--- a/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/remoteconfig/RemoteConfigClientTest.kt
@@ -609,16 +609,13 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            var callbackCount = 0
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
+            val results = mutableListOf<Source>()
+            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ -> results.add(source) }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Should still get cached config, no crash
-            assertTrue(callbackCount == 1, "Should receive cached config despite null API response")
-            client.updateConfigs()
-            testDispatcher.scheduler.advanceUntilIdle()
-            // No change, no crash
-            assertTrue(callbackCount == 1, "Should receive cached config despite null API response")
+            // CACHE from pre-populated storage, then null REMOTE from failed fetch
+            assertTrue(results.contains(Source.CACHE), "Should receive cached config despite null API response")
+            assertTrue(results.contains(Source.REMOTE), "Should receive null REMOTE callback on fetch failure")
         }
 
     @Test
@@ -640,14 +637,13 @@ class RemoteConfigClientTest {
                 DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
             )
 
-            var callbackCount = 0
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
+            val results = mutableListOf<Source>()
+            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ -> results.add(source) }
             testDispatcher.scheduler.advanceUntilIdle()
-            assertTrue(callbackCount == 1, "Should receive cached config despite malformed JSON")
 
-            client.updateConfigs()
-            testDispatcher.scheduler.advanceUntilIdle()
-            assertTrue(callbackCount == 1, "Should receive cached config despite malformed JSON")
+            // CACHE from pre-populated storage, then null REMOTE from failed parse
+            assertTrue(results.contains(Source.CACHE), "Should receive cached config despite malformed JSON")
+            assertTrue(results.contains(Source.REMOTE), "Should receive null REMOTE callback on parse failure")
         }
 
     @Test
@@ -742,15 +738,16 @@ class RemoteConfigClientTest {
                         ),
                 )
 
-            var callbackInvoked = false
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ ->
-                callbackInvoked = true
+            val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, timestamp ->
+                results.add(Triple(config, source, timestamp))
             }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            client.updateConfigs()
-            testDispatcher.scheduler.advanceUntilIdle()
-            assertFalse(callbackInvoked, "Should not invoke callback for empty response")
+            // No CACHE (no pre-populated storage). Fetch fails (empty body) → null REMOTE delivered.
+            assertEquals(1, results.size, "Expected one null REMOTE callback on empty response")
+            assertNull(results.single().first, "Config should be null on failed fetch")
+            assertEquals(Source.REMOTE, results.single().second, "Source should be REMOTE on fetch failure")
         }
 
     @Test
@@ -773,14 +770,13 @@ class RemoteConfigClientTest {
             )
             storage.write(Storage.Constants.REMOTE_CONFIG_TIMESTAMP, "1234567890")
 
-            var callbackCount = 0
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
+            val results = mutableListOf<Source>()
+            client.subscribe(SessionReplayPrivacyConfig) { _, source, _ -> results.add(source) }
             testDispatcher.scheduler.advanceUntilIdle()
-            assertTrue(callbackCount == 1, "Should receive cached config despite server error")
 
-            client.updateConfigs()
-            testDispatcher.scheduler.advanceUntilIdle()
-            assertTrue(callbackCount == 1, "Should receive cached config despite server error")
+            // CACHE from pre-populated storage, then null REMOTE from 500 fetch failure
+            assertTrue(results.contains(Source.CACHE), "Should receive cached config despite server error")
+            assertTrue(results.contains(Source.REMOTE), "Should receive null REMOTE callback on 500 error")
         }
 
     @Test
@@ -860,13 +856,16 @@ class RemoteConfigClientTest {
                         ),
                 )
 
-            var callbackCount = 0
-            client.subscribe(SessionReplayPrivacyConfig) { _, _, _ -> callbackCount++ }
+            val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, timestamp ->
+                results.add(Triple(config, source, timestamp))
+            }
             testDispatcher.scheduler.advanceUntilIdle()
 
-            client.updateConfigs()
-            testDispatcher.scheduler.advanceUntilIdle()
-            assertTrue(callbackCount == 0, "Should not invoke callback when configs key is missing")
+            // No CACHE. Missing "configs" key → fetch returns null → null REMOTE delivered.
+            assertEquals(1, results.size, "Should deliver null REMOTE when configs key is missing")
+            assertNull(results.single().first, "Config should be null when configs key absent")
+            assertEquals(Source.REMOTE, results.single().second, "Source should be REMOTE")
         }
 
     // endregion API Response Edge Cases
@@ -1200,10 +1199,11 @@ class RemoteConfigClientTest {
             }
 
         @Test
-        fun `WaitForRemote times out and falls back to cached config`() =
+        fun `WaitForRemote receives null REMOTE immediately when fetch fails`() =
             runTest {
-                // HTTP returns 500: fetchRemoteConfig returns null, regular path does not
-                // deliver. WaitForRemote then times out and falls back to cache.
+                // HTTP returns 500: notifySubscribersOnFailure fires immediately, claiming
+                // the WaitForRemote gate. The timeout fallback is suppressed because the
+                // gate is already claimed — subscriber gets null REMOTE, not a stale cache.
                 val mockHttpClient = mockk<HttpClient>()
                 every { mockHttpClient.request(any()) } returns
                     HttpClient.Response(
@@ -1224,7 +1224,7 @@ class RemoteConfigClientTest {
                         logger = silentLogger,
                     )
 
-                // Pre-populate cache so timeout fallback has data to deliver.
+                // Pre-populate cache — must NOT be delivered (gate claimed by failure path first).
                 storage.write(
                     Storage.Constants.REMOTE_CONFIG,
                     DEFAULT_STORED_REMOTE_CONFIG_JSON.trimIndent(),
@@ -1241,17 +1241,17 @@ class RemoteConfigClientTest {
 
                 testDispatcher.scheduler.advanceUntilIdle()
 
-                assertEquals(1, results.size, "Expected one timeout-fallback delivery, got: $results")
-                val (config, source, timestamp) = results.single()
-                assertEquals(Source.CACHE, source)
-                assertEquals("medium", config!!["defaultMaskLevel"])
-                assertEquals(1234567890L, timestamp)
+                assertEquals(1, results.size, "Expected one null REMOTE delivery on fetch failure, got: $results")
+                val (config, source, _) = results.single()
+                assertEquals(Source.REMOTE, source, "Fetch failure must deliver Source.REMOTE")
+                assertNull(config, "Fetch failure must deliver null config")
             }
 
         @Test
-        fun `WaitForRemote falls back to empty config when cache is also empty`() =
+        fun `WaitForRemote receives null REMOTE immediately when fetch fails and cache is empty`() =
             runTest {
-                // HTTP returns 500: no cache, no remote. Fallback should be empty.
+                // HTTP returns 500: no cache, failure path claims the gate immediately.
+                // Subscriber receives null REMOTE — no wait for the timeout.
                 val mockHttpClient = mockk<HttpClient>()
                 every { mockHttpClient.request(any()) } returns
                     HttpClient.Response(
@@ -1282,9 +1282,9 @@ class RemoteConfigClientTest {
 
                 testDispatcher.scheduler.advanceUntilIdle()
 
-                assertEquals(1, results.size, "Expected one timeout-fallback delivery, got: $results")
-                assertTrue(results.single().first == null, "Expected null config fallback")
-                assertEquals(Source.CACHE, results.single().second)
+                assertEquals(1, results.size, "Expected one null REMOTE delivery on fetch failure, got: $results")
+                assertNull(results.single().first, "Expected null config on fetch failure")
+                assertEquals(Source.REMOTE, results.single().second, "Fetch failure must deliver Source.REMOTE")
             }
 
         @Test
@@ -1387,12 +1387,13 @@ class RemoteConfigClientTest {
 
                 testDispatcher.scheduler.advanceUntilIdle()
 
-                // Timeout fallback fired with cache.
+                // Fetch failure immediately claims the gate and delivers null REMOTE.
                 assertEquals(
-                    listOf(Source.CACHE),
+                    listOf(Source.REMOTE),
                     results.map { it.second },
-                    "Expected only the cache fallback before remote arrives, got: $results",
+                    "Expected null REMOTE from fetch failure before successful remote arrives, got: $results",
                 )
+                assertNull(results.single().first, "First delivery must be null from fetch failure")
 
                 // Now flip the response to a fresh successful payload and trigger
                 // another fetch. The previously-gated subscriber must receive
@@ -1411,10 +1412,11 @@ class RemoteConfigClientTest {
                 testDispatcher.scheduler.advanceUntilIdle()
 
                 assertEquals(
-                    listOf(Source.CACHE, Source.REMOTE),
+                    listOf(Source.REMOTE, Source.REMOTE),
                     results.map { it.second },
-                    "Subscriber must receive fresh remote after the timeout fallback, got: $results",
+                    "Subscriber must receive fresh remote after the fetch-failure null, got: $results",
                 )
+                assertEquals("medium", results.last().first!!["defaultMaskLevel"], "Second REMOTE must carry fresh data")
             }
 
         @Test
@@ -1765,6 +1767,44 @@ class RemoteConfigClientTest {
         }
     }
 
+    @Test
+    fun `updateConfigs delivers null callback to All subscribers when fetch fails`() =
+        runTest {
+            val mockHttpClient = mockk<HttpClient>()
+            every { mockHttpClient.request(any()) } returns
+                HttpClient.Response(
+                    statusCode = 500,
+                    body = """{"error": "Internal Server Error"}""",
+                    headers = emptyMap(),
+                    statusMessage = "Internal Server Error",
+                )
+            val client =
+                RemoteConfigClientImpl(
+                    apiKey = "test-key",
+                    serverZone = ServerZone.US,
+                    coroutineScope = testScope,
+                    networkIODispatcher = testDispatcher,
+                    storageIODispatcher = testDispatcher,
+                    storage = storage,
+                    httpClient = mockHttpClient,
+                    logger = silentLogger,
+                )
+
+            val results = mutableListOf<Triple<ConfigMap?, Source, Long>>()
+            // Subscribe with All mode and no pre-populated cache
+            client.subscribe(SessionReplayPrivacyConfig) { config, source, timestamp ->
+                results.add(Triple(config, source, timestamp))
+            }
+
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Fetch failed — All subscriber must receive exactly one null REMOTE callback
+            assertEquals(1, results.size, "Expected one null REMOTE callback on fetch failure, got: $results")
+            val (config, source, _) = results.single()
+            assertEquals(Source.REMOTE, source, "Failed fetch must report Source.REMOTE")
+            assertNull(config, "Failed fetch must deliver null config")
+        }
+
     // endregion DeliveryMode
 
     // region Dot-Path and Key Alignment
@@ -1970,16 +2010,20 @@ class RemoteConfigClientTest {
 
             testDispatcher.scheduler.advanceUntilIdle()
 
-            // Privacy: WaitForRemote times out, blob was cleared so fallback is null
-            assertEquals(1, privacyResults.size, "Expected exactly one timeout-fallback delivery")
+            // Privacy: WaitForRemote — fetch failure claims gate immediately, delivers null REMOTE
+            assertEquals(1, privacyResults.size, "Expected one null REMOTE delivery on fetch failure")
             val (privacyConfig, privacySource, _) = privacyResults.single()
-            assertEquals(Source.CACHE, privacySource, "Timeout fallback reports Source.CACHE")
+            assertEquals(Source.REMOTE, privacySource, "Fetch failure must deliver Source.REMOTE")
             assertNull(privacyConfig, "Stale old-format blob must not produce real cache data")
 
-            // Diagnostics: All mode — old-format blob is discarded so no CACHE delivery
+            // Diagnostics: All mode — old-format blob discarded (no CACHE), null REMOTE from failure
             assertFalse(
                 diagnosticsResults.any { it.second == Source.CACHE },
                 "All subscriber must not receive stale old-format blob as CACHE",
+            )
+            assertTrue(
+                diagnosticsResults.any { it.second == Source.REMOTE },
+                "All subscriber should receive null REMOTE callback on fetch failure",
             )
 
             // Stale blob cleared from storage


### PR DESCRIPTION
### Describe what this PR is addressing
Android pre-flattened the remote config blob and matched exact key strings. iOS and Web store the full nested blob and resolve a slice by dot-path at delivery time. This aligns Android's key model **and** delivery semantics with them.

### Describe the solution
- **Key model:** `Key` is now a `sealed class` — `data object`s (`AnalyticsSdk`, `Diagnostics`, `SessionReplayPrivacyConfig`, `SessionReplaySamplingConfig`) plus `Custom("dot.path")` for arbitrary sections. `Custom` is a plain class (no `copy()`/`componentN()` leak).
- **Fetch + resolve:** one nested blob via `config_group=android`; slices resolved by dot-path at delivery (no pre-flattening).
- **Callback contract:** `onUpdate(config: ConfigMap?, source, timestamp: Long?)` — `timestamp == null` ⇒ failed fetch; non-null timestamp + `config == null` ⇒ key absent.
- **Delivery:** the mode governs only the **initial** callback; afterward every subscriber receives subsequent successful fetches as updates. `All` = cache-if-present, then remote, then ongoing updates. `WaitForRemote(timeout)` = block the initial on the remote up to `timeout`, else cache fallback, else `(null, REMOTE, null)` — then ongoing updates, the same as `All`. **Any** successful fetch (subscribe- or `updateConfigs()`-triggered) delivers the latest config to **all** current subscribers, de-duplicated per subscriber by `fetchId`; failures are never broadcast (subscribers keep their last valid config); `updateConfigs()` is rate-limited (5 min). Never a stale `CACHE` after a `REMOTE`; storage persistence is best-effort. Mirrors iOS (incl. `AmplitudeCore-Swift#80`).
- **Cache:** an empty cached blob is a valid hit; stale old flat-format blobs (top-level keys containing `.`) are ignored and overwritten by a successful fetch, not migrated.
- **Gating:** `RemoteConfigClient`, its nested types, the `ConfigMap` extensions, and `Amplitude.remoteConfigClient` are behind `@RestrictedAmplitudeFeature` (ERROR-level opt-in) — an internal mechanism, consumed via narrowly-scoped `@OptIn`.

**Breaking (binary):** `Key` enum→sealed and `onUpdate` `long`→`Long?` are binary-incompatible, but confined to the now-gated internal `RemoteConfigClient`; see the package README migration note. No public-facing feature exposes these types.

### Steps to verify the change
- `./gradlew :core:test :android:test :core:apiCheck :android:apiCheck ktlintCheck` — all green.
- `amplitude-sdk-verification` remote-config scenarios (sealed key, delivery modes, `WaitForRemote` via MockWebServer incl. receiving a later refresh, dot-path, cache) pass against this branch.

### Useful links and documentation (optional)
- Package README: `core/src/main/java/com/amplitude/core/remoteconfig/README.md` (mermaid diagrams + migration note)
- iOS reference: `AmplitudeCore-Swift/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift`; subsequent-update parity: `AmplitudeCore-Swift#80`

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change? binary-incompatible, but confined to the gated internal \`RemoteConfigClient\` (see [README migration note](https://github.com/amplitude/Amplitude-Kotlin/blob/6ba6602282dbc293149516e6c3ef81504f9403a5/core/src/main/java/com/amplitude/core/remoteconfig/README.md#compatibility))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large rewrite of remote-config fetch, cache, and callback delivery affects autocapture, network tracking, diagnostics, and session replay; binary-incompatible API changes require all internal subscribers to handle null config/timestamp correctly.
> 
> **Overview**
> **Aligns Android remote config with iOS/Web:** one nested blob from `config_group=android`, dot-path slices at delivery, and shared subscribe/delivery semantics.
> 
> **API and gating:** `RemoteConfigClient.Key` moves from an enum to a sealed class (`AnalyticsSdk`, `Diagnostics`, session-replay keys, `Custom("dot.path")`). `onUpdate` now takes nullable `config` and `timestamp` (null timestamp = fetch failed; null config with a timestamp = key missing). The client, `Amplitude.remoteConfigClient`, and `ConfigMap` helpers are behind `@RestrictedAmplitudeFeature`; internal callers opt in and use the new key names.
> 
> **Client behavior:** Subscribers share one in-flight fetch with `fetchId` de-duplication; successful refreshes broadcast to all subscribers while failures are not fan-out. Delivery modes only control the **initial** callback—after that, everyone gets updates. Cache vs remote ordering is fixed (no stale cache after remote), old flat cached blobs are ignored, persistence is best-effort, and `WaitForRemote` matches iOS (including later refreshes after the first delivery).
> 
> **Android consumers:** `AutocaptureManager` and `NetworkTrackingPlugin` handle nullable config (network tracking resets to local options on null). Tests and `core.api` reflect the binary API change; a package README documents behavior and migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8868a65c94cc357ce43121c49560626c62dc5e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->