### PR TITLE
feat(core): Plugin contract — state callbacks, identity notifications, dedup (SDKA-6)

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -133,12 +133,14 @@ open class Amplitude internal constructor(
     }
 
     override fun reset(): Amplitude {
-        setUserId(null)
-        if (isBuilt.isCompleted) {
-            androidContextPlugin.initializeDeviceId(configuration as Configuration, forceRegenerate = true)
-        } else {
-            setDeviceId(ContextPlugin.generateRandomDeviceId())
-        }
+        val newDeviceId =
+            if (isBuilt.isCompleted) {
+                androidContextPlugin.resolveDeviceId(configuration as Configuration, forceRegenerate = true)
+                    ?: ContextPlugin.generateRandomDeviceId()
+            } else {
+                ContextPlugin.generateRandomDeviceId()
+            }
+        resetIdentity(newDeviceId)
         return this
     }
 

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -47,6 +47,8 @@ class Timeline(
                     if (restoredSessionId > DEFAULT_SESSION_ID) {
                         amplitude.notifySessionIdChanged(restoredSessionId)
                     }
+                } else if (initialSessionId > DEFAULT_SESSION_ID) {
+                    amplitude.notifySessionIdChanged(initialSessionId)
                 }
                 lastEventId = storage.readLong(LAST_EVENT_ID, DEFAULT_EVENT_ID_OR_TIME)
                 lastEventTime = storage.readLong(LAST_EVENT_TIME, DEFAULT_EVENT_ID_OR_TIME)

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -2,6 +2,7 @@ package com.amplitude.android
 
 import com.amplitude.android.Amplitude.Companion.END_SESSION_EVENT
 import com.amplitude.android.Amplitude.Companion.START_SESSION_EVENT
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.Storage
 import com.amplitude.core.Storage.Constants
 import com.amplitude.core.Storage.Constants.LAST_EVENT_ID
@@ -41,7 +42,11 @@ class Timeline(
                 isBuilt.await()
 
                 if (initialSessionId == null) {
-                    _sessionId.set(storage.readLong(PREVIOUS_SESSION_ID, DEFAULT_SESSION_ID))
+                    val restoredSessionId = storage.readLong(PREVIOUS_SESSION_ID, DEFAULT_SESSION_ID)
+                    _sessionId.set(restoredSessionId)
+                    if (restoredSessionId > DEFAULT_SESSION_ID) {
+                        amplitude.notifySessionIdChanged(restoredSessionId)
+                    }
                 }
                 lastEventId = storage.readLong(LAST_EVENT_ID, DEFAULT_EVENT_ID_OR_TIME)
                 lastEventTime = storage.readLong(LAST_EVENT_TIME, DEFAULT_EVENT_ID_OR_TIME)
@@ -156,6 +161,7 @@ class Timeline(
     private suspend fun setSessionId(timestamp: Long) {
         _sessionId.set(timestamp)
         amplitude.storage.write(PREVIOUS_SESSION_ID, sessionId.toString())
+        amplitude.notifySessionIdChanged(timestamp)
     }
 
     private suspend fun startNewSession(timestamp: Long): List<BaseEvent> {
@@ -210,6 +216,11 @@ class Timeline(
     ): Long {
         return read(key)?.toLongOrNull() ?: default
     }
+}
+
+@OptIn(RestrictedAmplitudeFeature::class)
+private fun com.amplitude.core.Amplitude.notifySessionIdChanged(sessionId: Long) {
+    notifyAllPlugins { it.onSessionIdChanged(sessionId) }
 }
 
 sealed class EventQueueMessage {

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -60,18 +60,21 @@ open class AndroidContextPlugin : Plugin {
         configuration: Configuration,
         forceRegenerate: Boolean = false,
     ) {
+        resolveDeviceId(configuration, forceRegenerate)?.let { setDeviceId(it) }
+    }
+
+    internal fun resolveDeviceId(
+        configuration: Configuration,
+        forceRegenerate: Boolean = false,
+    ): String? {
         // Check configuration
-        var deviceId = configuration.deviceId
-        if (deviceId != null) {
-            setDeviceId(deviceId)
-            return
-        }
+        configuration.deviceId?.let { return it }
 
         // Check store
         if (!forceRegenerate) {
-            deviceId = amplitude.store.deviceId
+            val deviceId = amplitude.store.deviceId
             if (deviceId != null && validDeviceId(deviceId) && !deviceId.endsWith(APP_SET_DEVICE_ID_SUFFIX)) {
-                return
+                return null
             }
         }
 
@@ -82,8 +85,7 @@ open class AndroidContextPlugin : Plugin {
         ) {
             val advertisingId = contextProvider.advertisingId
             if (advertisingId != null && validDeviceId(advertisingId)) {
-                setDeviceId(advertisingId)
-                return
+                return advertisingId
             }
         }
 
@@ -91,13 +93,12 @@ open class AndroidContextPlugin : Plugin {
         if (configuration.useAppSetIdForDeviceId) {
             val appSetId = contextProvider.appSetId
             if (appSetId != null && validDeviceId(appSetId)) {
-                setDeviceId("$appSetId$APP_SET_DEVICE_ID_SUFFIX")
-                return
+                return "$appSetId$APP_SET_DEVICE_ID_SUFFIX"
             }
         }
 
         // Generate random id
-        setDeviceId(ContextPlugin.generateRandomDeviceId())
+        return ContextPlugin.generateRandomDeviceId()
     }
 
     private fun applyContextData(event: BaseEvent) {

--- a/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
@@ -1,0 +1,216 @@
+package com.amplitude.android
+
+import android.app.Application
+import android.content.Context
+import android.net.ConnectivityManager
+import com.amplitude.MainDispatcherRule
+import com.amplitude.android.utilities.createFakeAmplitude
+import com.amplitude.android.utilities.enterForeground
+import com.amplitude.android.utilities.setupMockAndroidContext
+import com.amplitude.core.Amplitude
+import com.amplitude.core.Storage
+import com.amplitude.core.StorageProvider
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.platform.ObservePlugin
+import com.amplitude.core.platform.Plugin
+import com.amplitude.core.utilities.ConsoleLoggerProvider
+import com.amplitude.core.utilities.InMemoryStorage
+import com.amplitude.core.utilities.InMemoryStorageProvider
+import com.amplitude.id.IMIdentityStorageProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class PluginContractAndroidTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `session callback fires for new and observe plugins`() =
+        runTest {
+            val amplitude = createTestAmplitude()
+            val timeline = SessionPlugin("timeline")
+            val observe = SessionObservePlugin("observe")
+
+            amplitude.add(timeline)
+            amplitude.add(observe)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            enterForeground(amplitude, 1_000L)
+
+            assertEquals(listOf(amplitude.sessionId), timeline.sessionIds)
+            assertEquals(listOf(amplitude.sessionId), observe.sessionIds)
+        }
+
+    @Test
+    fun `session callback fires when persisted session is restored`() =
+        runTest {
+            val storage = InMemoryStorage()
+            storage.write(Storage.Constants.PREVIOUS_SESSION_ID, "12345")
+            val amplitude = createTestAmplitude(storageProvider = SharedStorageProvider(storage))
+            val timeline = SessionPlugin("timeline")
+
+            amplitude.add(timeline)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            assertEquals(listOf(12345L), timeline.sessionIds)
+        }
+
+    @Test
+    fun `reset rotates deviceId and uses one identity reset notification`() =
+        runTest {
+            val amplitude = createTestAmplitude()
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+            amplitude.setUserId("user-1")
+            val before = amplitude.getDeviceId()
+            val recorder = ResetPlugin("reset")
+
+            amplitude.add(recorder)
+            amplitude.reset()
+            advanceUntilIdle()
+
+            assertNotNull(before)
+            assertNotEquals(before, amplitude.getDeviceId())
+            assertEquals(listOf<String?>(null), recorder.userIds)
+            assertEquals(1, recorder.deviceIds.size)
+            assertEquals(1, recorder.resets)
+        }
+
+    @Test
+    fun `named plugin add replaces old Android plugin`() =
+        runTest {
+            val amplitude = createTestAmplitude()
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+            val first = NamedPlugin("shared")
+            val second = NamedPlugin("shared")
+
+            amplitude.add(first)
+            amplitude.add(second)
+
+            assertTrue(first.tornDown)
+            assertSame(second, amplitude.findPlugin<NamedPlugin>())
+        }
+
+    private fun TestScope.createTestAmplitude(
+        storageProvider: StorageProvider = InMemoryStorageProvider(),
+    ): com.amplitude.android.Amplitude {
+        return createFakeAmplitude(
+            server = null,
+            scheduler = testScheduler,
+            configuration = configuration(storageProvider),
+        )
+    }
+
+    private fun configuration(storageProvider: StorageProvider): Configuration {
+        setupMockAndroidContext()
+        val context = mockk<Application>(relaxed = true)
+        val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
+        every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        val dirNameSlot = slot<String>()
+        every { context.getDir(capture(dirNameSlot), any()) } answers {
+            File("/tmp/amplitude-kotlin/${dirNameSlot.captured}")
+        }
+
+        return Configuration(
+            apiKey = "api-key",
+            context = context,
+            instanceName = "plugin-contract-android-test",
+            minTimeBetweenSessionsMillis = 100,
+            storageProvider = storageProvider,
+            autocapture = autocaptureOptions { +sessions },
+            loggerProvider = ConsoleLoggerProvider(),
+            identifyInterceptStorageProvider = InMemoryStorageProvider(),
+            identityStorageProvider = IMIdentityStorageProvider(),
+            enableAutocaptureRemoteConfig = false,
+            enableDiagnostics = false,
+        )
+    }
+}
+
+private class SharedStorageProvider(
+    private val storage: Storage,
+) : StorageProvider {
+    override fun getStorage(
+        amplitude: Amplitude,
+        prefix: String?,
+    ): Storage = storage
+}
+
+private class SessionPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+    val sessionIds = mutableListOf<Long>()
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onSessionIdChanged(sessionId: Long) {
+        sessionIds += sessionId
+    }
+}
+
+private class SessionObservePlugin(override val name: String) : ObservePlugin() {
+    override lateinit var amplitude: Amplitude
+    val sessionIds = mutableListOf<Long>()
+
+    override fun onUserIdChanged(userId: String?) {}
+
+    override fun onDeviceIdChanged(deviceId: String?) {}
+
+    override fun onSessionIdChanged(sessionId: Long) {
+        sessionIds += sessionId
+    }
+}
+
+private class ResetPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+    val userIds = mutableListOf<String?>()
+    val deviceIds = mutableListOf<String?>()
+    var resets = 0
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onUserIdChanged(userId: String?) {
+        userIds += userId
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds += deviceId
+    }
+
+    override fun onReset() {
+        resets += 1
+    }
+}
+
+private class NamedPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+    var tornDown = false
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        tornDown = true
+    }
+}

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -83,8 +83,10 @@ public class com/amplitude/core/Amplitude {
 	public final fun isBuilt ()Lkotlinx/coroutines/Deferred;
 	public final fun logEvent (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/Amplitude;
 	public final fun logRevenue (Lcom/amplitude/core/events/Revenue;)Lcom/amplitude/core/Amplitude;
+	public final fun notifyAllPlugins (Lkotlin/jvm/functions/Function1;)V
 	public final fun remove (Lcom/amplitude/core/platform/Plugin;)Lcom/amplitude/core/Amplitude;
 	public fun reset ()Lcom/amplitude/core/Amplitude;
+	public final fun resetIdentity (Ljava/lang/String;)V
 	public final fun revenue (Lcom/amplitude/core/events/Revenue;)Lcom/amplitude/core/Amplitude;
 	public final fun revenue (Lcom/amplitude/core/events/Revenue;Lcom/amplitude/core/events/EventOptions;)Lcom/amplitude/core/Amplitude;
 	public final fun revenue (Lcom/amplitude/core/events/RevenueEvent;)Lcom/amplitude/core/Amplitude;
@@ -803,7 +805,13 @@ public abstract class com/amplitude/core/platform/ObservePlugin : com/amplitude/
 public abstract interface class com/amplitude/core/platform/Plugin {
 	public fun execute (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;
 	public abstract fun getAmplitude ()Lcom/amplitude/core/Amplitude;
+	public fun getName ()Ljava/lang/String;
 	public abstract fun getType ()Lcom/amplitude/core/platform/Plugin$Type;
+	public fun onDeviceIdChanged (Ljava/lang/String;)V
+	public fun onOptOutChanged (Z)V
+	public fun onReset ()V
+	public fun onSessionIdChanged (J)V
+	public fun onUserIdChanged (Ljava/lang/String;)V
 	public abstract fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
 	public fun setup (Lcom/amplitude/core/Amplitude;)V
 	public fun teardown ()V

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import java.io.File
+import java.util.EnumSet
 import java.util.concurrent.Executors
 
 /**
@@ -86,7 +87,7 @@ open class Amplitude(
             coroutineScope = amplitudeScope,
             networkIODispatcher = networkIODispatcher,
             storageIODispatcher = storageIODispatcher,
-            remoteConfigClient = remoteConfigClient,
+            remoteConfigClient = if (configuration.enableDiagnostics) remoteConfigClient else null,
             httpClient = HttpClient(configuration, logger),
             contextProvider = diagnosticsContextProvider(),
             enabled = configuration.enableDiagnostics,
@@ -132,12 +133,15 @@ open class Amplitude(
     open var optOut: Boolean
         get() = configuration.optOut
         set(value) {
+            if (configuration.optOut == value) return
             configuration.optOut = value
+            notifyPlugins { it.onOptOutChanged(value) }
         }
 
     init {
         require(configuration.isValid()) { "invalid configuration" }
         timeline = this.createTimeline()
+        store.onIdentityChanged = ::notifyIdentityChanged
         isBuilt = this.build()
         isBuilt.start()
     }
@@ -164,7 +168,7 @@ open class Amplitude(
 
     protected fun createIdentityContainer(identityConfiguration: IdentityConfiguration) {
         idContainer = IdentityContainer.getInstance(identityConfiguration)
-        identityCoordinator.bootstrap(idContainer.identityManager)
+        notifyIdentityChanged(identityCoordinator.bootstrap(idContainer.identityManager))
     }
 
     protected open fun build(): Deferred<Boolean> {
@@ -306,7 +310,7 @@ open class Amplitude(
      * @return the Amplitude instance
      */
     fun setUserId(userId: String?): Amplitude {
-        identityCoordinator.setUserId(userId)
+        notifyIdentityChanged(identityCoordinator.setUserId(userId))
         return this
     }
 
@@ -326,7 +330,7 @@ open class Amplitude(
      * @return the Amplitude instance
      */
     fun setDeviceId(deviceId: String): Amplitude {
-        identityCoordinator.setDeviceId(deviceId)
+        notifyIdentityChanged(identityCoordinator.setDeviceId(deviceId))
         return this
     }
 
@@ -346,8 +350,7 @@ open class Amplitude(
      * @return the Amplitude instance
      */
     open fun reset(): Amplitude {
-        setUserId(null)
-        setDeviceId(ContextPlugin.generateRandomDeviceId())
+        doResetWithDeviceId(ContextPlugin.generateRandomDeviceId())
         return this
     }
 
@@ -517,6 +520,8 @@ open class Amplitude(
      * @return the Amplitude instance
      */
     fun add(plugin: Plugin): Amplitude {
+        plugin.name?.let { removePluginsByName(it) }
+
         when (plugin) {
             is ObservePlugin -> {
                 this.store.add(plugin, this)
@@ -527,6 +532,12 @@ open class Amplitude(
         }
 
         return this
+    }
+
+    inline fun <reified T : Plugin> findPlugin(): T? {
+        timeline.findPlugin<T>()?.let { return it }
+        val observeSnapshot = synchronized(store.plugins) { store.plugins.toList() }
+        return observeSnapshot.firstOrNull { it is T } as? T
     }
 
     fun remove(plugin: Plugin): Amplitude {
@@ -542,6 +553,20 @@ open class Amplitude(
         return this
     }
 
+    @RestrictedAmplitudeFeature
+    fun notifyAllPlugins(block: (Plugin) -> Unit) {
+        notifyPlugins(block)
+    }
+
+    @RestrictedAmplitudeFeature
+    fun resetIdentity(newDeviceId: String) {
+        doResetWithDeviceId(newDeviceId)
+    }
+
+    private fun doResetWithDeviceId(newDeviceId: String) {
+        notifyIdentityChanged(identityCoordinator.resetIdentity(newDeviceId), notifyReset = true)
+    }
+
     fun flush() {
         amplitudeScope.launch(amplitudeDispatcher) {
             isBuilt.await()
@@ -549,6 +574,74 @@ open class Amplitude(
             timeline.applyClosure {
                 (it as? EventPlugin)?.flush()
             }
+        }
+    }
+
+    private fun notifyIdentityChanged(changes: EnumSet<State.IdentityChange>) {
+        notifyIdentityChanged(changes, notifyReset = false)
+    }
+
+    private fun notifyIdentityChanged(
+        changes: EnumSet<State.IdentityChange>,
+        notifyReset: Boolean,
+    ) {
+        if (changes.isEmpty() && !notifyReset) return
+
+        val plugins = pluginsSnapshot()
+        if (changes.contains(State.IdentityChange.USER_ID)) {
+            plugins.forEach { plugin ->
+                notifyPlugin(plugin) { it.onUserIdChanged(store.userId) }
+            }
+        }
+        if (changes.contains(State.IdentityChange.DEVICE_ID)) {
+            plugins.forEach { plugin ->
+                notifyPlugin(plugin) { it.onDeviceIdChanged(store.deviceId) }
+            }
+        }
+        if (notifyReset) {
+            plugins.forEach { plugin ->
+                notifyPlugin(plugin) { it.onReset() }
+            }
+        }
+    }
+
+    private fun pluginsSnapshot(): List<Plugin> {
+        return timeline.pluginsSnapshot() + store.pluginsSnapshot()
+    }
+
+    private fun notifyPlugins(block: (Plugin) -> Unit) {
+        pluginsSnapshot().forEach { notifyPlugin(it, block) }
+    }
+
+    private fun removePluginsByName(name: String) {
+        val removed = timeline.removeByName(name) + store.removeByName(name)
+        removed.forEach { teardownPlugin(it) }
+    }
+
+    private fun teardownPlugin(plugin: Plugin) {
+        try {
+            plugin.teardown()
+        } catch (e: Exception) {
+            logger.warn("Plugin '${plugin.identifier()}' threw during teardown: $e")
+        }
+    }
+
+    private fun notifyPlugin(
+        plugin: Plugin,
+        block: (Plugin) -> Unit,
+    ) {
+        try {
+            block(plugin)
+        } catch (e: Exception) {
+            logger.warn("Plugin '${plugin.identifier()}' threw during notify callback: $e")
+        }
+    }
+
+    private fun Plugin.identifier(): String {
+        return try {
+            name ?: this::class.java.name
+        } catch (_: Exception) {
+            this::class.java.name
         }
     }
 

--- a/core/src/main/java/com/amplitude/core/IdentityCoordinator.kt
+++ b/core/src/main/java/com/amplitude/core/IdentityCoordinator.kt
@@ -1,6 +1,7 @@
 package com.amplitude.core
 
 import com.amplitude.id.IdentityManager
+import java.util.EnumSet
 
 /**
  * Coordinates identity (userId/deviceId) updates between [State] and [IdentityManager].
@@ -8,6 +9,10 @@ import com.amplitude.id.IdentityManager
  * All mutations go through synchronized blocks to ensure atomic state + persistence.
  * Before build, only [State] is updated and pending flags are set.
  * During [bootstrap], persisted identity is reconciled with any pre-build changes.
+ *
+ * Notifications are deliberately not sent while [lock] is held. Plugin callbacks
+ * can re-enter identity APIs, and JVM monitors are reentrant, so notifying inside
+ * the lock can let an outer call overwrite an inner callback's newer value.
  */
 internal class IdentityCoordinator internal constructor(private val state: State) {
     private val lock = Any()
@@ -20,27 +25,45 @@ internal class IdentityCoordinator internal constructor(private val state: State
 
     private fun <T> Pending<T>?.getOrElse(default: T?) = if (this != null) value else default
 
-    fun setUserId(userId: String?) {
+    fun setUserId(userId: String?): EnumSet<State.IdentityChange> {
         synchronized(lock) {
-            state.userId = userId
+            state.setUserIdSilently(userId)
             identityManager?.editIdentity()?.setUserId(userId)?.commit()
                 ?: run { pendingUserId = Pending(userId) }
         }
+        return EnumSet.of(State.IdentityChange.USER_ID)
     }
 
-    fun setDeviceId(deviceId: String) {
+    fun setDeviceId(deviceId: String): EnumSet<State.IdentityChange> {
         synchronized(lock) {
-            state.deviceId = deviceId
+            state.setDeviceIdSilently(deviceId)
             identityManager?.editIdentity()?.setDeviceId(deviceId)?.commit()
                 ?: run { pendingDeviceId = Pending(deviceId) }
         }
+        return EnumSet.of(State.IdentityChange.DEVICE_ID)
+    }
+
+    fun resetIdentity(newDeviceId: String): EnumSet<State.IdentityChange> {
+        synchronized(lock) {
+            state.setUserIdSilently(null)
+            state.setDeviceIdSilently(newDeviceId)
+            identityManager?.editIdentity()
+                ?.setUserId(null)
+                ?.setDeviceId(newDeviceId)
+                ?.commit()
+                ?: run {
+                    pendingUserId = Pending(null)
+                    pendingDeviceId = Pending(newDeviceId)
+                }
+        }
+        return EnumSet.of(State.IdentityChange.USER_ID, State.IdentityChange.DEVICE_ID)
     }
 
     /**
      * Called during [com.amplitude.core.Amplitude.createIdentityContainer] to reconcile
      * persisted identity with any pre-build changes. User intent wins over persisted values.
      */
-    internal fun bootstrap(identityManager: IdentityManager) {
+    internal fun bootstrap(identityManager: IdentityManager): EnumSet<State.IdentityChange> {
         synchronized(lock) {
             this.identityManager = identityManager
             val persisted = identityManager.getIdentity()
@@ -48,8 +71,8 @@ internal class IdentityCoordinator internal constructor(private val state: State
             val userId = pendingUserId.getOrElse(persisted.userId)
             val deviceId = pendingDeviceId.getOrElse(persisted.deviceId)
 
-            state.userId = userId
-            state.deviceId = deviceId
+            state.setUserIdSilently(userId)
+            state.setDeviceIdSilently(deviceId)
 
             identityManager.editIdentity()
                 .setUserId(userId)
@@ -59,5 +82,6 @@ internal class IdentityCoordinator internal constructor(private val state: State
             pendingUserId = null
             pendingDeviceId = null
         }
+        return EnumSet.of(State.IdentityChange.USER_ID, State.IdentityChange.DEVICE_ID)
     }
 }

--- a/core/src/main/java/com/amplitude/core/State.kt
+++ b/core/src/main/java/com/amplitude/core/State.kt
@@ -1,36 +1,80 @@
 package com.amplitude.core
 
 import com.amplitude.core.platform.ObservePlugin
+import java.util.EnumSet
 
 class State {
-    var userId: String? = null
-        set(value: String?) {
-            field = value
-            plugins.forEach { plugin ->
-                plugin.onUserIdChanged(value)
-            }
+    internal enum class IdentityChange {
+        USER_ID,
+        DEVICE_ID,
+    }
+
+    internal var onIdentityChanged: ((EnumSet<IdentityChange>) -> Unit)? = null
+
+    private var _userId: String? = null
+    private var _deviceId: String? = null
+
+    var userId: String?
+        get() = _userId
+        set(value) {
+            _userId = value
+            notifyIdentityChanged(IdentityChange.USER_ID)
         }
 
-    var deviceId: String? = null
-        set(value: String?) {
-            field = value
-            plugins.forEach { plugin ->
-                plugin.onDeviceIdChanged(value)
-            }
+    var deviceId: String?
+        get() = _deviceId
+        set(value) {
+            _deviceId = value
+            notifyIdentityChanged(IdentityChange.DEVICE_ID)
         }
+
+    internal fun setUserIdSilently(value: String?) {
+        _userId = value
+    }
+
+    internal fun setDeviceIdSilently(value: String?) {
+        _deviceId = value
+    }
 
     val plugins: MutableList<ObservePlugin> = mutableListOf()
 
     fun add(
         plugin: ObservePlugin,
         amplitude: Amplitude,
-    ) = synchronized(plugins) {
+    ): Boolean {
         plugin.setup(amplitude)
-        plugins.add(plugin)
+        return synchronized(plugins) {
+            plugins.add(plugin)
+        }
     }
 
-    fun remove(plugin: ObservePlugin) =
+    fun remove(plugin: ObservePlugin): Boolean {
+        val removed =
+            synchronized(plugins) {
+                plugins.removeAll { it === plugin }
+            }
+        if (removed) plugin.teardown()
+        return removed
+    }
+
+    internal fun removeByName(name: String): List<ObservePlugin> =
         synchronized(plugins) {
-            plugins.removeAll { it === plugin }
+            val removed = plugins.filter { it.name == name }
+            plugins.removeAll(removed)
+            removed
         }
+
+    internal fun pluginsSnapshot(): List<ObservePlugin> =
+        synchronized(plugins) {
+            plugins.toList()
+        }
+
+    internal fun notifyIdentityChanged(changes: EnumSet<IdentityChange>) {
+        if (changes.isEmpty()) return
+        onIdentityChanged?.invoke(changes)
+    }
+
+    private fun notifyIdentityChanged(change: IdentityChange) {
+        notifyIdentityChanged(EnumSet.of(change))
+    }
 }

--- a/core/src/main/java/com/amplitude/core/platform/Mediator.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Mediator.kt
@@ -15,6 +15,14 @@ internal class Mediator(
 
     fun remove(plugin: Plugin) = plugins.removeAll { it === plugin }
 
+    fun removeByName(name: String): List<Plugin> {
+        val removed = plugins.filter { it.name == name }
+        plugins.removeAll(removed)
+        return removed
+    }
+
+    fun snapshot(): List<Plugin> = plugins.toList()
+
     fun execute(event: BaseEvent): BaseEvent? {
         var result: BaseEvent? = event
 

--- a/core/src/main/java/com/amplitude/core/platform/Plugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Plugin.kt
@@ -18,6 +18,12 @@ interface Plugin {
     val type: Type
     var amplitude: Amplitude
 
+    /**
+     * Optional stable plugin identifier. When non-null, adding another plugin
+     * with the same name replaces the previous one.
+     */
+    val name: String? get() = null
+
     fun setup(amplitude: Amplitude) {
         this.amplitude = amplitude
     }
@@ -29,6 +35,16 @@ interface Plugin {
     fun teardown() {
         // Clean up any resources from setup if necessary
     }
+
+    fun onUserIdChanged(userId: String?) {}
+
+    fun onDeviceIdChanged(deviceId: String?) {}
+
+    fun onSessionIdChanged(sessionId: Long) {}
+
+    fun onOptOutChanged(optOut: Boolean) {}
+
+    fun onReset() {}
 }
 
 interface EventPlugin : Plugin {
@@ -108,9 +124,9 @@ abstract class DestinationPlugin : EventPlugin {
 abstract class ObservePlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.Observe
 
-    abstract fun onUserIdChanged(userId: String?)
+    abstract override fun onUserIdChanged(userId: String?)
 
-    abstract fun onDeviceIdChanged(deviceId: String?)
+    abstract override fun onDeviceIdChanged(deviceId: String?)
 
     final override fun execute(event: BaseEvent): BaseEvent? {
         return null

--- a/core/src/main/java/com/amplitude/core/platform/Timeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Timeline.kt
@@ -10,6 +10,7 @@ open class Timeline {
             Plugin.Type.Enrichment to Mediator(),
             Plugin.Type.Destination to Mediator(),
             Plugin.Type.Utility to Mediator(),
+            Plugin.Type.Observe to Mediator(),
         )
     lateinit var amplitude: Amplitude
 
@@ -55,13 +56,26 @@ open class Timeline {
     }
 
     fun remove(plugin: Plugin) {
-        // remove all plugins with this name in every category
         plugins.forEach { (_, list) ->
             val wasRemoved = list.remove(plugin)
             if (wasRemoved) {
                 plugin.teardown()
             }
         }
+    }
+
+    internal fun removeByName(name: String): List<Plugin> = plugins.values.flatMap { it.removeByName(name) }
+
+    internal fun pluginsSnapshot(): List<Plugin> = plugins.values.flatMap { it.snapshot() }
+
+    inline fun <reified T : Plugin> findPlugin(): T? {
+        var match: T? = null
+        applyClosure { plugin ->
+            if (match == null && plugin is T) {
+                match = plugin
+            }
+        }
+        return match
     }
 
     // Applies a closure on all registered plugins

--- a/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
@@ -1,0 +1,275 @@
+package com.amplitude.core.platform
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.utils.FakeAmplitude
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class PluginContractTest {
+    @Test
+    fun `state callbacks fan out to timeline and observe plugins`() {
+        val amplitude = FakeAmplitude()
+        val timeline = RecordingPlugin("timeline")
+        val observe = RecordingObservePlugin("observe")
+
+        amplitude.add(timeline)
+        amplitude.add(observe)
+
+        amplitude.setUserId("user-1")
+        amplitude.setDeviceId("device-1")
+        amplitude.optOut = true
+        amplitude.reset()
+
+        assertEquals(listOf("user-1", null), timeline.userIds)
+        assertEquals(2, timeline.deviceIds.size)
+        assertEquals("device-1", timeline.deviceIds.first())
+        assertEquals(listOf(true), timeline.optOuts)
+        assertEquals(1, timeline.resets)
+
+        assertEquals(listOf("user-1", null), observe.userIds)
+        assertEquals(2, observe.deviceIds.size)
+        assertEquals("device-1", observe.deviceIds.first())
+        assertEquals(listOf(true), observe.optOuts)
+        assertEquals(1, observe.resets)
+    }
+
+    @Test
+    fun `reset uses one plugin snapshot for identity and reset callbacks`() {
+        val amplitude = FakeAmplitude()
+        val late = RecordingPlugin("late")
+        val mutator =
+            object : Plugin {
+                override val type: Plugin.Type = Plugin.Type.Before
+                override val name: String = "mutator"
+                override lateinit var amplitude: Amplitude
+
+                override fun execute(event: BaseEvent): BaseEvent = event
+
+                override fun onUserIdChanged(userId: String?) {
+                    if (userId == null) {
+                        amplitude.add(late)
+                    }
+                }
+            }
+
+        amplitude.add(mutator)
+        amplitude.reset()
+
+        assertTrue(late.userIds.isEmpty())
+        assertTrue(late.deviceIds.isEmpty())
+        assertEquals(0, late.resets)
+        assertSame(late, amplitude.findPlugin<RecordingPlugin>())
+    }
+
+    @Test
+    fun `throwing plugins do not stop later callbacks or later plugins`() {
+        val amplitude = FakeAmplitude()
+        val thrower = ThrowingObservePlugin()
+        val recorder = RecordingObservePlugin("recorder")
+
+        amplitude.add(thrower)
+        amplitude.add(recorder)
+
+        amplitude.reset()
+
+        assertEquals(listOf<String?>(null), recorder.userIds)
+        assertEquals(1, recorder.deviceIds.size)
+        assertEquals(1, recorder.resets)
+        assertEquals(1, thrower.deviceCallbackAttempts)
+    }
+
+    @Test
+    fun `reentrant userId callback does not get overwritten by outer mutation`() {
+        val amplitude = FakeAmplitude()
+        val completed = CountDownLatch(1)
+        val plugin =
+            object : ObservePlugin() {
+                override lateinit var amplitude: Amplitude
+                private var reentered = false
+
+                override fun onUserIdChanged(userId: String?) {
+                    if (!reentered && userId == "outer") {
+                        reentered = true
+                        amplitude.setUserId("inner")
+                    }
+                    if (userId == "inner") {
+                        completed.countDown()
+                    }
+                }
+
+                override fun onDeviceIdChanged(deviceId: String?) {}
+            }
+
+        amplitude.add(plugin)
+        amplitude.setUserId("outer")
+
+        assertTrue(completed.await(5, TimeUnit.SECONDS))
+        assertEquals("inner", amplitude.store.userId)
+    }
+
+    @Test
+    fun `named plugin add replaces existing plugin across stores`() {
+        val amplitude = FakeAmplitude()
+        val first = NamedPlugin("shared")
+        val replacement = NamedObservePlugin("shared")
+
+        amplitude.add(first)
+        amplitude.add(replacement)
+
+        assertTrue(first.tornDown)
+        assertNull(amplitude.findPlugin<NamedPlugin>())
+        assertSame(replacement, amplitude.findPlugin<NamedObservePlugin>())
+    }
+
+    @Test
+    fun `bare observe type plugin is stored in the timeline`() {
+        val amplitude = FakeAmplitude()
+        val plugin = RecordingPlugin("bare-observe", Plugin.Type.Observe)
+
+        amplitude.add(plugin)
+        amplitude.setUserId("user-1")
+
+        assertEquals(listOf<String?>("user-1"), plugin.userIds)
+        assertSame(plugin, amplitude.findPlugin<RecordingPlugin>())
+    }
+
+    @RepeatedTest(10)
+    fun `concurrent add setUserId and reset do not crash or deadlock`() {
+        val amplitude = FakeAmplitude()
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+        val barrier = CyclicBarrier(3)
+        val done = CountDownLatch(3)
+
+        fun launch(block: () -> Unit) {
+            Thread {
+                try {
+                    barrier.await()
+                    block()
+                } catch (t: Throwable) {
+                    errors += t
+                } finally {
+                    done.countDown()
+                }
+            }.start()
+        }
+
+        launch {
+            repeat(50) { amplitude.add(RecordingObservePlugin("observe-$it")) }
+        }
+        launch {
+            repeat(50) { amplitude.setUserId("user-$it") }
+        }
+        launch {
+            repeat(50) { amplitude.reset() }
+        }
+
+        assertTrue(done.await(5, TimeUnit.SECONDS))
+        assertTrue(errors.isEmpty(), errors.joinToString { it.message.orEmpty() })
+    }
+}
+
+private open class RecordingPlugin(
+    override val name: String?,
+    override val type: Plugin.Type = Plugin.Type.Before,
+) : Plugin {
+    override lateinit var amplitude: Amplitude
+    val userIds = Collections.synchronizedList(mutableListOf<String?>())
+    val deviceIds = Collections.synchronizedList(mutableListOf<String?>())
+    val optOuts = Collections.synchronizedList(mutableListOf<Boolean>())
+    private val resetCount = AtomicInteger()
+    val resets: Int get() = resetCount.get()
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onUserIdChanged(userId: String?) {
+        userIds.add(userId)
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds.add(deviceId)
+    }
+
+    override fun onOptOutChanged(optOut: Boolean) {
+        optOuts.add(optOut)
+    }
+
+    override fun onReset() {
+        resetCount.incrementAndGet()
+    }
+}
+
+private class RecordingObservePlugin(
+    override val name: String?,
+) : ObservePlugin() {
+    override lateinit var amplitude: Amplitude
+    val userIds = Collections.synchronizedList(mutableListOf<String?>())
+    val deviceIds = Collections.synchronizedList(mutableListOf<String?>())
+    val optOuts = Collections.synchronizedList(mutableListOf<Boolean>())
+    private val resetCount = AtomicInteger()
+    val resets: Int get() = resetCount.get()
+
+    override fun onUserIdChanged(userId: String?) {
+        userIds.add(userId)
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds.add(deviceId)
+    }
+
+    override fun onOptOutChanged(optOut: Boolean) {
+        optOuts.add(optOut)
+    }
+
+    override fun onReset() {
+        resetCount.incrementAndGet()
+    }
+}
+
+private class ThrowingObservePlugin : ObservePlugin() {
+    override val name: String = "thrower"
+    override lateinit var amplitude: Amplitude
+    var deviceCallbackAttempts = 0
+
+    override fun onUserIdChanged(userId: String?) {
+        throw RuntimeException("user")
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceCallbackAttempts += 1
+        throw RuntimeException("device")
+    }
+
+    override fun onReset() {
+        throw RuntimeException("reset")
+    }
+}
+
+private class NamedPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+    var tornDown = false
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        tornDown = true
+    }
+}
+
+private class NamedObservePlugin(override val name: String) : ObservePlugin() {
+    override lateinit var amplitude: Amplitude
+
+    override fun onUserIdChanged(userId: String?) {}
+
+    override fun onDeviceIdChanged(deviceId: String?) {}
+}


### PR DESCRIPTION
### Describe what this PR is addressing

Blade SDKs (Session Replay, G&S, Experiment) and third-party hosts (Segment, mParticle) need to observe identity and lifecycle changes on the Amplitude instance they're plugged into. Before this PR, `Plugin` had no callbacks for userId/deviceId/optOut/reset/session changes, no way to find a registered plugin by type, and no deduplication when re-adding the same plugin. Reset was also broken — it fired two separate identity notifications (userId then deviceId) instead of one atomic wave.

### Describe the solution

**`IdentityCoordinator` returns, doesn't dispatch.** `setUserId`, `setDeviceId`, `resetIdentity`, and `bootstrap` each return an `EnumSet<State.IdentityChange>` describing what changed and notify nothing. `Amplitude` is the single dispatch owner — it turns that return value into plugin callbacks. This keeps notification structurally outside the identity lock (reentrancy fix), with no dual-path surface that could cause double-fires or ordering bugs.

**`Plugin` interface additions** (all defaulted — binary compat preserved):
- `onUserIdChanged(userId)`, `onDeviceIdChanged(deviceId)`, `onOptOutChanged(optOut)`, `onReset()`, `onSessionIdChanged(sessionId)`
- `name: String?` — optional identifier for replace-on-add dedup (teardown called on the displaced plugin)

**`Amplitude` additions:**
- `findPlugin<T>()` — searches timeline and observe store
- `notifyAllPlugins(block)` — single snapshot fan-out with per-plugin try/catch (one bad plugin doesn't block others)
- `resetIdentity(newDeviceId)` — atomic identity reset, fires one `onReset` wave

**Android:**
- `AndroidContextPlugin.resolveDeviceId` split out from `initializeDeviceId` so `reset()` can resolve the new device id before calling `resetIdentity` — eliminates the double identity-change
- `Timeline` fires `onSessionIdChanged` on both session restore (persisted session) and new session start
- `Type.Observe` mediator wired into `Timeline` so bare `Plugin` with `type = Observe` is no longer silently dropped

### Steps to verify the change

```bash
./gradlew :core:test :android:test apiCheck
```

New test classes: `PluginContractTest` (core), `PluginContractAndroidTest` (Android) — cover fan-out, dedup, reset atomicity, session callback on restore, and named-plugin replace-on-add.

### Useful links and documentation (optional)

[SDKA-6 — Linear](https://linear.app/amplitude/issue/SDKA-6/plugin-contract-state-callbacks-dedup-findplugin)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?