### PR TITLE
feat: plugin contract for blades - state callbacks, identity notifications

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -133,13 +133,19 @@ open class Amplitude internal constructor(
     }
 
     override fun reset(): Amplitude {
-        setUserId(null)
-        if (isBuilt.isCompleted) {
-            androidContextPlugin.initializeDeviceId(configuration as Configuration, forceRegenerate = true)
-        } else {
-            setDeviceId(ContextPlugin.generateRandomDeviceId())
-        }
+        val newDeviceId =
+            if (isBuilt.isCompleted) {
+                androidContextPlugin.resolveDeviceId(configuration as Configuration, forceRegenerate = true)
+                    ?: ContextPlugin.generateRandomDeviceId()
+            } else {
+                ContextPlugin.generateRandomDeviceId()
+            }
+        doResetWithDeviceId(newDeviceId)
         return this
+    }
+
+    internal fun notifySessionIdChanged(sessionId: Long) {
+        notifyAllPlugins { it.onSessionIdChanged(sessionId) }
     }
 
     @GuardedAmplitudeFeature

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -41,7 +41,13 @@ class Timeline(
                 isBuilt.await()
 
                 if (initialSessionId == null) {
-                    _sessionId.set(storage.readLong(PREVIOUS_SESSION_ID, DEFAULT_SESSION_ID))
+                    val restoredSessionId = storage.readLong(PREVIOUS_SESSION_ID, DEFAULT_SESSION_ID)
+                    _sessionId.set(restoredSessionId)
+                    if (restoredSessionId > DEFAULT_SESSION_ID) {
+                        (amplitude as Amplitude).notifySessionIdChanged(restoredSessionId)
+                    }
+                } else if (initialSessionId > DEFAULT_SESSION_ID) {
+                    (amplitude as Amplitude).notifySessionIdChanged(initialSessionId)
                 }
                 lastEventId = storage.readLong(LAST_EVENT_ID, DEFAULT_EVENT_ID_OR_TIME)
                 lastEventTime = storage.readLong(LAST_EVENT_TIME, DEFAULT_EVENT_ID_OR_TIME)
@@ -156,6 +162,7 @@ class Timeline(
     private suspend fun setSessionId(timestamp: Long) {
         _sessionId.set(timestamp)
         amplitude.storage.write(PREVIOUS_SESSION_ID, sessionId.toString())
+        (amplitude as Amplitude).notifySessionIdChanged(timestamp)
     }
 
     private suspend fun startNewSession(timestamp: Long): List<BaseEvent> {

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidContextPlugin.kt
@@ -60,18 +60,26 @@ open class AndroidContextPlugin : Plugin {
         configuration: Configuration,
         forceRegenerate: Boolean = false,
     ) {
+        resolveDeviceId(configuration, forceRegenerate)?.let { setDeviceId(it) }
+    }
+
+    /**
+     * Resolve the device id without writing it. Returns the id to use, or `null` to mean
+     * "keep the current one" (only possible when [forceRegenerate] is false). Splitting this
+     * out lets reset() compute a fresh id and route it through the single identity-reset path.
+     */
+    internal fun resolveDeviceId(
+        configuration: Configuration,
+        forceRegenerate: Boolean = false,
+    ): String? {
         // Check configuration
-        var deviceId = configuration.deviceId
-        if (deviceId != null) {
-            setDeviceId(deviceId)
-            return
-        }
+        configuration.deviceId?.let { return it }
 
         // Check store
         if (!forceRegenerate) {
-            deviceId = amplitude.store.deviceId
+            val deviceId = amplitude.store.deviceId
             if (deviceId != null && validDeviceId(deviceId) && !deviceId.endsWith(APP_SET_DEVICE_ID_SUFFIX)) {
-                return
+                return null
             }
         }
 
@@ -82,8 +90,7 @@ open class AndroidContextPlugin : Plugin {
         ) {
             val advertisingId = contextProvider.advertisingId
             if (advertisingId != null && validDeviceId(advertisingId)) {
-                setDeviceId(advertisingId)
-                return
+                return advertisingId
             }
         }
 
@@ -91,13 +98,12 @@ open class AndroidContextPlugin : Plugin {
         if (configuration.useAppSetIdForDeviceId) {
             val appSetId = contextProvider.appSetId
             if (appSetId != null && validDeviceId(appSetId)) {
-                setDeviceId("$appSetId$APP_SET_DEVICE_ID_SUFFIX")
-                return
+                return "$appSetId$APP_SET_DEVICE_ID_SUFFIX"
             }
         }
 
         // Generate random id
-        setDeviceId(ContextPlugin.generateRandomDeviceId())
+        return ContextPlugin.generateRandomDeviceId()
     }
 
     private fun applyContextData(event: BaseEvent) {

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeTest.kt
@@ -218,6 +218,32 @@ class AmplitudeTest {
         }
 
     @Test
+    fun `analytics connector identity is cleared and rotated on reset`() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = createConfiguration(),
+                )
+            amplitude.isBuilt.await()
+
+            val connector = AnalyticsConnector.getInstance(INSTANCE_NAME)
+            amplitude.setUserId("user-before-reset")
+            amplitude.setDeviceId("device-before-reset")
+            advanceUntilIdle()
+
+            val deviceIdBeforeReset = connector.identityStore.getIdentity().deviceId
+
+            amplitude.reset()
+            advanceUntilIdle()
+
+            val identityAfterReset = connector.identityStore.getIdentity()
+            assertNull(identityAfterReset.userId)
+            assertNotNull(identityAfterReset.deviceId)
+            assertNotEquals(deviceIdBeforeReset, identityAfterReset.deviceId)
+        }
+
+    @Test
     fun amplitude_getDeviceId_should_return_not_null_after_isBuilt() =
         runTest {
             val amplitude =

--- a/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
@@ -75,6 +75,21 @@ class PluginContractAndroidTest {
         }
 
     @Test
+    fun `persisted session restore reaches an ObservePlugin`() =
+        runTest {
+            val storage = InMemoryStorage()
+            storage.write(Storage.Constants.PREVIOUS_SESSION_ID, "12345")
+            val amplitude = createTestAmplitude(storageProvider = SharedStorageProvider(storage))
+            val observe = SessionObservePlugin("observe-restore")
+
+            amplitude.add(observe)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            assertEquals(listOf(12345L), observe.sessionIds)
+        }
+
+    @Test
     fun `reset rotates deviceId and uses one identity reset notification`() =
         runTest {
             val amplitude = createTestAmplitude()

--- a/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
@@ -25,10 +25,10 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -96,7 +96,7 @@ class PluginContractAndroidTest {
         }
 
     @Test
-    fun `named plugin add replaces old Android plugin`() =
+    fun `named plugin add keeps the first Android plugin`() =
         runTest {
             val amplitude = createTestAmplitude()
             amplitude.isBuilt.await()
@@ -107,8 +107,11 @@ class PluginContractAndroidTest {
             amplitude.add(first)
             amplitude.add(second)
 
-            assertTrue(first.tornDown)
-            assertSame(second, amplitude.findPlugin<NamedPlugin>())
+            // First registration wins; incumbent is not torn down.
+            assertSame(first, amplitude.findPlugin<NamedPlugin>())
+            assertFalse(first.tornDown)
+            // Newcomer was never set up.
+            assertFalse(second.wasSetUp)
         }
 
     private fun TestScope.createTestAmplitude(
@@ -207,6 +210,12 @@ private class NamedPlugin(override val name: String) : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
     override lateinit var amplitude: Amplitude
     var tornDown = false
+    var wasSetUp = false
+
+    override fun setup(amplitude: Amplitude) {
+        super.setup(amplitude)
+        wasSetUp = true
+    }
 
     override fun execute(event: BaseEvent): BaseEvent = event
 

--- a/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
@@ -1,0 +1,216 @@
+package com.amplitude.android
+
+import android.app.Application
+import android.content.Context
+import android.net.ConnectivityManager
+import com.amplitude.MainDispatcherRule
+import com.amplitude.android.utilities.createFakeAmplitude
+import com.amplitude.android.utilities.enterForeground
+import com.amplitude.android.utilities.setupMockAndroidContext
+import com.amplitude.core.Amplitude
+import com.amplitude.core.Storage
+import com.amplitude.core.StorageProvider
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.platform.ObservePlugin
+import com.amplitude.core.platform.Plugin
+import com.amplitude.core.utilities.ConsoleLoggerProvider
+import com.amplitude.core.utilities.InMemoryStorage
+import com.amplitude.core.utilities.InMemoryStorageProvider
+import com.amplitude.id.IMIdentityStorageProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class PluginContractAndroidTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `session callback fires for new and observe plugins`() =
+        runTest {
+            val amplitude = createTestAmplitude()
+            val timeline = SessionPlugin("timeline")
+            val observe = SessionObservePlugin("observe")
+
+            amplitude.add(timeline)
+            amplitude.add(observe)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            enterForeground(amplitude, 1_000L)
+
+            assertEquals(listOf(amplitude.sessionId), timeline.sessionIds)
+            assertEquals(listOf(amplitude.sessionId), observe.sessionIds)
+        }
+
+    @Test
+    fun `session callback fires when persisted session is restored`() =
+        runTest {
+            val storage = InMemoryStorage()
+            storage.write(Storage.Constants.PREVIOUS_SESSION_ID, "12345")
+            val amplitude = createTestAmplitude(storageProvider = SharedStorageProvider(storage))
+            val timeline = SessionPlugin("timeline")
+
+            amplitude.add(timeline)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            assertEquals(listOf(12345L), timeline.sessionIds)
+        }
+
+    @Test
+    fun `reset rotates deviceId and uses one identity reset notification`() =
+        runTest {
+            val amplitude = createTestAmplitude()
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+            amplitude.setUserId("user-1")
+            val before = amplitude.getDeviceId()
+            val recorder = ResetPlugin("reset")
+
+            amplitude.add(recorder)
+            amplitude.reset()
+            advanceUntilIdle()
+
+            assertNotNull(before)
+            assertNotEquals(before, amplitude.getDeviceId())
+            assertEquals(listOf<String?>(null), recorder.userIds)
+            assertEquals(1, recorder.deviceIds.size)
+            assertEquals(1, recorder.resets)
+        }
+
+    @Test
+    fun `named plugin add replaces old Android plugin`() =
+        runTest {
+            val amplitude = createTestAmplitude()
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+            val first = NamedPlugin("shared")
+            val second = NamedPlugin("shared")
+
+            amplitude.add(first)
+            amplitude.add(second)
+
+            assertTrue(first.tornDown)
+            assertSame(second, amplitude.findPlugin<NamedPlugin>())
+        }
+
+    private fun TestScope.createTestAmplitude(
+        storageProvider: StorageProvider = InMemoryStorageProvider(),
+    ): com.amplitude.android.Amplitude {
+        return createFakeAmplitude(
+            server = null,
+            scheduler = testScheduler,
+            configuration = configuration(storageProvider),
+        )
+    }
+
+    private fun configuration(storageProvider: StorageProvider): Configuration {
+        setupMockAndroidContext()
+        val context = mockk<Application>(relaxed = true)
+        val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
+        every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        val dirNameSlot = slot<String>()
+        every { context.getDir(capture(dirNameSlot), any()) } answers {
+            File("/tmp/amplitude-kotlin/${dirNameSlot.captured}")
+        }
+
+        return Configuration(
+            apiKey = "api-key",
+            context = context,
+            instanceName = "plugin-contract-android-test",
+            minTimeBetweenSessionsMillis = 100,
+            storageProvider = storageProvider,
+            autocapture = autocaptureOptions { +sessions },
+            loggerProvider = ConsoleLoggerProvider(),
+            identifyInterceptStorageProvider = InMemoryStorageProvider(),
+            identityStorageProvider = IMIdentityStorageProvider(),
+            enableAutocaptureRemoteConfig = false,
+            enableDiagnostics = false,
+        )
+    }
+}
+
+private class SharedStorageProvider(
+    private val storage: Storage,
+) : StorageProvider {
+    override fun getStorage(
+        amplitude: Amplitude,
+        prefix: String?,
+    ): Storage = storage
+}
+
+private class SessionPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+    val sessionIds = mutableListOf<Long>()
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onSessionIdChanged(sessionId: Long) {
+        sessionIds += sessionId
+    }
+}
+
+private class SessionObservePlugin(override val name: String) : ObservePlugin() {
+    override lateinit var amplitude: Amplitude
+    val sessionIds = mutableListOf<Long>()
+
+    override fun onUserIdChanged(userId: String?) {}
+
+    override fun onDeviceIdChanged(deviceId: String?) {}
+
+    override fun onSessionIdChanged(sessionId: Long) {
+        sessionIds += sessionId
+    }
+}
+
+private class ResetPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+    val userIds = mutableListOf<String?>()
+    val deviceIds = mutableListOf<String?>()
+    var resets = 0
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onUserIdChanged(userId: String?) {
+        userIds += userId
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds += deviceId
+    }
+
+    override fun onReset() {
+        resets += 1
+    }
+}
+
+private class NamedPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+    var tornDown = false
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        tornDown = true
+    }
+}

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -48,6 +48,7 @@ public class com/amplitude/core/Amplitude {
 	public fun createTimeline ()Lcom/amplitude/core/platform/Timeline;
 	protected fun diagnosticsContextProvider ()Lcom/amplitude/core/diagnostics/DiagnosticsContextProvider;
 	protected fun diagnosticsStorageDirectory ()Ljava/io/File;
+	protected final fun doResetWithDeviceId (Ljava/lang/String;)V
 	public final fun flush ()V
 	public final fun getAmplitudeDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getAmplitudeScope ()Lkotlinx/coroutines/CoroutineScope;
@@ -83,6 +84,7 @@ public class com/amplitude/core/Amplitude {
 	public final fun isBuilt ()Lkotlinx/coroutines/Deferred;
 	public final fun logEvent (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/Amplitude;
 	public final fun logRevenue (Lcom/amplitude/core/events/Revenue;)Lcom/amplitude/core/Amplitude;
+	protected final fun notifyAllPlugins (Lkotlin/jvm/functions/Function1;)V
 	public final fun remove (Lcom/amplitude/core/platform/Plugin;)Lcom/amplitude/core/Amplitude;
 	public fun reset ()Lcom/amplitude/core/Amplitude;
 	public final fun revenue (Lcom/amplitude/core/events/Revenue;)Lcom/amplitude/core/Amplitude;
@@ -803,7 +805,13 @@ public abstract class com/amplitude/core/platform/ObservePlugin : com/amplitude/
 public abstract interface class com/amplitude/core/platform/Plugin {
 	public fun execute (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;
 	public abstract fun getAmplitude ()Lcom/amplitude/core/Amplitude;
+	public fun getName ()Ljava/lang/String;
 	public abstract fun getType ()Lcom/amplitude/core/platform/Plugin$Type;
+	public fun onDeviceIdChanged (Ljava/lang/String;)V
+	public fun onOptOutChanged (Z)V
+	public fun onReset ()V
+	public fun onSessionIdChanged (J)V
+	public fun onUserIdChanged (Ljava/lang/String;)V
 	public abstract fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
 	public fun setup (Lcom/amplitude/core/Amplitude;)V
 	public fun teardown ()V

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import java.io.File
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 
 /**
@@ -60,7 +59,6 @@ open class Amplitude(
     val storageIODispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
 ) {
     val timeline: Timeline
-    private val reservedPlugins: ConcurrentHashMap<String, Plugin> = ConcurrentHashMap()
     val storage: Storage by lazy {
         configuration.storageProvider.getStorage(this)
     }
@@ -143,6 +141,7 @@ open class Amplitude(
     init {
         require(configuration.isValid()) { "invalid configuration" }
         timeline = this.createTimeline()
+        store.owner = this
         isBuilt = this.build()
         isBuilt.start()
     }
@@ -544,42 +543,17 @@ open class Amplitude(
      * @return the Amplitude instance
      */
     fun add(plugin: Plugin): Amplitude {
-        val name = plugin.name
-        if (name != null && reservedPlugins.putIfAbsent(name, plugin) != null) {
-            logger.warn("Plugin \"$name\" is already registered; keeping the existing one.")
-            return this
-        }
-        try {
-            @Suppress("DEPRECATION")
-            when (plugin) {
-                is ObservePlugin -> store.add(plugin, this)
-                else -> timeline.add(plugin)
-            }
-        } catch (t: Throwable) {
-            if (name != null) reservedPlugins.remove(name, plugin)
-            throw t
-        }
+        timeline.add(plugin)
         return this
     }
 
     /**
-     * Find the first registered plugin assignable to [T], across both the timeline mediators
-     * and the observe store (store iteration is snapshotted under its lock).
+     * Find the first registered plugin assignable to [T] in the timeline mediators.
      */
-    inline fun <reified T : Plugin> findPlugin(): T? {
-        timeline.findPlugin<T>()?.let { return it }
-        @Suppress("DEPRECATION")
-        val observeSnapshot = synchronized(store.plugins) { store.plugins.toList() }
-        return observeSnapshot.firstOrNull { it is T } as? T
-    }
+    inline fun <reified T : Plugin> findPlugin(): T? = timeline.findPlugin<T>()
 
     fun remove(plugin: Plugin): Amplitude {
-        plugin.name?.let { reservedPlugins.remove(it, plugin) }
-        @Suppress("DEPRECATION")
-        when (plugin) {
-            is ObservePlugin -> store.remove(plugin)
-            else -> timeline.remove(plugin)
-        }
+        timeline.remove(plugin)
         return this
     }
 
@@ -603,7 +577,9 @@ open class Amplitude(
         pluginsSnapshot().forEach { safelyNotify(it, block) }
     }
 
-    private fun pluginsSnapshot(): List<Plugin> = timeline.pluginsSnapshot() + store.pluginsSnapshot()
+    private fun pluginsSnapshot(): List<Plugin> = timeline.pluginsSnapshot()
+
+    internal fun observePluginsSnapshot(): List<ObservePlugin> = timeline.pluginsSnapshot().filterIsInstance<ObservePlugin>()
 
     private fun safelyNotify(
         plugin: Plugin,

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -133,6 +133,7 @@ open class Amplitude(
         get() = configuration.optOut
         set(value) {
             configuration.optOut = value
+            notifyPlugins { it.onOptOutChanged(value) }
         }
 
     init {
@@ -307,6 +308,7 @@ open class Amplitude(
      */
     fun setUserId(userId: String?): Amplitude {
         identityCoordinator.setUserId(userId)
+        notifyPlugins { it.onUserIdChanged(store.userId) }
         return this
     }
 
@@ -327,6 +329,7 @@ open class Amplitude(
      */
     fun setDeviceId(deviceId: String): Amplitude {
         identityCoordinator.setDeviceId(deviceId)
+        notifyPlugins { it.onDeviceIdChanged(store.deviceId) }
         return this
     }
 
@@ -346,9 +349,29 @@ open class Amplitude(
      * @return the Amplitude instance
      */
     open fun reset(): Amplitude {
-        setUserId(null)
-        setDeviceId(ContextPlugin.generateRandomDeviceId())
+        doResetWithDeviceId(ContextPlugin.generateRandomDeviceId())
         return this
+    }
+
+    /**
+     * Reset identity and fan the bundled change out to every plugin from a **single**
+     * snapshot: onUserIdChanged(null), then onDeviceIdChanged(newDeviceId), then onReset().
+     * The mutation commits under the identity lock before any callback runs (reentrancy-safe).
+     */
+    protected fun doResetWithDeviceId(newDeviceId: String) {
+        identityCoordinator.reset(newDeviceId)
+        val plugins = pluginsSnapshot()
+        plugins.forEach { safelyNotify(it) { plugin -> plugin.onUserIdChanged(store.userId) } }
+        plugins.forEach { safelyNotify(it) { plugin -> plugin.onDeviceIdChanged(store.deviceId) } }
+        plugins.forEach { safelyNotify(it) { plugin -> plugin.onReset() } }
+    }
+
+    /**
+     * Fan an arbitrary state-change callback out to every plugin (timeline + observe store).
+     * For platform SDKs (e.g. Android session-id changes); each invocation is isolated.
+     */
+    protected fun notifyAllPlugins(block: (Plugin) -> Unit) {
+        notifyPlugins(block)
     }
 
     /**
@@ -517,6 +540,10 @@ open class Amplitude(
      * @return the Amplitude instance
      */
     fun add(plugin: Plugin): Amplitude {
+        // Dedup by name (best-effort; add() is expected from a single thread): a named plugin
+        // replaces and tears down any existing plugin with the same name.
+        plugin.name?.let { removePluginsByName(it) }
+
         when (plugin) {
             is ObservePlugin -> {
                 this.store.add(plugin, this)
@@ -527,6 +554,16 @@ open class Amplitude(
         }
 
         return this
+    }
+
+    /**
+     * Find the first registered plugin assignable to [T], across both the timeline mediators
+     * and the observe store (store iteration is snapshotted under its lock).
+     */
+    inline fun <reified T : Plugin> findPlugin(): T? {
+        timeline.findPlugin<T>()?.let { return it }
+        val observeSnapshot = synchronized(store.plugins) { store.plugins.toList() }
+        return observeSnapshot.firstOrNull { it is T } as? T
     }
 
     fun remove(plugin: Plugin): Amplitude {
@@ -551,6 +588,48 @@ open class Amplitude(
             }
         }
     }
+
+    /**
+     * The single plugin fan-out path. Snapshots timeline + store once and isolates every
+     * invocation, so a throwing plugin can't break the loop or the calling thread.
+     * Never call while holding the identity lock (notify happens after it's released).
+     */
+    private fun notifyPlugins(block: (Plugin) -> Unit) {
+        pluginsSnapshot().forEach { safelyNotify(it, block) }
+    }
+
+    private fun pluginsSnapshot(): List<Plugin> = timeline.pluginsSnapshot() + store.pluginsSnapshot()
+
+    private fun removePluginsByName(name: String) {
+        val removed = timeline.removeByName(name) + store.removeByName(name)
+        removed.forEach { teardownPlugin(it) }
+    }
+
+    private fun teardownPlugin(plugin: Plugin) {
+        try {
+            plugin.teardown()
+        } catch (e: Exception) {
+            logger.warn("Plugin '${plugin.identifier()}' threw during teardown: $e")
+        }
+    }
+
+    private fun safelyNotify(
+        plugin: Plugin,
+        block: (Plugin) -> Unit,
+    ) {
+        try {
+            block(plugin)
+        } catch (e: Exception) {
+            logger.warn("Plugin '${plugin.identifier()}' threw during state callback: $e")
+        }
+    }
+
+    private fun Plugin.identifier(): String =
+        try {
+            name ?: this::class.java.name
+        } catch (_: Exception) {
+            this::class.java.name
+        }
 
     private fun convertPropertiesToIdentify(userProperties: Map<String, Any?>?): Identify {
         val identify = Identify()

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -12,7 +12,6 @@ import com.amplitude.core.events.IdentifyEvent
 import com.amplitude.core.events.Revenue
 import com.amplitude.core.events.RevenueEvent
 import com.amplitude.core.platform.EventPlugin
-import com.amplitude.core.platform.ObservePlugin
 import com.amplitude.core.platform.Plugin
 import com.amplitude.core.platform.Signal
 import com.amplitude.core.platform.Timeline
@@ -141,7 +140,6 @@ open class Amplitude(
     init {
         require(configuration.isValid()) { "invalid configuration" }
         timeline = this.createTimeline()
-        store.owner = this
         isBuilt = this.build()
         isBuilt.start()
     }
@@ -578,8 +576,6 @@ open class Amplitude(
     }
 
     private fun pluginsSnapshot(): List<Plugin> = timeline.pluginsSnapshot()
-
-    internal fun observePluginsSnapshot(): List<ObservePlugin> = timeline.pluginsSnapshot().filterIsInstance<ObservePlugin>()
 
     private fun safelyNotify(
         plugin: Plugin,

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -550,6 +550,7 @@ open class Amplitude(
             return this
         }
         try {
+            @Suppress("DEPRECATION")
             when (plugin) {
                 is ObservePlugin -> store.add(plugin, this)
                 else -> timeline.add(plugin)
@@ -567,12 +568,14 @@ open class Amplitude(
      */
     inline fun <reified T : Plugin> findPlugin(): T? {
         timeline.findPlugin<T>()?.let { return it }
+        @Suppress("DEPRECATION")
         val observeSnapshot = synchronized(store.plugins) { store.plugins.toList() }
         return observeSnapshot.firstOrNull { it is T } as? T
     }
 
     fun remove(plugin: Plugin): Amplitude {
         plugin.name?.let { reservedPlugins.remove(it, plugin) }
+        @Suppress("DEPRECATION")
         when (plugin) {
             is ObservePlugin -> store.remove(plugin)
             else -> timeline.remove(plugin)

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -595,7 +595,8 @@ open class Amplitude(
 
     /**
      * The single plugin fan-out path. Snapshots timeline + store once and isolates every
-     * invocation, so a throwing plugin can't break the loop or the calling thread.
+     * invocation, so a plugin that throws an exception can't break the loop or the other
+     * plugins. Errors (e.g. OutOfMemoryError) are not caught and propagate to the caller.
      * Never call while holding the identity lock (notify happens after it's released).
      */
     private fun notifyPlugins(block: (Plugin) -> Unit) {

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -127,7 +127,9 @@ open class Amplitude(
 
     /**
      * Whether events should be suppressed. Set this at runtime to opt the user in or out.
-     * Delegates to [Configuration.optOut] — mutating either is equivalent.
+     * Reads through to [Configuration.optOut]. Set via this property (not
+     * `configuration.optOut` directly) — only this setter notifies plugins via
+     * [Plugin.onOptOutChanged].
      */
     open var optOut: Boolean
         get() = configuration.optOut

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 
 /**
@@ -59,6 +60,7 @@ open class Amplitude(
     val storageIODispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
 ) {
     val timeline: Timeline
+    private val reservedPlugins: ConcurrentHashMap<String, Plugin> = ConcurrentHashMap()
     val storage: Storage by lazy {
         configuration.storageProvider.getStorage(this)
     }
@@ -542,19 +544,20 @@ open class Amplitude(
      * @return the Amplitude instance
      */
     fun add(plugin: Plugin): Amplitude {
-        // Dedup by name (best-effort; add() is expected from a single thread): a named plugin
-        // replaces and tears down any existing plugin with the same name.
-        plugin.name?.let { removePluginsByName(it) }
-
-        when (plugin) {
-            is ObservePlugin -> {
-                this.store.add(plugin, this)
-            }
-            else -> {
-                this.timeline.add(plugin)
-            }
+        val name = plugin.name
+        if (name != null && reservedPlugins.putIfAbsent(name, plugin) != null) {
+            logger.warn("Plugin \"$name\" is already registered; keeping the existing one.")
+            return this
         }
-
+        try {
+            when (plugin) {
+                is ObservePlugin -> store.add(plugin, this)
+                else -> timeline.add(plugin)
+            }
+        } catch (t: Throwable) {
+            if (name != null) reservedPlugins.remove(name, plugin)
+            throw t
+        }
         return this
     }
 
@@ -569,15 +572,11 @@ open class Amplitude(
     }
 
     fun remove(plugin: Plugin): Amplitude {
+        plugin.name?.let { reservedPlugins.remove(it, plugin) }
         when (plugin) {
-            is ObservePlugin -> {
-                this.store.remove(plugin)
-            }
-            else -> {
-                this.timeline.remove(plugin)
-            }
+            is ObservePlugin -> store.remove(plugin)
+            else -> timeline.remove(plugin)
         }
-
         return this
     }
 
@@ -601,19 +600,6 @@ open class Amplitude(
     }
 
     private fun pluginsSnapshot(): List<Plugin> = timeline.pluginsSnapshot() + store.pluginsSnapshot()
-
-    private fun removePluginsByName(name: String) {
-        val removed = timeline.removeByName(name) + store.removeByName(name)
-        removed.forEach { teardownPlugin(it) }
-    }
-
-    private fun teardownPlugin(plugin: Plugin) {
-        try {
-            plugin.teardown()
-        } catch (e: Exception) {
-            logger.warn("Plugin '${plugin.identifier()}' threw during teardown: $e")
-        }
-    }
 
     private fun safelyNotify(
         plugin: Plugin,

--- a/core/src/main/java/com/amplitude/core/IdentityCoordinator.kt
+++ b/core/src/main/java/com/amplitude/core/IdentityCoordinator.kt
@@ -37,6 +37,25 @@ internal class IdentityCoordinator internal constructor(private val state: State
     }
 
     /**
+     * Reset clears userId and rotates deviceId as **one** locked mutation, so the two fields
+     * never tear apart and persistence commits once. Callers fan out callbacks after this
+     * returns (lock released) — never from inside.
+     */
+    fun reset(newDeviceId: String) {
+        synchronized(lock) {
+            state.userId = null
+            state.deviceId = newDeviceId
+            val editor = identityManager?.editIdentity()
+            if (editor != null) {
+                editor.setUserId(null).setDeviceId(newDeviceId).commit()
+            } else {
+                pendingUserId = Pending(null)
+                pendingDeviceId = Pending(newDeviceId)
+            }
+        }
+    }
+
+    /**
      * Called during [com.amplitude.core.Amplitude.createIdentityContainer] to reconcile
      * persisted identity with any pre-build changes. User intent wins over persisted values.
      */

--- a/core/src/main/java/com/amplitude/core/IdentityCoordinator.kt
+++ b/core/src/main/java/com/amplitude/core/IdentityCoordinator.kt
@@ -3,11 +3,19 @@ package com.amplitude.core
 import com.amplitude.id.IdentityManager
 
 /**
- * Coordinates identity (userId/deviceId) updates between [State] and [IdentityManager].
+ * Owns **runtime** identity (userId/deviceId) for one [Amplitude] instance. The two-layer model:
  *
- * All mutations go through synchronized blocks to ensure atomic state + persistence.
- * Before build, only [State] is updated and pending flags are set.
- * During [bootstrap], persisted identity is reconciled with any pre-build changes.
+ *  - [IdentityCoordinator] (here): the in-memory mirror in [State] + pre-build pending intent +
+ *    bootstrap reconciliation. Every mutation is serialized on [lock] so the State write and the
+ *    persistence commit are atomic. Before build there is no [IdentityManager], so touched fields
+ *    are remembered as pending; [bootstrap] reconciles them against persisted values (user intent
+ *    wins) once the manager binds.
+ *  - [IdentityManager] (com.amplitude.id, shared with Experiment): durable persistence only.
+ *
+ * Notification is intentionally **not** here. The coordinator only mutates and returns; [Amplitude]
+ * fans plugin callbacks out *after* [lock] is released, which is what makes a reentrant
+ * setUserId/setDeviceId from inside a callback safe (the inner write can't be clobbered by the
+ * outer commit). Keep this class free of plugin/callback concerns.
  */
 internal class IdentityCoordinator internal constructor(private val state: State) {
     private val lock = Any()

--- a/core/src/main/java/com/amplitude/core/README.md
+++ b/core/src/main/java/com/amplitude/core/README.md
@@ -1,0 +1,96 @@
+# Plugins & Identity — `com.amplitude.core`
+
+How the SDK is extended (plugins) and how identity (userId / deviceId / sessionId)
+reaches those plugins. Read this before touching `Plugin`, `Timeline`, `State`,
+`IdentityCoordinator`, or `com.amplitude.id`.
+
+---
+
+## 1. Plugins
+
+A **plugin** observes or transforms the SDK. Each declares a `Plugin.Type` that
+decides *where* it runs:
+
+| Type | In the event path? | Lives in |
+|------|--------------------|----------|
+| `Before` / `Enrichment` / `Destination` | yes | a `Timeline` mediator |
+| `Utility` | no | a `Timeline` mediator |
+| `Observe` | no | see below |
+
+Two ways to reach the "observe" world — **both receive the state callbacks below**:
+
+- An **`ObservePlugin`** (abstract class) is routed by `Amplitude.add()` to the
+  `State` store.
+- A plain **`Plugin` with `type = Observe`** lands in the timeline's `Observe`
+  mediator.
+
+### Lifecycle & lookup
+- `add(plugin)` — if `plugin.name != null`, any existing plugin with that name is
+  removed (and `teardown()`-ed) first. Dedup is **best-effort**: `add()` is expected
+  from a single thread.
+- `findPlugin<T>()` — first match assignable to `T`, across the timeline mediators
+  **and** the store (store iteration is snapshotted under its lock).
+
+---
+
+## 2. State-change callbacks
+
+`Plugin` exposes default no-op callbacks, so existing plugins are unaffected:
+
+- `onUserIdChanged(userId)` / `onDeviceIdChanged(deviceId)`
+- `onSessionIdChanged(sessionId)` *(Android only — it owns sessions)*
+- `onOptOutChanged(optOut)`
+- `onReset()` *(bundled with the userId/deviceId change from a reset)*
+
+**One fan-out path.** Every callback goes through `Amplitude.notifyPlugins`, which
+snapshots `timeline + store` **once** and invokes each plugin inside `safelyNotify`
+(try/catch + log). A throwing plugin can't break the loop, the calling thread, or
+the Android event-message coroutine. `reset()` reuses a single snapshot for its
+three passes (userId → deviceId → reset), so a plugin added *during* a callback
+doesn't receive that reset's callbacks but is immediately findable afterward.
+
+**Semantics: intent-based.** Every explicit `setUserId` / `setDeviceId` / `optOut` /
+`reset` notifies once, whether or not the value changed. Delivery is best-effort,
+latest-value: under concurrent setters notifications may coalesce, but the value a
+plugin sees is always consistent with the instance's current identity. Identity
+mutation is expected from a single thread.
+
+---
+
+## 3. Identity — two layers, lock released before notify
+
+Identity has exactly two owners:
+
+- **`IdentityCoordinator`** (`internal`, this package) — the **runtime** owner:
+  the in-memory mirror in `State`, pre-build *pending* intent, and `bootstrap()`
+  reconciliation (user intent wins over persisted). Every mutation is serialized on
+  one lock so the `State` write and the persistence commit are atomic.
+- **`IdentityManager`** (`com.amplitude.id`, shared with the Experiment SDK) —
+  durable **persistence** only. Treat it as a stable, public boundary; don't push
+  Amplitude-specific concerns into it.
+
+`State` is a silent `@Volatile` mirror for synchronous reads (event enrichment,
+callback values). It does **not** notify — notification belongs to `Amplitude`.
+
+### Reentrancy (the subtle part)
+`Amplitude.setUserId` calls the coordinator, then fans callbacks out **after the
+lock is released**. JVM `synchronized` is reentrant, so a "notify while holding the
+lock" design would let a plugin's `onUserIdChanged` call `setUserId` reentrantly,
+fully commit the inner value, then have the *outer* commit clobber it. Committing
+under the lock and notifying after releasing it makes the inner write win.
+
+```
+setUserId("a"): lock { store.userId = "a"; manager.commit() }   // lock released
+                notifyPlugins { onUserIdChanged("a") }           // plugin may reentrantly setUserId("b")
+                                                                  //   → fresh lock, commits "b", notifies "b"
+                // outer does NOT write again → final = "b" ✓
+```
+
+### Invariants to preserve
+- **No lock is held across any plugin callback** (`onX`, `setup`, `teardown`).
+  Lock order is one-directional: coordinator lock → manager lock; the manager never
+  calls back into core.
+- `State.add`/`remove`/dedup call `setup()`/`teardown()` **outside** the `plugins`
+  monitor.
+- Timeline storage is `CopyOnWriteArrayList`; store iteration uses a `toList()`
+  snapshot. Both are CME-immune.

--- a/core/src/main/java/com/amplitude/core/README.md
+++ b/core/src/main/java/com/amplitude/core/README.md
@@ -51,9 +51,11 @@ doesn't receive that reset's callbacks but is immediately findable afterward.
 
 **Semantics: intent-based.** Every explicit `setUserId` / `setDeviceId` / `optOut` /
 `reset` notifies once, whether or not the value changed. Delivery is best-effort,
-latest-value: under concurrent setters notifications may coalesce, but the value a
-plugin sees is always consistent with the instance's current identity. Identity
-mutation is expected from a single thread.
+latest-value: each callback reads the *current* `store` value (reset's three passes
+re-read too), so under concurrent setters — or a plugin that reentrantly re-sets
+identity from within a callback — notifications may coalesce, but the value a plugin
+sees is always consistent with the instance's current identity. Identity mutation is
+expected from a single thread.
 
 ---
 

--- a/core/src/main/java/com/amplitude/core/State.kt
+++ b/core/src/main/java/com/amplitude/core/State.kt
@@ -3,12 +3,19 @@ package com.amplitude.core
 import com.amplitude.core.platform.ObservePlugin
 
 /**
- * Runtime mirror of identity (userId / deviceId) for synchronous reads (event enrichment,
- * plugin callback values) plus the registry of [ObservePlugin]s.
+ * Runtime mirror of identity (userId / deviceId) for synchronous reads — event enrichment
+ * and the values handed to plugin state-change callbacks.
  *
- * Identity fields are written **silently** — notification is owned by [Amplitude] so that a
- * single fan-out reaches every plugin (timeline and store). Mutate identity via
- * [Amplitude.setUserId] / [Amplitude.setDeviceId] / [Amplitude.reset], not these setters.
+ * Identity fields are written **silently**; notification is owned by [Amplitude] so a single
+ * fan-out reaches every registered plugin. Mutate identity via [Amplitude.setUserId] /
+ * [Amplitude.setDeviceId] / [Amplitude.reset], not these setters.
+ *
+ * The [ObservePlugin] registry below is **deprecated**. Now that every plugin receives the
+ * identity/state callbacks through [Amplitude]'s fan-out, observe plugins no longer need a
+ * dedicated registry here — register and remove them via [Amplitude.add] / [Amplitude.remove]
+ * like any other plugin. The registry is retained for binary compatibility and will be removed
+ * in the next major version, when observe plugins move fully into the
+ * [com.amplitude.core.platform.Timeline].
  */
 class State {
     @Volatile
@@ -17,20 +24,35 @@ class State {
     @Volatile
     var deviceId: String? = null
 
+    @Deprecated(
+        "Observe plugins are managed by Amplitude/Timeline; this registry will be removed in the " +
+            "next major version. Register via Amplitude.add(plugin).",
+    )
     val plugins: MutableList<ObservePlugin> = mutableListOf()
 
+    @Deprecated(
+        "Register observe plugins via Amplitude.add(plugin). State's registry will be removed in " +
+            "the next major version.",
+        ReplaceWith("amplitude.add(plugin)"),
+    )
     fun add(
         plugin: ObservePlugin,
         amplitude: Amplitude,
     ): Boolean {
         // setup() runs outside the monitor — never hold a lock across plugin code.
         plugin.setup(amplitude)
+        @Suppress("DEPRECATION")
         return synchronized(plugins) {
             plugins.add(plugin)
         }
     }
 
+    @Deprecated(
+        "Remove observe plugins via Amplitude.remove(plugin). State's registry will be removed in " +
+            "the next major version.",
+    )
     fun remove(plugin: ObservePlugin): Boolean {
+        @Suppress("DEPRECATION")
         val removed =
             synchronized(plugins) {
                 plugins.removeAll { it === plugin }
@@ -40,6 +62,7 @@ class State {
         return removed
     }
 
+    @Suppress("DEPRECATION")
     internal fun pluginsSnapshot(): List<ObservePlugin> =
         synchronized(plugins) {
             plugins.toList()

--- a/core/src/main/java/com/amplitude/core/State.kt
+++ b/core/src/main/java/com/amplitude/core/State.kt
@@ -10,12 +10,13 @@ import com.amplitude.core.platform.ObservePlugin
  * fan-out reaches every registered plugin. Mutate identity via [Amplitude.setUserId] /
  * [Amplitude.setDeviceId] / [Amplitude.reset], not these setters.
  *
- * The [ObservePlugin] registry below is **deprecated**. Now that every plugin receives the
- * identity/state callbacks through [Amplitude]'s fan-out, observe plugins no longer need a
- * dedicated registry here — register and remove them via [Amplitude.add] / [Amplitude.remove]
- * like any other plugin. The registry is retained for binary compatibility and will be removed
- * in the next major version, when observe plugins move fully into the
- * [com.amplitude.core.platform.Timeline].
+ * The observe-plugin registry below is **deprecated**. All plugins — including [ObservePlugin]s —
+ * are now registered and managed by the [com.amplitude.core.platform.Timeline]. These members
+ * delegate to [Amplitude] / [Timeline] for binary compatibility and will be removed in the
+ * next major version.
+ *
+ * A [State] is owned by a single [Amplitude]; sharing one instance across multiple [Amplitude]s is
+ * unsupported (the deprecated delegates resolve against the most recently constructed owner).
  */
 class State {
     @Volatile
@@ -24,11 +25,20 @@ class State {
     @Volatile
     var deviceId: String? = null
 
+    /** Back-reference set by [Amplitude] immediately after [Timeline] creation. */
+    internal var owner: Amplitude? = null
+
+    /**
+     * A detached snapshot of the observe plugins registered in the
+     * [com.amplitude.core.platform.Timeline]. Mutating the returned list has no effect —
+     * register/unregister via [Amplitude.add] / [Amplitude.remove].
+     */
     @Deprecated(
         "Observe plugins are managed by Amplitude/Timeline; this registry will be removed in the " +
             "next major version. Register via Amplitude.add(plugin).",
     )
-    val plugins: MutableList<ObservePlugin> = mutableListOf()
+    val plugins: MutableList<ObservePlugin>
+        get() = owner?.observePluginsSnapshot()?.toMutableList() ?: mutableListOf()
 
     @Deprecated(
         "Register observe plugins via Amplitude.add(plugin). State's registry will be removed in " +
@@ -39,12 +49,9 @@ class State {
         plugin: ObservePlugin,
         amplitude: Amplitude,
     ): Boolean {
-        // setup() runs outside the monitor — never hold a lock across plugin code.
-        plugin.setup(amplitude)
-        @Suppress("DEPRECATION")
-        return synchronized(plugins) {
-            plugins.add(plugin)
-        }
+        amplitude.add(plugin)
+        // Reflect the real outcome: first-wins name dedup may have skipped a duplicate.
+        return amplitude.observePluginsSnapshot().any { it === plugin }
     }
 
     @Deprecated(
@@ -52,19 +59,9 @@ class State {
             "the next major version.",
     )
     fun remove(plugin: ObservePlugin): Boolean {
-        @Suppress("DEPRECATION")
-        val removed =
-            synchronized(plugins) {
-                plugins.removeAll { it === plugin }
-            }
-        // teardown() runs outside the monitor — never hold a lock across plugin code.
-        if (removed) plugin.teardown()
-        return removed
+        val amplitude = owner ?: return false
+        val wasRegistered = amplitude.observePluginsSnapshot().any { it === plugin }
+        amplitude.remove(plugin)
+        return wasRegistered
     }
-
-    @Suppress("DEPRECATION")
-    internal fun pluginsSnapshot(): List<ObservePlugin> =
-        synchronized(plugins) {
-            plugins.toList()
-        }
 }

--- a/core/src/main/java/com/amplitude/core/State.kt
+++ b/core/src/main/java/com/amplitude/core/State.kt
@@ -40,13 +40,6 @@ class State {
         return removed
     }
 
-    internal fun removeByName(name: String): List<ObservePlugin> =
-        synchronized(plugins) {
-            val removed = plugins.filter { it.name == name }
-            plugins.removeAll(removed)
-            removed
-        }
-
     internal fun pluginsSnapshot(): List<ObservePlugin> =
         synchronized(plugins) {
             plugins.toList()

--- a/core/src/main/java/com/amplitude/core/State.kt
+++ b/core/src/main/java/com/amplitude/core/State.kt
@@ -2,35 +2,53 @@ package com.amplitude.core
 
 import com.amplitude.core.platform.ObservePlugin
 
+/**
+ * Runtime mirror of identity (userId / deviceId) for synchronous reads (event enrichment,
+ * plugin callback values) plus the registry of [ObservePlugin]s.
+ *
+ * Identity fields are written **silently** — notification is owned by [Amplitude] so that a
+ * single fan-out reaches every plugin (timeline and store). Mutate identity via
+ * [Amplitude.setUserId] / [Amplitude.setDeviceId] / [Amplitude.reset], not these setters.
+ */
 class State {
+    @Volatile
     var userId: String? = null
-        set(value: String?) {
-            field = value
-            plugins.forEach { plugin ->
-                plugin.onUserIdChanged(value)
-            }
-        }
 
+    @Volatile
     var deviceId: String? = null
-        set(value: String?) {
-            field = value
-            plugins.forEach { plugin ->
-                plugin.onDeviceIdChanged(value)
-            }
-        }
 
     val plugins: MutableList<ObservePlugin> = mutableListOf()
 
     fun add(
         plugin: ObservePlugin,
         amplitude: Amplitude,
-    ) = synchronized(plugins) {
+    ): Boolean {
+        // setup() runs outside the monitor — never hold a lock across plugin code.
         plugin.setup(amplitude)
-        plugins.add(plugin)
+        return synchronized(plugins) {
+            plugins.add(plugin)
+        }
     }
 
-    fun remove(plugin: ObservePlugin) =
+    fun remove(plugin: ObservePlugin): Boolean {
+        val removed =
+            synchronized(plugins) {
+                plugins.removeAll { it === plugin }
+            }
+        // teardown() runs outside the monitor — never hold a lock across plugin code.
+        if (removed) plugin.teardown()
+        return removed
+    }
+
+    internal fun removeByName(name: String): List<ObservePlugin> =
         synchronized(plugins) {
-            plugins.removeAll { it === plugin }
+            val removed = plugins.filter { it.name == name }
+            plugins.removeAll(removed)
+            removed
+        }
+
+    internal fun pluginsSnapshot(): List<ObservePlugin> =
+        synchronized(plugins) {
+            plugins.toList()
         }
 }

--- a/core/src/main/java/com/amplitude/core/State.kt
+++ b/core/src/main/java/com/amplitude/core/State.kt
@@ -10,13 +10,12 @@ import com.amplitude.core.platform.ObservePlugin
  * fan-out reaches every registered plugin. Mutate identity via [Amplitude.setUserId] /
  * [Amplitude.setDeviceId] / [Amplitude.reset], not these setters.
  *
- * The observe-plugin registry below is **deprecated**. All plugins — including [ObservePlugin]s —
- * are now registered and managed by the [com.amplitude.core.platform.Timeline]. These members
- * delegate to [Amplitude] / [Timeline] for binary compatibility and will be removed in the
- * next major version.
- *
- * A [State] is owned by a single [Amplitude]; sharing one instance across multiple [Amplitude]s is
- * unsupported (the deprecated delegates resolve against the most recently constructed owner).
+ * The [ObservePlugin] registry below is **deprecated**. Now that every plugin receives the
+ * identity/state callbacks through [Amplitude]'s fan-out, observe plugins no longer need a
+ * dedicated registry here — register and remove them via [Amplitude.add] / [Amplitude.remove]
+ * like any other plugin. The registry is retained for binary compatibility and will be removed
+ * in the next major version, when observe plugins move fully into the
+ * [com.amplitude.core.platform.Timeline].
  */
 class State {
     @Volatile
@@ -25,20 +24,11 @@ class State {
     @Volatile
     var deviceId: String? = null
 
-    /** Back-reference set by [Amplitude] immediately after [Timeline] creation. */
-    internal var owner: Amplitude? = null
-
-    /**
-     * A detached snapshot of the observe plugins registered in the
-     * [com.amplitude.core.platform.Timeline]. Mutating the returned list has no effect —
-     * register/unregister via [Amplitude.add] / [Amplitude.remove].
-     */
     @Deprecated(
         "Observe plugins are managed by Amplitude/Timeline; this registry will be removed in the " +
             "next major version. Register via Amplitude.add(plugin).",
     )
-    val plugins: MutableList<ObservePlugin>
-        get() = owner?.observePluginsSnapshot()?.toMutableList() ?: mutableListOf()
+    val plugins: MutableList<ObservePlugin> = mutableListOf()
 
     @Deprecated(
         "Register observe plugins via Amplitude.add(plugin). State's registry will be removed in " +
@@ -49,9 +39,12 @@ class State {
         plugin: ObservePlugin,
         amplitude: Amplitude,
     ): Boolean {
-        amplitude.add(plugin)
-        // Reflect the real outcome: first-wins name dedup may have skipped a duplicate.
-        return amplitude.observePluginsSnapshot().any { it === plugin }
+        // setup() runs outside the monitor — never hold a lock across plugin code.
+        plugin.setup(amplitude)
+        @Suppress("DEPRECATION")
+        return synchronized(plugins) {
+            plugins.add(plugin)
+        }
     }
 
     @Deprecated(
@@ -59,9 +52,13 @@ class State {
             "the next major version.",
     )
     fun remove(plugin: ObservePlugin): Boolean {
-        val amplitude = owner ?: return false
-        val wasRegistered = amplitude.observePluginsSnapshot().any { it === plugin }
-        amplitude.remove(plugin)
-        return wasRegistered
+        @Suppress("DEPRECATION")
+        val removed =
+            synchronized(plugins) {
+                plugins.removeAll { it === plugin }
+            }
+        // teardown() runs outside the monitor — never hold a lock across plugin code.
+        if (removed) plugin.teardown()
+        return removed
     }
 }

--- a/core/src/main/java/com/amplitude/core/platform/Mediator.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Mediator.kt
@@ -15,6 +15,14 @@ internal class Mediator(
 
     fun remove(plugin: Plugin) = plugins.removeAll { it === plugin }
 
+    fun removeByName(name: String): List<Plugin> {
+        val removed = plugins.filter { it.name == name }
+        plugins.removeAll(removed)
+        return removed
+    }
+
+    fun snapshot(): List<Plugin> = plugins.toList()
+
     fun execute(event: BaseEvent): BaseEvent? {
         var result: BaseEvent? = event
 

--- a/core/src/main/java/com/amplitude/core/platform/Mediator.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Mediator.kt
@@ -15,12 +15,6 @@ internal class Mediator(
 
     fun remove(plugin: Plugin) = plugins.removeAll { it === plugin }
 
-    fun removeByName(name: String): List<Plugin> {
-        val removed = plugins.filter { it.name == name }
-        plugins.removeAll(removed)
-        return removed
-    }
-
     fun snapshot(): List<Plugin> = plugins.toList()
 
     fun execute(event: BaseEvent): BaseEvent? {

--- a/core/src/main/java/com/amplitude/core/platform/Plugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Plugin.kt
@@ -18,6 +18,12 @@ interface Plugin {
     val type: Type
     var amplitude: Amplitude
 
+    /**
+     * Optional stable plugin identifier. When non-null, adding another plugin
+     * with the same name replaces (and tears down) the previous one.
+     */
+    val name: String? get() = null
+
     fun setup(amplitude: Amplitude) {
         this.amplitude = amplitude
     }
@@ -29,6 +35,21 @@ interface Plugin {
     fun teardown() {
         // Clean up any resources from setup if necessary
     }
+
+    /**
+     * State-change callbacks. Default no-ops so existing plugins are unaffected.
+     * Delivered to every registered plugin (timeline and observe store) by
+     * [com.amplitude.core.Amplitude], each invocation isolated from exceptions.
+     */
+    fun onUserIdChanged(userId: String?) {}
+
+    fun onDeviceIdChanged(deviceId: String?) {}
+
+    fun onSessionIdChanged(sessionId: Long) {}
+
+    fun onOptOutChanged(optOut: Boolean) {}
+
+    fun onReset() {}
 }
 
 interface EventPlugin : Plugin {
@@ -108,9 +129,9 @@ abstract class DestinationPlugin : EventPlugin {
 abstract class ObservePlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.Observe
 
-    abstract fun onUserIdChanged(userId: String?)
+    abstract override fun onUserIdChanged(userId: String?)
 
-    abstract fun onDeviceIdChanged(deviceId: String?)
+    abstract override fun onDeviceIdChanged(deviceId: String?)
 
     final override fun execute(event: BaseEvent): BaseEvent? {
         return null

--- a/core/src/main/java/com/amplitude/core/platform/Plugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Plugin.kt
@@ -20,7 +20,8 @@ interface Plugin {
 
     /**
      * Optional stable plugin identifier. When non-null, adding another plugin
-     * with the same name replaces (and tears down) the previous one.
+     * with the same name is **skipped** — the first registration wins and is
+     * not torn down. A warning is logged for the duplicate.
      */
     val name: String? get() = null
 

--- a/core/src/main/java/com/amplitude/core/platform/Plugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Plugin.kt
@@ -40,7 +40,15 @@ interface Plugin {
     /**
      * State-change callbacks. Default no-ops so existing plugins are unaffected.
      * Delivered to every registered plugin (timeline and observe store) by
-     * [com.amplitude.core.Amplitude], each invocation isolated from exceptions.
+     * [com.amplitude.core.Amplitude]; each invocation is isolated so one plugin throwing an
+     * exception does not affect the others.
+     *
+     * Threading: callbacks are delivered **synchronously on the thread that triggers the
+     * change** — e.g. the caller's thread for [com.amplitude.core.Amplitude.setUserId] /
+     * [com.amplitude.core.Amplitude.setDeviceId], and a background (session/lifecycle) thread
+     * for [onSessionIdChanged]. No specific thread is guaranteed (in particular, not the main
+     * thread). Keep callbacks fast and non-blocking; identity values are read from `@Volatile`
+     * fields so individual reads are safe, but do not assume a stable thread across callbacks.
      */
     fun onUserIdChanged(userId: String?) {}
 

--- a/core/src/main/java/com/amplitude/core/platform/Timeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Timeline.kt
@@ -10,6 +10,7 @@ open class Timeline {
             Plugin.Type.Enrichment to Mediator(),
             Plugin.Type.Destination to Mediator(),
             Plugin.Type.Utility to Mediator(),
+            Plugin.Type.Observe to Mediator(),
         )
     lateinit var amplitude: Amplitude
 
@@ -62,6 +63,20 @@ open class Timeline {
                 plugin.teardown()
             }
         }
+    }
+
+    internal fun removeByName(name: String): List<Plugin> = plugins.values.flatMap { it.removeByName(name) }
+
+    internal fun pluginsSnapshot(): List<Plugin> = plugins.values.flatMap { it.snapshot() }
+
+    inline fun <reified T : Plugin> findPlugin(): T? {
+        var match: T? = null
+        applyClosure { plugin ->
+            if (match == null && plugin is T) {
+                match = plugin
+            }
+        }
+        return match
     }
 
     // Applies a closure on all registered plugins

--- a/core/src/main/java/com/amplitude/core/platform/Timeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Timeline.kt
@@ -2,6 +2,7 @@ package com.amplitude.core.platform
 
 import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
+import java.util.concurrent.ConcurrentHashMap
 
 open class Timeline {
     internal val plugins: Map<Plugin.Type, Mediator> =
@@ -12,6 +13,7 @@ open class Timeline {
             Plugin.Type.Utility to Mediator(),
             Plugin.Type.Observe to Mediator(),
         )
+    private val reservedNames = ConcurrentHashMap<String, Plugin>()
     lateinit var amplitude: Amplitude
 
     open fun process(incomingEvent: BaseEvent) {
@@ -30,8 +32,18 @@ open class Timeline {
     }
 
     fun add(plugin: Plugin) {
-        plugin.setup(amplitude)
-        plugins[plugin.type]?.add(plugin)
+        val name = plugin.name
+        if (name != null && reservedNames.putIfAbsent(name, plugin) != null) {
+            amplitude.logger.warn("Plugin \"$name\" is already registered; keeping the existing one.")
+            return
+        }
+        try {
+            plugin.setup(amplitude)
+            plugins[plugin.type]?.add(plugin)
+        } catch (t: Throwable) {
+            if (name != null) reservedNames.remove(name, plugin)
+            throw t
+        }
     }
 
     fun applyPlugins(
@@ -56,12 +68,9 @@ open class Timeline {
     }
 
     fun remove(plugin: Plugin) {
-        // remove all plugins with this name in every category
-        plugins.forEach { (_, list) ->
-            val wasRemoved = list.remove(plugin)
-            if (wasRemoved) {
-                plugin.teardown()
-            }
+        plugin.name?.let { reservedNames.remove(it, plugin) }
+        plugins.forEach { (_, mediator) ->
+            if (mediator.remove(plugin)) plugin.teardown()
         }
     }
 

--- a/core/src/main/java/com/amplitude/core/platform/Timeline.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Timeline.kt
@@ -65,8 +65,6 @@ open class Timeline {
         }
     }
 
-    internal fun removeByName(name: String): List<Plugin> = plugins.values.flatMap { it.removeByName(name) }
-
     internal fun pluginsSnapshot(): List<Plugin> = plugins.values.flatMap { it.snapshot() }
 
     inline fun <reified T : Plugin> findPlugin(): T? {

--- a/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
@@ -4,6 +4,7 @@ import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.utils.FakeAmplitude
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -118,17 +119,22 @@ class PluginContractTest {
     }
 
     @Test
-    fun `named plugin add replaces existing plugin across stores`() {
+    fun `named plugin add keeps the first registration across stores`() {
         val amplitude = FakeAmplitude()
+        // first is a timeline-type plugin, duplicate is an ObservePlugin — proves name
+        // reservation blocks across both registries.
         val first = NamedPlugin("shared")
-        val replacement = NamedObservePlugin("shared")
+        val duplicate = NamedObservePlugin("shared")
 
         amplitude.add(first)
-        amplitude.add(replacement)
+        amplitude.add(duplicate)
 
-        assertTrue(first.tornDown)
-        assertNull(amplitude.findPlugin<NamedPlugin>())
-        assertSame(replacement, amplitude.findPlugin<NamedObservePlugin>())
+        // First plugin survives untouched.
+        assertSame(first, amplitude.findPlugin<NamedPlugin>())
+        assertFalse(first.tornDown, "incumbent must not be torn down")
+        // Duplicate was never set up and is not findable.
+        assertFalse(duplicate.wasSetUp, "duplicate must not be set up")
+        assertNull(amplitude.findPlugin<NamedObservePlugin>())
     }
 
     @Test
@@ -320,78 +326,27 @@ class PluginContractTest {
 
         assertTrue(latch.await(5, TimeUnit.SECONDS), "concurrent dedup should not deadlock")
 
-        // Count how many plugins named "dedup-race" exist in the timeline.
+        // Exactly one plugin named "dedup-race" must survive — registration is atomic via
+        // putIfAbsent, so only one thread wins and the rest are rejected.
         var count = 0
         amplitude.timeline.applyClosure { if (it.name == "dedup-race") count++ }
-        // Known limitation: without full lock around add(), concurrent dedup can leave more than one.
-        // This test documents the current behavior — it must never crash, but may leave duplicates
-        // under extreme concurrency.
-        assertTrue(count >= 1, "at least one plugin should be registered")
+        assertEquals(1, count, "exactly one plugin should be registered")
     }
 
     @Test
-    fun `dedup teardown and identity callback add do not deadlock`() {
+    fun `duplicate add neither tears down the incumbent nor sets up the newcomer`() {
         val amplitude = FakeAmplitude()
-        val enteredTeardown = CountDownLatch(1)
-        val callbackReadyToAdd = CountDownLatch(1)
-        val completed = CountDownLatch(2)
-        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
-        val evicted =
-            TeardownSetsUserIdPlugin(
-                name = "deadlock-target",
-                enteredTeardown = enteredTeardown,
-                callbackReadyToAdd = callbackReadyToAdd,
-                errors = errors,
-            )
-        val identityCallback =
-            object : Plugin {
-                override val type: Plugin.Type = Plugin.Type.Before
-                override val name: String = "identity-callback"
-                override lateinit var amplitude: Amplitude
+        val incumbent = NamedPlugin("dup-target")
+        val newcomer = NamedPlugin("dup-target")
 
-                override fun execute(event: BaseEvent): BaseEvent = event
+        amplitude.add(incumbent)
+        amplitude.add(newcomer)
 
-                override fun onUserIdChanged(userId: String?) {
-                    if (userId != "identity-thread") return
-                    callbackReadyToAdd.countDown()
-                    if (!enteredTeardown.await(5, TimeUnit.SECONDS)) {
-                        errors += AssertionError("dedup teardown did not start")
-                        return
-                    }
-                    amplitude.add(NamedPlugin("callback-add"))
-                }
-            }
-
-        amplitude.add(evicted)
-        amplitude.add(identityCallback)
-
-        Thread {
-            try {
-                amplitude.add(NamedPlugin("deadlock-target"))
-            } catch (t: Throwable) {
-                errors += t
-            } finally {
-                completed.countDown()
-            }
-        }.apply {
-            isDaemon = true
-            start()
-        }
-        Thread {
-            try {
-                amplitude.setUserId("identity-thread")
-            } catch (t: Throwable) {
-                errors += t
-            } finally {
-                completed.countDown()
-            }
-        }.apply {
-            isDaemon = true
-            start()
-        }
-
-        assertTrue(completed.await(5, TimeUnit.SECONDS), "dedup teardown and identity callback add should not deadlock")
-        assertTrue(errors.isEmpty(), "unexpected concurrency errors: ${errors.joinToString { it.message.orEmpty() }}")
+        // Incumbent is still registered and was not torn down.
+        assertSame(incumbent, amplitude.findPlugin<NamedPlugin>())
+        assertFalse(incumbent.tornDown, "incumbent must not be torn down")
+        // Newcomer was never set up.
+        assertFalse(newcomer.wasSetUp, "newcomer must not be set up")
     }
 
     @RepeatedTest(20)
@@ -582,6 +537,12 @@ private class NamedPlugin(override val name: String) : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
     override lateinit var amplitude: Amplitude
     var tornDown = false
+    var wasSetUp = false
+
+    override fun setup(amplitude: Amplitude) {
+        super.setup(amplitude)
+        wasSetUp = true
+    }
 
     override fun execute(event: BaseEvent): BaseEvent = event
 
@@ -592,41 +553,14 @@ private class NamedPlugin(override val name: String) : Plugin {
 
 private class NamedObservePlugin(override val name: String) : ObservePlugin() {
     override lateinit var amplitude: Amplitude
+    var wasSetUp = false
+
+    override fun setup(amplitude: Amplitude) {
+        super.setup(amplitude)
+        wasSetUp = true
+    }
 
     override fun onUserIdChanged(userId: String?) {}
 
     override fun onDeviceIdChanged(deviceId: String?) {}
-}
-
-/** A named plugin whose teardown() always throws. */
-private class ThrowingTeardownPlugin(override val name: String) : Plugin {
-    override val type: Plugin.Type = Plugin.Type.Before
-    override lateinit var amplitude: Amplitude
-
-    override fun execute(event: BaseEvent): BaseEvent = event
-
-    override fun teardown() {
-        throw RuntimeException("boom: teardown")
-    }
-}
-
-private class TeardownSetsUserIdPlugin(
-    override val name: String,
-    private val enteredTeardown: CountDownLatch,
-    private val callbackReadyToAdd: CountDownLatch,
-    private val errors: MutableList<Throwable>,
-) : Plugin {
-    override val type: Plugin.Type = Plugin.Type.Before
-    override lateinit var amplitude: Amplitude
-
-    override fun execute(event: BaseEvent): BaseEvent = event
-
-    override fun teardown() {
-        enteredTeardown.countDown()
-        if (!callbackReadyToAdd.await(5, TimeUnit.SECONDS)) {
-            errors += AssertionError("identity callback did not enter add path")
-            return
-        }
-        amplitude.setUserId("teardown-thread")
-    }
 }

--- a/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
@@ -5,6 +5,7 @@ import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.utils.FakeAmplitude
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -261,7 +262,7 @@ class PluginContractTest {
     }
 
     @RepeatedTest(20)
-    fun `concurrent add and remove do not throw CME on observe store`() {
+    fun `concurrent add and remove of observe plugins do not throw CME`() {
         val amplitude = FakeAmplitude()
         val plugins = (0 until 20).map { NamedObservePlugin("obs-$it") }
         plugins.forEach { amplitude.add(it) }
@@ -444,6 +445,87 @@ class PluginContractTest {
 
         assertTrue(done.await(5, TimeUnit.SECONDS), "inner setDeviceId callback should complete")
         assertEquals("device-inner", amplitude.store.deviceId, "inner setDeviceId must not be overwritten by outer call")
+    }
+
+    @Test
+    fun `observe plugins stay passive — tracked event reaches destination despite observe plugin`() {
+        val amplitude = FakeAmplitude()
+        val received = mutableListOf<BaseEvent>()
+        val destination =
+            object : Plugin {
+                override val type: Plugin.Type = Plugin.Type.Destination
+                override val name: String = "recording-destination"
+                override lateinit var amplitude: Amplitude
+
+                override fun execute(event: BaseEvent): BaseEvent {
+                    received += event
+                    return event
+                }
+            }
+        val observeExecutions = AtomicInteger()
+        // A bare Plugin.Type.Observe plugin whose execute() would record invocations.
+        val bareObserve =
+            object : Plugin {
+                override val type: Plugin.Type = Plugin.Type.Observe
+                override val name: String = "bare-observe-spy"
+                override lateinit var amplitude: Amplitude
+
+                override fun execute(event: BaseEvent): BaseEvent {
+                    observeExecutions.incrementAndGet()
+                    return event
+                }
+            }
+        val observePlugin = RecordingObservePlugin("observe-passive")
+
+        amplitude.add(destination)
+        amplitude.add(observePlugin)
+        amplitude.add(bareObserve)
+        amplitude.track("test-event")
+
+        assertEquals(1, received.size, "destination must receive the event")
+        assertEquals("test-event", received[0].eventType)
+        assertEquals(0, observeExecutions.get(), "Observe plugin execute() must never be called for tracked events")
+    }
+
+    @Test
+    fun `deprecated State delegate registers observe plugin through the Timeline`() {
+        val amplitude = FakeAmplitude()
+        val plugin = RecordingObservePlugin("state-delegate-obs")
+
+        @Suppress("DEPRECATION")
+        val addResult = amplitude.store.add(plugin, amplitude)
+
+        assertTrue(addResult, "State.add should return true")
+        assertNotNull(amplitude.findPlugin<RecordingObservePlugin>(), "plugin must be findable via Amplitude.findPlugin")
+
+        // Plugin must receive identity callbacks routed through the timeline.
+        amplitude.setUserId("state-delegate-user")
+        assertEquals(listOf("state-delegate-user"), plugin.userIds)
+
+        // State.getPlugins() must return it via the deprecated delegate.
+        @Suppress("DEPRECATION")
+        val statePlugins = amplitude.store.plugins
+        assertTrue(statePlugins.any { it === plugin }, "State.getPlugins() must include the plugin")
+
+        // First-wins: a duplicate name is skipped, and State.add reports the real outcome.
+        @Suppress("DEPRECATION")
+        assertFalse(
+            amplitude.store.add(RecordingObservePlugin("state-delegate-obs"), amplitude),
+            "State.add should return false when a duplicate name is skipped",
+        )
+
+        // State.remove() must unregister it from the timeline.
+        @Suppress("DEPRECATION")
+        val removeResult = amplitude.store.remove(plugin)
+        assertTrue(removeResult, "State.remove should return true when the plugin was registered")
+        assertNull(amplitude.findPlugin<RecordingObservePlugin>(), "plugin must no longer be findable after State.remove")
+
+        // Removing an unregistered plugin reports false.
+        @Suppress("DEPRECATION")
+        assertFalse(
+            amplitude.store.remove(plugin),
+            "State.remove should return false for an unregistered plugin",
+        )
     }
 
     @Test

--- a/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
@@ -5,7 +5,6 @@ import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.utils.FakeAmplitude
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -485,47 +484,6 @@ class PluginContractTest {
         assertEquals(1, received.size, "destination must receive the event")
         assertEquals("test-event", received[0].eventType)
         assertEquals(0, observeExecutions.get(), "Observe plugin execute() must never be called for tracked events")
-    }
-
-    @Test
-    fun `deprecated State delegate registers observe plugin through the Timeline`() {
-        val amplitude = FakeAmplitude()
-        val plugin = RecordingObservePlugin("state-delegate-obs")
-
-        @Suppress("DEPRECATION")
-        val addResult = amplitude.store.add(plugin, amplitude)
-
-        assertTrue(addResult, "State.add should return true")
-        assertNotNull(amplitude.findPlugin<RecordingObservePlugin>(), "plugin must be findable via Amplitude.findPlugin")
-
-        // Plugin must receive identity callbacks routed through the timeline.
-        amplitude.setUserId("state-delegate-user")
-        assertEquals(listOf("state-delegate-user"), plugin.userIds)
-
-        // State.getPlugins() must return it via the deprecated delegate.
-        @Suppress("DEPRECATION")
-        val statePlugins = amplitude.store.plugins
-        assertTrue(statePlugins.any { it === plugin }, "State.getPlugins() must include the plugin")
-
-        // First-wins: a duplicate name is skipped, and State.add reports the real outcome.
-        @Suppress("DEPRECATION")
-        assertFalse(
-            amplitude.store.add(RecordingObservePlugin("state-delegate-obs"), amplitude),
-            "State.add should return false when a duplicate name is skipped",
-        )
-
-        // State.remove() must unregister it from the timeline.
-        @Suppress("DEPRECATION")
-        val removeResult = amplitude.store.remove(plugin)
-        assertTrue(removeResult, "State.remove should return true when the plugin was registered")
-        assertNull(amplitude.findPlugin<RecordingObservePlugin>(), "plugin must no longer be findable after State.remove")
-
-        // Removing an unregistered plugin reports false.
-        @Suppress("DEPRECATION")
-        assertFalse(
-            amplitude.store.remove(plugin),
-            "State.remove should return false for an unregistered plugin",
-        )
     }
 
     @Test

--- a/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
@@ -1,0 +1,632 @@
+package com.amplitude.core.platform
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.utils.FakeAmplitude
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class PluginContractTest {
+    @Test
+    fun `state callbacks fan out to timeline and observe plugins`() {
+        val amplitude = FakeAmplitude()
+        val timeline = RecordingPlugin("timeline")
+        val observe = RecordingObservePlugin("observe")
+
+        amplitude.add(timeline)
+        amplitude.add(observe)
+
+        amplitude.setUserId("user-1")
+        amplitude.setDeviceId("device-1")
+        amplitude.optOut = true
+        amplitude.reset()
+
+        assertEquals(listOf("user-1", null), timeline.userIds)
+        assertEquals(2, timeline.deviceIds.size)
+        assertEquals("device-1", timeline.deviceIds.first())
+        assertEquals(listOf(true), timeline.optOuts)
+        assertEquals(1, timeline.resets)
+
+        assertEquals(listOf("user-1", null), observe.userIds)
+        assertEquals(2, observe.deviceIds.size)
+        assertEquals("device-1", observe.deviceIds.first())
+        assertEquals(listOf(true), observe.optOuts)
+        assertEquals(1, observe.resets)
+    }
+
+    @Test
+    fun `reset uses one plugin snapshot for identity and reset callbacks`() {
+        val amplitude = FakeAmplitude()
+        val late = RecordingPlugin("late")
+        val mutator =
+            object : Plugin {
+                override val type: Plugin.Type = Plugin.Type.Before
+                override val name: String = "mutator"
+                override lateinit var amplitude: Amplitude
+
+                override fun execute(event: BaseEvent): BaseEvent = event
+
+                override fun onUserIdChanged(userId: String?) {
+                    if (userId == null) {
+                        amplitude.add(late)
+                    }
+                }
+            }
+
+        amplitude.add(mutator)
+        amplitude.reset()
+
+        assertTrue(late.userIds.isEmpty())
+        assertTrue(late.deviceIds.isEmpty())
+        assertEquals(0, late.resets)
+        assertSame(late, amplitude.findPlugin<RecordingPlugin>())
+    }
+
+    @Test
+    fun `throwing plugins do not stop later callbacks or later plugins`() {
+        val amplitude = FakeAmplitude()
+        val thrower = ThrowingObservePlugin()
+        val recorder = RecordingObservePlugin("recorder")
+
+        amplitude.add(thrower)
+        amplitude.add(recorder)
+
+        amplitude.reset()
+
+        assertEquals(listOf<String?>(null), recorder.userIds)
+        assertEquals(1, recorder.deviceIds.size)
+        assertEquals(1, recorder.resets)
+        assertEquals(1, thrower.deviceCallbackAttempts)
+    }
+
+    @Test
+    fun `reentrant userId callback does not get overwritten by outer mutation`() {
+        val amplitude = FakeAmplitude()
+        val completed = CountDownLatch(1)
+        val plugin =
+            object : ObservePlugin() {
+                override lateinit var amplitude: Amplitude
+                private var reentered = false
+
+                override fun onUserIdChanged(userId: String?) {
+                    if (!reentered && userId == "outer") {
+                        reentered = true
+                        amplitude.setUserId("inner")
+                    }
+                    if (userId == "inner") {
+                        completed.countDown()
+                    }
+                }
+
+                override fun onDeviceIdChanged(deviceId: String?) {}
+            }
+
+        amplitude.add(plugin)
+        amplitude.setUserId("outer")
+
+        assertTrue(completed.await(5, TimeUnit.SECONDS))
+        assertEquals("inner", amplitude.store.userId)
+    }
+
+    @Test
+    fun `named plugin add replaces existing plugin across stores`() {
+        val amplitude = FakeAmplitude()
+        val first = NamedPlugin("shared")
+        val replacement = NamedObservePlugin("shared")
+
+        amplitude.add(first)
+        amplitude.add(replacement)
+
+        assertTrue(first.tornDown)
+        assertNull(amplitude.findPlugin<NamedPlugin>())
+        assertSame(replacement, amplitude.findPlugin<NamedObservePlugin>())
+    }
+
+    @Test
+    fun `bare observe type plugin is stored in the timeline`() {
+        val amplitude = FakeAmplitude()
+        val plugin = RecordingPlugin("bare-observe", Plugin.Type.Observe)
+
+        amplitude.add(plugin)
+        amplitude.setUserId("user-1")
+
+        assertEquals(listOf<String?>("user-1"), plugin.userIds)
+        assertSame(plugin, amplitude.findPlugin<RecordingPlugin>())
+    }
+
+    @RepeatedTest(10)
+    fun `concurrent add setUserId and reset do not crash or deadlock`() {
+        val amplitude = FakeAmplitude()
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+        val barrier = CyclicBarrier(3)
+        val done = CountDownLatch(3)
+
+        fun launch(block: () -> Unit) {
+            Thread {
+                try {
+                    barrier.await()
+                    block()
+                } catch (t: Throwable) {
+                    errors += t
+                } finally {
+                    done.countDown()
+                }
+            }.start()
+        }
+
+        launch {
+            repeat(50) { amplitude.add(RecordingObservePlugin("observe-$it")) }
+        }
+        launch {
+            repeat(50) { amplitude.setUserId("user-$it") }
+        }
+        launch {
+            repeat(50) { amplitude.reset() }
+        }
+
+        assertTrue(done.await(5, TimeUnit.SECONDS))
+        assertTrue(errors.isEmpty(), errors.joinToString { it.message.orEmpty() })
+    }
+
+    @RepeatedTest(20)
+    fun `concurrent setUserId calls do not crash or lose notifications`() {
+        val amplitude = FakeAmplitude()
+        val received = Collections.synchronizedList(mutableListOf<String?>())
+        val observer =
+            object : ObservePlugin() {
+                override lateinit var amplitude: Amplitude
+
+                override fun onUserIdChanged(userId: String?) {
+                    received += userId
+                }
+
+                override fun onDeviceIdChanged(deviceId: String?) {}
+            }
+        amplitude.add(observer)
+
+        val threads = 10
+        val barrier = CyclicBarrier(threads)
+        val latch = CountDownLatch(threads)
+        repeat(threads) { i ->
+            Thread {
+                barrier.await()
+                amplitude.setUserId("user-$i")
+                latch.countDown()
+            }.start()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+
+        assertEquals(threads, received.size, "every setUserId should produce exactly one notification")
+    }
+
+    @RepeatedTest(20)
+    fun `concurrent add and setUserId do not throw CME`() {
+        val amplitude = FakeAmplitude()
+        val threads = 10
+        val barrier = CyclicBarrier(threads * 2)
+        val latch = CountDownLatch(threads * 2)
+
+        repeat(threads) { i ->
+            Thread {
+                barrier.await()
+                amplitude.add(RecordingObservePlugin("obs-add-$i"))
+                latch.countDown()
+            }.start()
+            Thread {
+                barrier.await()
+                amplitude.setUserId("user-$i")
+                latch.countDown()
+            }.start()
+        }
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "all threads should complete without deadlock")
+    }
+
+    @RepeatedTest(20)
+    fun `concurrent add and remove do not throw CME on observe store`() {
+        val amplitude = FakeAmplitude()
+        val plugins = (0 until 20).map { NamedObservePlugin("obs-$it") }
+        plugins.forEach { amplitude.add(it) }
+
+        val barrier = CyclicBarrier(2)
+        val latch = CountDownLatch(2)
+
+        Thread {
+            barrier.await()
+            plugins.take(10).forEach { amplitude.remove(it) }
+            latch.countDown()
+        }.start()
+        Thread {
+            barrier.await()
+            (20 until 30).forEach { amplitude.add(NamedObservePlugin("obs-$it")) }
+            latch.countDown()
+        }.start()
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "concurrent add+remove should not deadlock or crash")
+    }
+
+    @RepeatedTest(20)
+    fun `concurrent reset and setUserId produce consistent state`() {
+        val amplitude = FakeAmplitude()
+        val barrier = CyclicBarrier(2)
+        val latch = CountDownLatch(2)
+
+        Thread {
+            barrier.await()
+            amplitude.reset()
+            latch.countDown()
+        }.start()
+        Thread {
+            barrier.await()
+            amplitude.setUserId("concurrent-user")
+            latch.countDown()
+        }.start()
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "concurrent reset + setUserId should not deadlock")
+        val finalUserId = amplitude.store.userId
+        assertTrue(
+            finalUserId == null || finalUserId == "concurrent-user",
+            "userId should be null or 'concurrent-user', got: $finalUserId",
+        )
+    }
+
+    @RepeatedTest(20)
+    fun `concurrent findPlugin and add do not throw CME`() {
+        val amplitude = FakeAmplitude()
+        val found = AtomicInteger(0)
+        val threads = 10
+        val barrier = CyclicBarrier(threads * 2)
+        val latch = CountDownLatch(threads * 2)
+
+        repeat(threads) { i ->
+            Thread {
+                barrier.await()
+                amplitude.add(NamedObservePlugin("lookup-$i"))
+                latch.countDown()
+            }.start()
+            Thread {
+                barrier.await()
+                if (amplitude.findPlugin<NamedObservePlugin>() != null) found.incrementAndGet()
+                latch.countDown()
+            }.start()
+        }
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "concurrent findPlugin + add should not crash")
+    }
+
+    @RepeatedTest(20)
+    fun `concurrent dedup with same name does not leave duplicates`() {
+        val amplitude = FakeAmplitude()
+        val threads = 10
+        val barrier = CyclicBarrier(threads)
+        val latch = CountDownLatch(threads)
+
+        repeat(threads) {
+            Thread {
+                barrier.await()
+                amplitude.add(NamedPlugin("dedup-race"))
+                latch.countDown()
+            }.start()
+        }
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "concurrent dedup should not deadlock")
+
+        // Count how many plugins named "dedup-race" exist in the timeline.
+        var count = 0
+        amplitude.timeline.applyClosure { if (it.name == "dedup-race") count++ }
+        // Known limitation: without full lock around add(), concurrent dedup can leave more than one.
+        // This test documents the current behavior — it must never crash, but may leave duplicates
+        // under extreme concurrency.
+        assertTrue(count >= 1, "at least one plugin should be registered")
+    }
+
+    @Test
+    fun `dedup teardown and identity callback add do not deadlock`() {
+        val amplitude = FakeAmplitude()
+        val enteredTeardown = CountDownLatch(1)
+        val callbackReadyToAdd = CountDownLatch(1)
+        val completed = CountDownLatch(2)
+        val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+        val evicted =
+            TeardownSetsUserIdPlugin(
+                name = "deadlock-target",
+                enteredTeardown = enteredTeardown,
+                callbackReadyToAdd = callbackReadyToAdd,
+                errors = errors,
+            )
+        val identityCallback =
+            object : Plugin {
+                override val type: Plugin.Type = Plugin.Type.Before
+                override val name: String = "identity-callback"
+                override lateinit var amplitude: Amplitude
+
+                override fun execute(event: BaseEvent): BaseEvent = event
+
+                override fun onUserIdChanged(userId: String?) {
+                    if (userId != "identity-thread") return
+                    callbackReadyToAdd.countDown()
+                    if (!enteredTeardown.await(5, TimeUnit.SECONDS)) {
+                        errors += AssertionError("dedup teardown did not start")
+                        return
+                    }
+                    amplitude.add(NamedPlugin("callback-add"))
+                }
+            }
+
+        amplitude.add(evicted)
+        amplitude.add(identityCallback)
+
+        Thread {
+            try {
+                amplitude.add(NamedPlugin("deadlock-target"))
+            } catch (t: Throwable) {
+                errors += t
+            } finally {
+                completed.countDown()
+            }
+        }.apply {
+            isDaemon = true
+            start()
+        }
+        Thread {
+            try {
+                amplitude.setUserId("identity-thread")
+            } catch (t: Throwable) {
+                errors += t
+            } finally {
+                completed.countDown()
+            }
+        }.apply {
+            isDaemon = true
+            start()
+        }
+
+        assertTrue(completed.await(5, TimeUnit.SECONDS), "dedup teardown and identity callback add should not deadlock")
+        assertTrue(errors.isEmpty(), "unexpected concurrency errors: ${errors.joinToString { it.message.orEmpty() }}")
+    }
+
+    @RepeatedTest(20)
+    fun `notification during remove does not crash`() {
+        val amplitude = FakeAmplitude()
+        val observer = RecordingObservePlugin("remove-race")
+        amplitude.add(observer)
+
+        val barrier = CyclicBarrier(2)
+        val latch = CountDownLatch(2)
+
+        Thread {
+            barrier.await()
+            repeat(50) { amplitude.setUserId("user-$it") }
+            latch.countDown()
+        }.start()
+        Thread {
+            barrier.await()
+            amplitude.remove(observer)
+            latch.countDown()
+        }.start()
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "notification during remove should not crash")
+    }
+
+    @RepeatedTest(20)
+    fun `optOut and setUserId racing do not crash`() {
+        val amplitude = FakeAmplitude()
+        val recorder = RecordingPlugin("opt-out-race")
+        amplitude.add(recorder)
+
+        val barrier = CyclicBarrier(2)
+        val latch = CountDownLatch(2)
+
+        Thread {
+            barrier.await()
+            repeat(50) { amplitude.optOut = it % 2 == 0 }
+            latch.countDown()
+        }.start()
+        Thread {
+            barrier.await()
+            repeat(50) { amplitude.setUserId("user-$it") }
+            latch.countDown()
+        }.start()
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "optOut + setUserId racing should not crash")
+    }
+
+    @Test
+    fun `plugin reentrancy in onDeviceIdChanged does not overwrite inner setDeviceId value`() {
+        val amplitude = FakeAmplitude()
+        val done = CountDownLatch(1)
+
+        val reentrantPlugin =
+            object : ObservePlugin() {
+                override lateinit var amplitude: Amplitude
+                var triggered = false
+
+                override fun onUserIdChanged(userId: String?) {}
+
+                override fun onDeviceIdChanged(deviceId: String?) {
+                    if (!triggered && deviceId == "device-outer") {
+                        triggered = true
+                        amplitude.setDeviceId("device-inner")
+                    }
+                    if (deviceId == "device-inner") done.countDown()
+                }
+            }
+        amplitude.add(reentrantPlugin)
+
+        amplitude.setDeviceId("device-outer")
+
+        assertTrue(done.await(5, TimeUnit.SECONDS), "inner setDeviceId callback should complete")
+        assertEquals("device-inner", amplitude.store.deviceId, "inner setDeviceId must not be overwritten by outer call")
+    }
+
+    @Test
+    fun `plugin reentrancy in onUserIdChanged during reset does not overwrite inner setUserId value`() {
+        val amplitude = FakeAmplitude()
+        val done = CountDownLatch(1)
+
+        val reentrantPlugin =
+            object : ObservePlugin() {
+                override lateinit var amplitude: Amplitude
+                var triggered = false
+
+                override fun onUserIdChanged(userId: String?) {
+                    if (!triggered && userId == null) {
+                        triggered = true
+                        // Simulate a plugin that re-assigns userId after a reset.
+                        amplitude.setUserId("post-reset-user")
+                    }
+                    if (userId == "post-reset-user") done.countDown()
+                }
+
+                override fun onDeviceIdChanged(deviceId: String?) {}
+            }
+        amplitude.add(reentrantPlugin)
+
+        amplitude.reset()
+
+        assertTrue(done.await(5, TimeUnit.SECONDS), "inner setUserId from onUserIdChanged during reset should complete")
+        assertEquals(
+            "post-reset-user",
+            amplitude.store.userId,
+            "userId set inside onUserIdChanged callback must not be overwritten by the reset",
+        )
+    }
+}
+
+private open class RecordingPlugin(
+    override val name: String?,
+    override val type: Plugin.Type = Plugin.Type.Before,
+) : Plugin {
+    override lateinit var amplitude: Amplitude
+    val userIds = Collections.synchronizedList(mutableListOf<String?>())
+    val deviceIds = Collections.synchronizedList(mutableListOf<String?>())
+    val optOuts = Collections.synchronizedList(mutableListOf<Boolean>())
+    private val resetCount = AtomicInteger()
+    val resets: Int get() = resetCount.get()
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun onUserIdChanged(userId: String?) {
+        userIds.add(userId)
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds.add(deviceId)
+    }
+
+    override fun onOptOutChanged(optOut: Boolean) {
+        optOuts.add(optOut)
+    }
+
+    override fun onReset() {
+        resetCount.incrementAndGet()
+    }
+}
+
+private class RecordingObservePlugin(
+    override val name: String?,
+) : ObservePlugin() {
+    override lateinit var amplitude: Amplitude
+    val userIds = Collections.synchronizedList(mutableListOf<String?>())
+    val deviceIds = Collections.synchronizedList(mutableListOf<String?>())
+    val optOuts = Collections.synchronizedList(mutableListOf<Boolean>())
+    private val resetCount = AtomicInteger()
+    val resets: Int get() = resetCount.get()
+
+    override fun onUserIdChanged(userId: String?) {
+        userIds.add(userId)
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceIds.add(deviceId)
+    }
+
+    override fun onOptOutChanged(optOut: Boolean) {
+        optOuts.add(optOut)
+    }
+
+    override fun onReset() {
+        resetCount.incrementAndGet()
+    }
+}
+
+private class ThrowingObservePlugin : ObservePlugin() {
+    override val name: String = "thrower"
+    override lateinit var amplitude: Amplitude
+    var deviceCallbackAttempts = 0
+
+    override fun onUserIdChanged(userId: String?) {
+        throw RuntimeException("user")
+    }
+
+    override fun onDeviceIdChanged(deviceId: String?) {
+        deviceCallbackAttempts += 1
+        throw RuntimeException("device")
+    }
+
+    override fun onReset() {
+        throw RuntimeException("reset")
+    }
+}
+
+private class NamedPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+    var tornDown = false
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        tornDown = true
+    }
+}
+
+private class NamedObservePlugin(override val name: String) : ObservePlugin() {
+    override lateinit var amplitude: Amplitude
+
+    override fun onUserIdChanged(userId: String?) {}
+
+    override fun onDeviceIdChanged(deviceId: String?) {}
+}
+
+/** A named plugin whose teardown() always throws. */
+private class ThrowingTeardownPlugin(override val name: String) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        throw RuntimeException("boom: teardown")
+    }
+}
+
+private class TeardownSetsUserIdPlugin(
+    override val name: String,
+    private val enteredTeardown: CountDownLatch,
+    private val callbackReadyToAdd: CountDownLatch,
+    private val errors: MutableList<Throwable>,
+) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+
+    override fun execute(event: BaseEvent): BaseEvent = event
+
+    override fun teardown() {
+        enteredTeardown.countDown()
+        if (!callbackReadyToAdd.await(5, TimeUnit.SECONDS)) {
+            errors += AssertionError("identity callback did not enter add path")
+            return
+        }
+        amplitude.setUserId("teardown-thread")
+    }
+}

--- a/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/PluginContractTest.kt
@@ -90,6 +90,29 @@ class PluginContractTest {
     }
 
     @Test
+    fun `reset still delivers onReset to a plugin that threw in onDeviceIdChanged`() {
+        val amplitude = FakeAmplitude()
+        val thrower = ThrowingObservePlugin()
+        val recorder = RecordingObservePlugin("recorder")
+
+        amplitude.add(thrower)
+        amplitude.add(recorder)
+
+        amplitude.setUserId("pre-reset-user")
+        amplitude.reset()
+
+        // Thrower: all three loops attempted — throws are caught, not propagated.
+        assertEquals(2, thrower.userCallbackAttempts, "onUserIdChanged called for setUserId + reset")
+        assertEquals(1, thrower.deviceCallbackAttempts, "onDeviceIdChanged called during reset")
+        assertEquals(1, thrower.resets, "onReset still called despite prior throws in same reset")
+
+        // Clean recorder: all three callbacks delivered regardless of thrower's exceptions.
+        assertEquals(listOf("pre-reset-user", null), recorder.userIds)
+        assertEquals(1, recorder.deviceIds.size)
+        assertEquals(1, recorder.resets)
+    }
+
+    @Test
     fun `reentrant userId callback does not get overwritten by outer mutation`() {
         val amplitude = FakeAmplitude()
         val completed = CountDownLatch(1)
@@ -517,9 +540,13 @@ private class RecordingObservePlugin(
 private class ThrowingObservePlugin : ObservePlugin() {
     override val name: String = "thrower"
     override lateinit var amplitude: Amplitude
+    var userCallbackAttempts = 0
     var deviceCallbackAttempts = 0
+    private val resetCount = AtomicInteger()
+    val resets: Int get() = resetCount.get()
 
     override fun onUserIdChanged(userId: String?) {
+        userCallbackAttempts += 1
         throw RuntimeException("user")
     }
 
@@ -529,6 +556,7 @@ private class ThrowingObservePlugin : ObservePlugin() {
     }
 
     override fun onReset() {
+        resetCount.incrementAndGet()
         throw RuntimeException("reset")
     }
 }


### PR DESCRIPTION
### Describe what this PR is addressing

Part of the Unified SDK work (**SDKA-6**). "Blades" — Session Replay, Experiment, Guides & Surveys — need to register as plugins on the analytics `Amplitude` instance and react to identity/session/opt-out changes. Today the plugin model only delivers `onUserIdChanged`/`onDeviceIdChanged`, and only to `ObservePlugin`s in the `State` store — timeline plugins and the other state transitions (session, opt-out, reset) aren't surfaced, and there's no way to look a plugin up or dedup one by name.

### Describe the solution

A small, additive plugin contract layered on top of the existing pipeline — no rewrite of identity internals.

- **`Plugin` gains five default no-op callbacks** — `onUserIdChanged`, `onDeviceIdChanged`, `onSessionIdChanged` (Android), `onOptOutChanged`, `onReset` — so existing plugins are unaffected.
- **`findPlugin<T>()`** across the timeline mediators **and** the observe store, and **name-based dedup** on `add()` (a named plugin replaces + tears down the previous).
- **One fan-out path** (`Amplitude.notifyPlugins`): snapshots timeline + store once and isolates each call (`safelyNotify`), so a throwing plugin can't break the loop, the calling thread, or the Android event-message coroutine. `reset()` reuses a single snapshot for its userId → deviceId → reset passes.

Design decisions / trade-offs:
- **`com.amplitude.id.*` is untouched.** It's shared with the Experiment SDK and is the binary-compat boundary — identity persistence stays where it is. The shipped `IdentityCoordinator` remains the single runtime identity owner (lock + `State` mirror + pre-build pending + bootstrap reconcile); it gains an atomic `reset(newDeviceId)`.
- **Reentrancy-safe by construction.** `State.userId/deviceId` became silent `@Volatile` mirrors; all notification moved to `Amplitude` and fires **after** the identity lock is released — so a plugin that re-sets identity from inside its own callback isn't clobbered by the outer commit. No lock is ever held across a plugin callback.
- Notification is **intent-based** (every explicit set notifies once), one rule for all five callbacks.

Incidentally fixes two latent issues on `main`: a cross-thread visibility gap on the (previously non-`@Volatile`) identity fields, and userId/deviceId tearing in Android `reset()` (previously two separate mutations, now one atomic reset).

**Public API:** additive only — `core.api` +8 (`Plugin` name + 5 callbacks, `protected doResetWithDeviceId`/`notifyAllPlugins`); `android.api` unchanged. **Not a breaking change.**

### Steps to verify the change

- `./gradlew :core:test :android:test` — green. Core includes a new `PluginContractTest` (179 cases incl. reentrancy + `@RepeatedTest` concurrency) and Android `PluginContractAndroidTest` (session/reset/dedup).
- `./gradlew apiCheck` — green; `core/api/core.api` is +8 additive, `android/api/android.api` unchanged.
- **sdk-verification harness** — verified against this branch under a customer-shaped Android/Gradle/AGP/Kotlin setup; all plugin/remote-config/remote scenarios pass, including a new `PluginConcurrencyScenario` (reentrant `setUserId`/`setDeviceId` from a callback; concurrent add/setUserId/reset with no deadlock). The scenario coverage lands as a **follow-up PR in the `amplitude-sdk-verification` repo** (currently on a branch); run locally with `cd android-baseline && ./gradlew :scenarios:testDebugUnitTest -Pamplitude.sdk.path=<this-clone>`.

### Useful links and documentation (optional)

- SDKA-6 (Jira) · Unified SDK for Android (Confluence)
- Plugin & identity contributor guide added in `core/src/main/java/com/amplitude/core/README.md`
- Follow-up: `amplitude-sdk-verification` PR adding `PluginConcurrencyScenario` + realigning the reset scenario to the shipped API.

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)? (`feat:`)
* [ ] Does your PR have a breaking change? — **No** (additive public API only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core identity mutation and plugin notification ordering (reset, reentrancy, session restore); behavior is additive but blades will depend on these semantics.
> 
> **Overview**
> Adds a **unified plugin contract** so blades can react to identity and SDK state without living only in the deprecated `State` observe registry.
> 
> **`Plugin`** now exposes optional **`name`** plus default no-op callbacks (`onUserIdChanged`, `onDeviceIdChanged`, `onSessionIdChanged`, `onOptOutChanged`, `onReset`). **`Amplitude`** fans these out through one **`notifyPlugins`** path: snapshot registered plugins once, **`safelyNotify`** per plugin, and fire **after** `IdentityCoordinator` releases its lock so reentrant `setUserId` / `setDeviceId` from a callback is not clobbered. **`reset()`** goes through **`doResetWithDeviceId`** and **`IdentityCoordinator.reset`**, delivering userId → deviceId → `onReset` from a single snapshot. **`optOut`** assignment on `Amplitude` also notifies plugins.
> 
> **`State`** identity fields are silent **`@Volatile`** mirrors (no notification in setters); the legacy **`State.plugins`** registry is deprecated. **`Timeline`** gains an **Observe** mediator, **`findPlugin<T>()`**, and **name-based dedup** (first registration wins). **Android** calls **`notifySessionIdChanged`** when sessions are restored, configured, or rotated; **`reset()`** resolves a new device id via **`AndroidContextPlugin.resolveDeviceId`** then uses the shared reset path.
> 
> Contributor docs in **`core/README.md`** and broad **`PluginContractTest`** / **`PluginContractAndroidTest`** coverage accompany additive **`core.api`** surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5deb61577782f7490ec2e2a97102dd0d7cebd0ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->