### PR TITLE
chore: add size-limit checks to PR

### DIFF
--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Build binaries
         run: ./gradlew :core:jar :android:assembleRelease -x test
 
-      - name: Setup Node.js ${{ inputs.node-version }}
+      - name: Setup Node.js 24
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -65,3 +65,33 @@ jobs:
           name: test-and-lint-results
           path: '**/build/reports/**'
           retention-days: 7
+
+  size-limit:
+    name: Size Limit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Build binaries
+        run: ./gradlew :core:jar :android:assembleRelease -x test
+
+      - name: Setup Node.js ${{ inputs.node-version }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install size-limit
+        run: npm ci
+
+      - name: Check size
+        run: npm run size-limit
+        

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,0 +1,19 @@
+const limits = [
+  {
+    // Android Release AAR
+    path: './android/build/outputs/aar/android-release.aar',
+    limit: '399kb',
+    brotli: false,
+  },
+  {
+    // Core JAR file
+    path: [
+      './core/build/libs/core-*.jar',
+      '!core/build/libs/*-sources.jar',
+    ],
+    limit: '550kb',
+    brotli: false,
+  },
+]
+
+module.exports = limits;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,10 @@
         "@semantic-release/git": "9.0.1",
         "lodash": "4.17.21",
         "semantic-release": "17.4.7"
+      },
+      "devDependencies": {
+        "@size-limit/file": "12.1.0",
+        "size-limit": "12.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -537,6 +541,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -765,6 +782,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/callsites": {
@@ -2035,6 +2062,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -2320,6 +2360,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -5971,6 +6021,34 @@
         "node": ">=4"
       }
     },
+    "node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6259,6 +6337,54 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "private": true,
   "dependencies": {
-    "lodash": "4.17.21",
-    "semantic-release": "17.4.7",
-    "@semantic-release/changelog": "5.0.1",
-    "@semantic-release/git": "9.0.1",
     "@google/semantic-release-replace-plugin": "1.2.0",
-    "@semantic-release/exec": "5.0.0"
+    "@semantic-release/changelog": "5.0.1",
+    "@semantic-release/exec": "5.0.0",
+    "@semantic-release/git": "9.0.1",
+    "lodash": "4.17.21",
+    "semantic-release": "17.4.7"
+  },
+  "devDependencies": {
+    "@size-limit/file": "12.1.0",
+    "size-limit": "12.1.0"
+  },
+  "scripts": {
+    "size-limit": "size-limit"
   }
 }


### PR DESCRIPTION
### Describe what this PR is addressing
Adds bundle size gating to the pull request

### Describe the solution
Add a CI job that builds the AAR and JAR builds, installs "size-limit" dependencies, and then checks the sizes of the AAR and JAR and fails if it goes over the threshold

### Steps to verify the change
Tested the job within this PR and observed it working

<img width="1090" height="623" alt="Screenshot 2026-06-04 at 3 07 09 PM" src="https://github.com/user-attachments/assets/a94e25b0-3a8c-4473-8881-1435967024d5" />



### Useful links and documentation (optional)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI workflow and size config are added; no SDK runtime or API behavior changes.
> 
> **Overview**
> Adds **automated bundle size gates** to the PR workflow so regressions in shipped artifacts fail CI before merge.
> 
> A new **`size-limit`** job runs after **`build`**, builds `:core:jar` and `:android:assembleRelease` (tests skipped), then runs **`daniel-statsig/size-limit-action`** with **`GITHUB_TOKEN`** for PR feedback. Limits live in **`.size-limit.js`**: **399kb** for `android-release.aar` and **550kb** for the core JAR (sources JAR excluded), with **`brotli: false`** for raw file sizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4111dbe1b5e6c3534586cd4bfbe3f5de3177aa99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->