### PR TITLE
feat(core): introduce UniversalPlugin interface (SDKA-7)

### DIFF
--- a/android/api/android.api
+++ b/android/api/android.api
@@ -10,7 +10,7 @@ public class com/amplitude/android/Amplitude : com/amplitude/core/Amplitude {
 	public synthetic fun createTimeline ()Lcom/amplitude/core/platform/Timeline;
 	protected fun diagnosticsContextProvider ()Lcom/amplitude/core/diagnostics/DiagnosticsContextProvider;
 	protected fun diagnosticsStorageDirectory ()Ljava/io/File;
-	public final fun getSessionId ()J
+	public fun getSessionId ()J
 	public final fun onEnterForeground (J)V
 	public final fun onExitForeground (J)V
 	public fun reset ()Lcom/amplitude/android/Amplitude;

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -56,7 +56,7 @@ open class Amplitude internal constructor(
         )
     }
 
-    val sessionId: Long
+    override val sessionId: Long
         get() {
             return (timeline as Timeline).sessionId
         }

--- a/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
@@ -114,7 +114,6 @@ class AndroidLifecyclePluginTest {
                 mockedAmplitude.track(
                     EventTypes.APPLICATION_INSTALLED,
                     any(),
-                    any(),
                 )
             }
 
@@ -196,7 +195,7 @@ class AndroidLifecyclePluginTest {
             advanceUntilIdle()
 
             verify(exactly = 0) { mockedAmplitude.track(EventTypes.APPLICATION_INSTALLED, any(), any()) }
-            verify(exactly = 1) { mockedAmplitude.track(EventTypes.APPLICATION_UPDATED, any(), any()) }
+            verify(exactly = 1) { mockedAmplitude.track(EventTypes.APPLICATION_UPDATED, any()) }
 
             close()
         }
@@ -218,7 +217,6 @@ class AndroidLifecyclePluginTest {
             verify {
                 mockedAmplitude.track(
                     EventTypes.APPLICATION_UPDATED,
-                    any(),
                     any(),
                 )
             }
@@ -398,7 +396,6 @@ class AndroidLifecyclePluginTest {
                 mockedAmplitude.track(
                     eq(EventTypes.APPLICATION_OPENED),
                     match { param -> param.values.first() == false },
-                    null,
                 )
             }
 
@@ -418,7 +415,6 @@ class AndroidLifecyclePluginTest {
                 mockedAmplitude.track(
                     eq(EventTypes.APPLICATION_OPENED),
                     match { param -> param.values.first() == false },
-                    null,
                 )
             }
             close()

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -36,7 +36,7 @@ public final class com/amplitude/common/jvm/ConsoleLogger$Companion {
 	public final fun getLogger ()Lcom/amplitude/common/jvm/ConsoleLogger;
 }
 
-public class com/amplitude/core/Amplitude {
+public class com/amplitude/core/Amplitude : com/amplitude/core/AnalyticsClient {
 	public fun <init> (Lcom/amplitude/core/Configuration;)V
 	public fun <init> (Lcom/amplitude/core/Configuration;Lcom/amplitude/core/State;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public synthetic fun <init> (Lcom/amplitude/core/Configuration;Lcom/amplitude/core/State;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -58,11 +58,13 @@ public class com/amplitude/core/Amplitude {
 	public final fun getDiagnosticsClient ()Lcom/amplitude/core/diagnostics/DiagnosticsClient;
 	public final fun getIdContainer ()Lcom/amplitude/id/IdentityContainer;
 	public final fun getIdentifyInterceptStorage ()Lcom/amplitude/core/Storage;
+	public fun getIdentity ()Lcom/amplitude/core/AnalyticsIdentity;
 	public final fun getIdentityStorage ()Lcom/amplitude/id/IdentityStorage;
 	public final fun getLogger ()Lcom/amplitude/common/Logger;
 	public final fun getNetworkIODispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getOptOut ()Z
 	public final fun getRemoteConfigClient ()Lcom/amplitude/core/remoteconfig/RemoteConfigClient;
+	public fun getSessionId ()J
 	public final fun getSignalFlow ()Lkotlinx/coroutines/flow/SharedFlow;
 	public final fun getStorage ()Lcom/amplitude/core/Storage;
 	public final fun getStorageIODispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
@@ -105,6 +107,7 @@ public class com/amplitude/core/Amplitude {
 	public final fun track (Lcom/amplitude/core/events/BaseEvent;Lcom/amplitude/core/events/EventOptions;Lkotlin/jvm/functions/Function3;)Lcom/amplitude/core/Amplitude;
 	public final fun track (Ljava/lang/String;)Lcom/amplitude/core/Amplitude;
 	public final fun track (Ljava/lang/String;Ljava/util/Map;)Lcom/amplitude/core/Amplitude;
+	public fun track (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;Ljava/util/Map;Lcom/amplitude/core/events/EventOptions;)Lcom/amplitude/core/Amplitude;
 	public static synthetic fun track$default (Lcom/amplitude/core/Amplitude;Lcom/amplitude/core/events/BaseEvent;Lcom/amplitude/core/events/EventOptions;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lcom/amplitude/core/Amplitude;
 	public static synthetic fun track$default (Lcom/amplitude/core/Amplitude;Ljava/lang/String;Ljava/util/Map;Lcom/amplitude/core/events/EventOptions;ILjava/lang/Object;)Lcom/amplitude/core/Amplitude;
@@ -112,6 +115,19 @@ public class com/amplitude/core/Amplitude {
 
 public final class com/amplitude/core/AmplitudeKt {
 	public static final fun Amplitude (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/amplitude/core/Amplitude;
+}
+
+public abstract interface class com/amplitude/core/AnalyticsClient {
+	public abstract fun getIdentity ()Lcom/amplitude/core/AnalyticsIdentity;
+	public abstract fun getOptOut ()Z
+	public abstract fun getSessionId ()J
+	public abstract fun track (Ljava/lang/String;Ljava/util/Map;)V
+	public static synthetic fun track$default (Lcom/amplitude/core/AnalyticsClient;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+}
+
+public abstract interface class com/amplitude/core/AnalyticsIdentity {
+	public abstract fun getDeviceId ()Ljava/lang/String;
+	public abstract fun getUserId ()Ljava/lang/String;
 }
 
 public class com/amplitude/core/Configuration {
@@ -802,7 +818,7 @@ public abstract class com/amplitude/core/platform/ObservePlugin : com/amplitude/
 	public abstract fun onUserIdChanged (Ljava/lang/String;)V
 }
 
-public abstract interface class com/amplitude/core/platform/Plugin {
+public abstract interface class com/amplitude/core/platform/Plugin : com/amplitude/core/platform/UniversalPlugin {
 	public fun execute (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;
 	public abstract fun getAmplitude ()Lcom/amplitude/core/Amplitude;
 	public fun getName ()Ljava/lang/String;
@@ -814,6 +830,7 @@ public abstract interface class com/amplitude/core/platform/Plugin {
 	public fun onUserIdChanged (Ljava/lang/String;)V
 	public abstract fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
 	public fun setup (Lcom/amplitude/core/Amplitude;)V
+	public fun setup (Lcom/amplitude/core/AnalyticsClient;)V
 	public fun teardown ()V
 }
 
@@ -849,6 +866,17 @@ public class com/amplitude/core/platform/Timeline {
 	public fun process (Lcom/amplitude/core/events/BaseEvent;)V
 	public final fun remove (Lcom/amplitude/core/platform/Plugin;)V
 	public final fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
+}
+
+public abstract interface class com/amplitude/core/platform/UniversalPlugin {
+	public fun execute (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;
+	public fun getName ()Ljava/lang/String;
+	public fun onIdentityChanged (Lcom/amplitude/core/AnalyticsIdentity;)V
+	public fun onOptOutChanged (Z)V
+	public fun onReset ()V
+	public fun onSessionIdChanged (J)V
+	public fun setup (Lcom/amplitude/core/AnalyticsClient;)V
+	public fun teardown ()V
 }
 
 public final class com/amplitude/core/platform/WriteQueueMessage {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -107,10 +107,10 @@ public class com/amplitude/core/Amplitude : com/amplitude/core/AnalyticsClient {
 	public final fun track (Lcom/amplitude/core/events/BaseEvent;Lcom/amplitude/core/events/EventOptions;Lkotlin/jvm/functions/Function3;)Lcom/amplitude/core/Amplitude;
 	public final fun track (Ljava/lang/String;)Lcom/amplitude/core/Amplitude;
 	public final fun track (Ljava/lang/String;Ljava/util/Map;)Lcom/amplitude/core/Amplitude;
-	public fun track (Ljava/lang/String;Ljava/util/Map;)V
 	public final fun track (Ljava/lang/String;Ljava/util/Map;Lcom/amplitude/core/events/EventOptions;)Lcom/amplitude/core/Amplitude;
 	public static synthetic fun track$default (Lcom/amplitude/core/Amplitude;Lcom/amplitude/core/events/BaseEvent;Lcom/amplitude/core/events/EventOptions;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lcom/amplitude/core/Amplitude;
 	public static synthetic fun track$default (Lcom/amplitude/core/Amplitude;Ljava/lang/String;Ljava/util/Map;Lcom/amplitude/core/events/EventOptions;ILjava/lang/Object;)Lcom/amplitude/core/Amplitude;
+	public fun trackEvent (Ljava/lang/String;Ljava/util/Map;)V
 }
 
 public final class com/amplitude/core/AmplitudeKt {
@@ -121,7 +121,7 @@ public abstract interface class com/amplitude/core/AnalyticsClient {
 	public abstract fun getIdentity ()Lcom/amplitude/core/AnalyticsIdentity;
 	public abstract fun getOptOut ()Z
 	public abstract fun getSessionId ()J
-	public abstract fun track (Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun trackEvent (Ljava/lang/String;Ljava/util/Map;)V
 }
 
 public abstract interface class com/amplitude/core/AnalyticsIdentity {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -122,7 +122,6 @@ public abstract interface class com/amplitude/core/AnalyticsClient {
 	public abstract fun getOptOut ()Z
 	public abstract fun getSessionId ()J
 	public abstract fun track (Ljava/lang/String;Ljava/util/Map;)V
-	public static synthetic fun track$default (Lcom/amplitude/core/AnalyticsClient;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
 public abstract interface class com/amplitude/core/AnalyticsIdentity {

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -251,9 +251,9 @@ open class Amplitude(
 
     /**
      * Log event with the specified event type and optional event properties.
-     * Satisfies [AnalyticsClient.track].
+     * Satisfies [AnalyticsClient.trackEvent].
      */
-    override fun track(
+    override fun trackEvent(
         eventType: String,
         eventProperties: Map<String, Any?>?,
     ) {
@@ -334,8 +334,9 @@ open class Amplitude(
      */
     fun setUserId(userId: String?): Amplitude {
         identityCoordinator.setUserId(userId)
+        val snapshot = identity
         notifyPlugins { it.onUserIdChanged(store.userId) }
-        notifyPlugins { it.onIdentityChanged(identity) }
+        notifyPlugins { plugin -> plugin.onIdentityChanged(snapshot) }
         return this
     }
 
@@ -356,8 +357,9 @@ open class Amplitude(
      */
     fun setDeviceId(deviceId: String): Amplitude {
         identityCoordinator.setDeviceId(deviceId)
+        val snapshot = identity
         notifyPlugins { it.onDeviceIdChanged(store.deviceId) }
-        notifyPlugins { it.onIdentityChanged(identity) }
+        notifyPlugins { plugin -> plugin.onIdentityChanged(snapshot) }
         return this
     }
 

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -133,6 +133,7 @@ open class Amplitude(
     open var optOut: Boolean
         get() = configuration.optOut
         set(value) {
+            if (configuration.optOut == value) return
             configuration.optOut = value
             notifyPlugins { it.onOptOutChanged(value) }
         }

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -68,7 +68,7 @@ open class Amplitude(
      * Session id is Android-only. Core returns -1 by default; the Android
      * subclass overrides this with the real value.
      */
-    override val sessionId: Long
+    open override val sessionId: Long
         get() = -1L
     val timeline: Timeline
     val storage: Storage by lazy {

--- a/core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -56,7 +56,20 @@ open class Amplitude(
     val amplitudeDispatcher: CoroutineDispatcher = Executors.newCachedThreadPool().asCoroutineDispatcher(),
     val networkIODispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
     val storageIODispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
-) {
+) : AnalyticsClient {
+    override val identity: AnalyticsIdentity
+        get() =
+            object : AnalyticsIdentity {
+                override val userId: String? = store.userId
+                override val deviceId: String? = store.deviceId
+            }
+
+    /**
+     * Session id is Android-only. Core returns -1 by default; the Android
+     * subclass overrides this with the real value.
+     */
+    override val sessionId: Long
+        get() = -1L
     val timeline: Timeline
     val storage: Storage by lazy {
         configuration.storageProvider.getStorage(this)
@@ -130,7 +143,7 @@ open class Amplitude(
      * `configuration.optOut` directly) — only this setter notifies plugins via
      * [Plugin.onOptOutChanged].
      */
-    open var optOut: Boolean
+    override var optOut: Boolean
         get() = configuration.optOut
         set(value) {
             if (configuration.optOut == value) return
@@ -237,6 +250,17 @@ open class Amplitude(
     }
 
     /**
+     * Log event with the specified event type and optional event properties.
+     * Satisfies [AnalyticsClient.track].
+     */
+    override fun track(
+        eventType: String,
+        eventProperties: Map<String, Any?>?,
+    ) {
+        track(eventType, eventProperties, null)
+    }
+
+    /**
      * Log event with the specified event type, event properties, and optional event options.
      *
      * @param eventType the event type
@@ -311,6 +335,7 @@ open class Amplitude(
     fun setUserId(userId: String?): Amplitude {
         identityCoordinator.setUserId(userId)
         notifyPlugins { it.onUserIdChanged(store.userId) }
+        notifyPlugins { it.onIdentityChanged(identity) }
         return this
     }
 
@@ -332,6 +357,7 @@ open class Amplitude(
     fun setDeviceId(deviceId: String): Amplitude {
         identityCoordinator.setDeviceId(deviceId)
         notifyPlugins { it.onDeviceIdChanged(store.deviceId) }
+        notifyPlugins { it.onIdentityChanged(identity) }
         return this
     }
 
@@ -365,6 +391,8 @@ open class Amplitude(
         val plugins = pluginsSnapshot()
         plugins.forEach { safelyNotify(it) { plugin -> plugin.onUserIdChanged(store.userId) } }
         plugins.forEach { safelyNotify(it) { plugin -> plugin.onDeviceIdChanged(store.deviceId) } }
+        val snapshot = identity
+        plugins.forEach { safelyNotify(it) { plugin -> plugin.onIdentityChanged(snapshot) } }
         plugins.forEach { safelyNotify(it) { plugin -> plugin.onReset() } }
     }
 

--- a/core/src/main/java/com/amplitude/core/AnalyticsClient.kt
+++ b/core/src/main/java/com/amplitude/core/AnalyticsClient.kt
@@ -1,0 +1,12 @@
+package com.amplitude.core
+
+interface AnalyticsClient {
+    val identity: AnalyticsIdentity
+    val sessionId: Long
+    val optOut: Boolean
+
+    fun track(
+        eventType: String,
+        eventProperties: Map<String, Any?>? = null,
+    )
+}

--- a/core/src/main/java/com/amplitude/core/AnalyticsClient.kt
+++ b/core/src/main/java/com/amplitude/core/AnalyticsClient.kt
@@ -5,7 +5,7 @@ interface AnalyticsClient {
     val sessionId: Long
     val optOut: Boolean
 
-    fun track(
+    fun trackEvent(
         eventType: String,
         eventProperties: Map<String, Any?>?,
     )

--- a/core/src/main/java/com/amplitude/core/AnalyticsClient.kt
+++ b/core/src/main/java/com/amplitude/core/AnalyticsClient.kt
@@ -7,6 +7,6 @@ interface AnalyticsClient {
 
     fun track(
         eventType: String,
-        eventProperties: Map<String, Any?>? = null,
+        eventProperties: Map<String, Any?>?,
     )
 }

--- a/core/src/main/java/com/amplitude/core/AnalyticsIdentity.kt
+++ b/core/src/main/java/com/amplitude/core/AnalyticsIdentity.kt
@@ -1,0 +1,6 @@
+package com.amplitude.core
+
+interface AnalyticsIdentity {
+    val userId: String?
+    val deviceId: String?
+}

--- a/core/src/main/java/com/amplitude/core/platform/Plugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Plugin.kt
@@ -1,12 +1,13 @@
 package com.amplitude.core.platform
 
 import com.amplitude.core.Amplitude
+import com.amplitude.core.AnalyticsClient
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.events.GroupIdentifyEvent
 import com.amplitude.core.events.IdentifyEvent
 import com.amplitude.core.events.RevenueEvent
 
-interface Plugin {
+interface Plugin : UniversalPlugin {
     enum class Type {
         Before,
         Enrichment,
@@ -23,17 +24,26 @@ interface Plugin {
      * with the same name is **skipped** — the first registration wins and is
      * not torn down. A warning is logged for the duplicate.
      */
-    val name: String? get() = null
+    override val name: String? get() = null
 
+    /**
+     * Called by [Amplitude.add] to wire this plugin into the host instance.
+     * The default implementation of [UniversalPlugin.setup] is a no-op for
+     * [Plugin] subclasses — callers always go through this typed overload.
+     */
     fun setup(amplitude: Amplitude) {
         this.amplitude = amplitude
     }
 
-    fun execute(event: BaseEvent): BaseEvent? {
+    override fun setup(client: AnalyticsClient) {
+        (client as? Amplitude)?.let { setup(it) }
+    }
+
+    override fun execute(event: BaseEvent): BaseEvent? {
         return event
     }
 
-    fun teardown() {
+    override fun teardown() {
         // Clean up any resources from setup if necessary
     }
 
@@ -54,11 +64,25 @@ interface Plugin {
 
     fun onDeviceIdChanged(deviceId: String?) {}
 
-    fun onSessionIdChanged(sessionId: Long) {}
+    /**
+     * Invoked when the session id changes on the Amplitude instance this plugin
+     * is registered with. Only fires for SDK builds that maintain a session id
+     * (e.g. the Android SDK).
+     */
+    override fun onSessionIdChanged(sessionId: Long) {}
 
-    fun onOptOutChanged(optOut: Boolean) {}
+    /**
+     * Invoked when the [Amplitude.optOut] flag flips on the Amplitude instance
+     * this plugin is registered with.
+     */
+    override fun onOptOutChanged(optOut: Boolean) {}
 
-    fun onReset() {}
+    /**
+     * Invoked when [Amplitude.reset] is called on the Amplitude instance this
+     * plugin is registered with. The accompanying userId/deviceId changes are
+     * delivered via the same notification (one batched callback, not two).
+     */
+    override fun onReset() {}
 }
 
 interface EventPlugin : Plugin {

--- a/core/src/main/java/com/amplitude/core/platform/UniversalPlugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/UniversalPlugin.kt
@@ -13,6 +13,19 @@ import com.amplitude.core.events.BaseEvent
  *
  * [Plugin] extends [UniversalPlugin] for backward compatibility — all existing plugins
  * continue to work without modification.
+ *
+ * ## Registration model
+ *
+ * **Amplitude host:** register plugins via [com.amplitude.core.Amplitude.add]. [Plugin]
+ * extends [UniversalPlugin], so any existing [Plugin] continues to work without change.
+ * Amplitude calls [setup], [execute], and the state-change callbacks automatically as part
+ * of its internal lifecycle.
+ *
+ * **Third-party hosts (Segment, mParticle, etc.):** implement [AnalyticsClient] and manage
+ * the [UniversalPlugin] lifecycle yourself — call [setup] with the client reference when the
+ * plugin is registered, forward events through [execute], forward state changes to the
+ * appropriate callbacks, and call [teardown] when the plugin is removed. No
+ * [com.amplitude.core.Amplitude] instance is required.
  */
 interface UniversalPlugin {
     /**

--- a/core/src/main/java/com/amplitude/core/platform/UniversalPlugin.kt
+++ b/core/src/main/java/com/amplitude/core/platform/UniversalPlugin.kt
@@ -1,0 +1,50 @@
+package com.amplitude.core.platform
+
+import com.amplitude.core.AnalyticsClient
+import com.amplitude.core.AnalyticsIdentity
+import com.amplitude.core.events.BaseEvent
+
+/**
+ * A host-agnostic plugin contract that has no dependency on [com.amplitude.core.Amplitude].
+ *
+ * Blade SDKs (Experiment, G&S) and third-party analytics hosts (Segment, mParticle) can
+ * implement this interface while depending only on `:core`, without pulling in the full
+ * Android SDK.
+ *
+ * [Plugin] extends [UniversalPlugin] for backward compatibility — all existing plugins
+ * continue to work without modification.
+ */
+interface UniversalPlugin {
+    /**
+     * Optional unique identifier for this plugin, used for deduplication. Defaults to `null`.
+     * Plugins with a non-null name are deduplicated on [com.amplitude.core.Amplitude.add].
+     */
+    val name: String? get() = null
+
+    /**
+     * Called when the plugin is registered with an analytics host. Use this to store a
+     * reference to [client] and perform one-time setup.
+     */
+    fun setup(client: AnalyticsClient) {}
+
+    /**
+     * Process an event passing through the pipeline. Return the (possibly mutated) event to
+     * allow it to continue, or `null` to drop it.
+     */
+    fun execute(event: BaseEvent): BaseEvent? = event
+
+    /** Release any resources acquired in [setup]. */
+    fun teardown() {}
+
+    /** Invoked when the host's userId or deviceId changes. */
+    fun onIdentityChanged(identity: AnalyticsIdentity) {}
+
+    /** Invoked when the host's session id changes. */
+    fun onSessionIdChanged(sessionId: Long) {}
+
+    /** Invoked when the host's opt-out flag flips. */
+    fun onOptOutChanged(optOut: Boolean) {}
+
+    /** Invoked when the host is reset (userId cleared, deviceId rotated). */
+    fun onReset() {}
+}

--- a/core/src/test/kotlin/com/amplitude/core/platform/UniversalPluginTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/UniversalPluginTest.kt
@@ -1,0 +1,235 @@
+package com.amplitude.core.platform
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.AnalyticsClient
+import com.amplitude.core.AnalyticsIdentity
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.utils.FakeAmplitude
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class UniversalPluginTest {
+    private fun amplitude(): Amplitude = FakeAmplitude()
+
+    // A minimal UniversalPlugin that is NOT a Plugin — has no Amplitude dependency.
+    private class RecordingUniversalPlugin : UniversalPlugin {
+        val identitySnapshots = mutableListOf<AnalyticsIdentity>()
+        val sessionIds = mutableListOf<Long>()
+        val optOuts = mutableListOf<Boolean>()
+        var setupClient: AnalyticsClient? = null
+        var resets = 0
+
+        override fun setup(client: AnalyticsClient) {
+            setupClient = client
+        }
+
+        override fun onIdentityChanged(identity: AnalyticsIdentity) {
+            identitySnapshots += identity
+        }
+
+        override fun onSessionIdChanged(sessionId: Long) {
+            sessionIds += sessionId
+        }
+
+        override fun onOptOutChanged(optOut: Boolean) {
+            optOuts += optOut
+        }
+
+        override fun onReset() {
+            resets += 1
+        }
+    }
+
+    // A Plugin subclass that records both per-field and bundled identity callbacks.
+    private class RecordingPlugin : Plugin {
+        override val type: Plugin.Type = Plugin.Type.Before
+        override lateinit var amplitude: Amplitude
+
+        val userIds = mutableListOf<String?>()
+        val deviceIds = mutableListOf<String?>()
+        val identitySnapshots = mutableListOf<AnalyticsIdentity>()
+        var resets = 0
+
+        override fun execute(event: BaseEvent): BaseEvent = event
+
+        override fun onUserIdChanged(userId: String?) {
+            userIds += userId
+        }
+
+        override fun onDeviceIdChanged(deviceId: String?) {
+            deviceIds += deviceId
+        }
+
+        override fun onIdentityChanged(identity: AnalyticsIdentity) {
+            identitySnapshots += identity
+        }
+
+        override fun onReset() {
+            resets += 1
+        }
+    }
+
+    @Nested
+    inner class UniversalPluginContract {
+        @Test
+        fun `UniversalPlugin has no-op defaults for all callbacks`() {
+            val plugin = object : UniversalPlugin {}
+            val identity =
+                object : AnalyticsIdentity {
+                    override val userId: String? = "u"
+                    override val deviceId: String? = "d"
+                }
+            // None of these should throw.
+            plugin.setup(FakeAmplitude())
+            plugin.onIdentityChanged(identity)
+            plugin.onSessionIdChanged(1L)
+            plugin.onOptOutChanged(true)
+            plugin.onReset()
+            val result = plugin.execute(BaseEvent().also { it.eventType = "test" })
+            assertNotNull(result)
+        }
+
+        @Test
+        fun `UniversalPlugin name defaults to null`() {
+            val plugin = object : UniversalPlugin {}
+            assertNull(plugin.name)
+        }
+    }
+
+    @Nested
+    inner class IdentityChangedWiring {
+        @Test
+        fun `Plugin receives onIdentityChanged after setUserId`() {
+            val a = amplitude()
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            a.setUserId("user-1")
+
+            assertEquals(1, recorder.identitySnapshots.size)
+            assertEquals("user-1", recorder.identitySnapshots[0].userId)
+        }
+
+        @Test
+        fun `Plugin receives onIdentityChanged after setDeviceId`() {
+            val a = amplitude()
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            a.setDeviceId("device-1")
+
+            assertEquals(1, recorder.identitySnapshots.size)
+            assertEquals("device-1", recorder.identitySnapshots[0].deviceId)
+        }
+
+        @Test
+        fun `onIdentityChanged carries the current identity snapshot`() {
+            val a = amplitude()
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            a.setUserId("snap-user")
+            a.setDeviceId("snap-device")
+
+            // Two separate mutations → two onIdentityChanged calls.
+            assertEquals(2, recorder.identitySnapshots.size)
+            // After the second mutation, the snapshot has both values.
+            val last = recorder.identitySnapshots.last()
+            assertEquals("snap-user", last.userId)
+            assertEquals("snap-device", last.deviceId)
+        }
+
+        @Test
+        fun `per-field callbacks fire before onIdentityChanged`() {
+            // We verify ordering by checking that when onIdentityChanged fires,
+            // onUserIdChanged has already been called (order within same plugin).
+            val a = amplitude()
+            val callOrder = mutableListOf<String>()
+            val ordered =
+                object : Plugin {
+                    override val type: Plugin.Type = Plugin.Type.Before
+                    override lateinit var amplitude: Amplitude
+
+                    override fun execute(event: BaseEvent): BaseEvent = event
+
+                    override fun onUserIdChanged(userId: String?) {
+                        callOrder += "userId"
+                    }
+
+                    override fun onIdentityChanged(identity: AnalyticsIdentity) {
+                        callOrder += "identity"
+                    }
+                }
+            a.add(ordered)
+
+            a.setUserId("order-test")
+
+            assertEquals(listOf("userId", "identity"), callOrder)
+        }
+
+        @Test
+        fun `onIdentityChanged fires on reset with null userId and new deviceId`() {
+            val a = amplitude()
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            a.reset()
+
+            // reset fires one userId + one deviceId notification → two onIdentityChanged calls.
+            // The last snapshot reflects the fully-reset state.
+            val last = recorder.identitySnapshots.last()
+            assertNull(last.userId)
+            assertNotNull(last.deviceId)
+        }
+
+        @Test
+        fun `existing Plugin subclasses still receive onUserIdChanged and onDeviceIdChanged`() {
+            val a = amplitude()
+            val recorder = RecordingPlugin()
+            a.add(recorder)
+
+            a.setUserId("legacy-user")
+            a.setDeviceId("legacy-device")
+
+            assertEquals(listOf<String?>("legacy-user"), recorder.userIds)
+            assertEquals(listOf<String?>("legacy-device"), recorder.deviceIds)
+        }
+    }
+
+    @Nested
+    inner class AnalyticsClientImplementation {
+        @Test
+        fun `Amplitude identity reflects current store state`() {
+            val a = amplitude()
+            a.store.userId = "id-user"
+            a.store.deviceId = "id-device"
+
+            assertEquals("id-user", a.identity.userId)
+            assertEquals("id-device", a.identity.deviceId)
+        }
+
+        @Test
+        fun `Amplitude sessionId returns -1 in core`() {
+            val a = amplitude()
+            assertEquals(-1L, a.sessionId)
+        }
+
+        @Test
+        fun `Amplitude optOut reflects configuration`() {
+            val a = amplitude()
+            a.optOut = true
+            assertEquals(true, a.optOut)
+        }
+
+        @Test
+        fun `Amplitude track(eventType) satisfies AnalyticsClient contract`() {
+            val client: AnalyticsClient = amplitude()
+            // Just verify it doesn't throw — events are processed asynchronously.
+            client.track("test-event")
+            client.track("test-event", mapOf("key" to "value"))
+        }
+    }
+}

--- a/core/src/test/kotlin/com/amplitude/core/platform/UniversalPluginTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/UniversalPluginTest.kt
@@ -178,8 +178,7 @@ class UniversalPluginTest {
 
             a.reset()
 
-            // reset fires one userId + one deviceId notification → two onIdentityChanged calls.
-            // The last snapshot reflects the fully-reset state.
+            assertEquals(1, recorder.identitySnapshots.size)
             val last = recorder.identitySnapshots.last()
             assertNull(last.userId)
             assertNotNull(last.deviceId)
@@ -228,7 +227,7 @@ class UniversalPluginTest {
         fun `Amplitude track(eventType) satisfies AnalyticsClient contract`() {
             val client: AnalyticsClient = amplitude()
             // Just verify it doesn't throw — events are processed asynchronously.
-            client.track("test-event")
+            client.track("test-event", null)
             client.track("test-event", mapOf("key" to "value"))
         }
     }

--- a/core/src/test/kotlin/com/amplitude/core/platform/UniversalPluginTest.kt
+++ b/core/src/test/kotlin/com/amplitude/core/platform/UniversalPluginTest.kt
@@ -224,11 +224,11 @@ class UniversalPluginTest {
         }
 
         @Test
-        fun `Amplitude track(eventType) satisfies AnalyticsClient contract`() {
+        fun `Amplitude trackEvent satisfies AnalyticsClient contract`() {
             val client: AnalyticsClient = amplitude()
             // Just verify it doesn't throw — events are processed asynchronously.
-            client.track("test-event", null)
-            client.track("test-event", mapOf("key" to "value"))
+            client.trackEvent("test-event", null)
+            client.trackEvent("test-event", mapOf("key" to "value"))
         }
     }
 }


### PR DESCRIPTION
### Describe what this PR is addressing

Blade SDKs (Experiment, G&S) and third-party analytics hosts (Segment, mParticle) currently depend on `:android` to get a plugin contract, which pulls in the full Android SDK. There is no way to implement an Amplitude plugin from a pure-Kotlin module that doesn't need the Android runtime.

Tracked in [SDKA-7](https://linear.app/amplitude/issue/SDKA-7).

### Describe the solution

Introduces three interfaces in `:core`:

- **`AnalyticsIdentity`** — immutable snapshot of `userId` / `deviceId`.
- **`AnalyticsClient`** — minimal host contract (`identity`, `sessionId`, `optOut`, `track`). `Amplitude` implements this.
- **`UniversalPlugin`** — host-agnostic plugin contract with lifecycle callbacks (`setup`, `execute`, `teardown`, `onIdentityChanged`, `onSessionIdChanged`, `onOptOutChanged`, `onReset`). `Plugin` extends `UniversalPlugin` for full backward compatibility.

`onIdentityChanged` is wired into the existing notification fan-out, firing after the per-field `onUserIdChanged` / `onDeviceIdChanged` callbacks with a consistent identity snapshot.

Binary compatibility is maintained; `Plugin` picks up `onIdentityChanged` as a no-op default so existing plugins need no changes.

### Steps to verify the change

1. `./gradlew :core:test` — all tests pass including the new `UniversalPluginTest`.
2. `./gradlew :android:test` — no regressions in the Android module.
3. `./gradlew build -x test` — clean build.
4. `./gradlew apiCheck` — binary compat check passes.

### Useful links and documentation (optional)

- Linear: [SDKA-7](https://linear.app/amplitude/issue/SDKA-7)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the public plugin/host API and changes identity/opt-out notification behavior, though defaults preserve backward compatibility for existing `Plugin` implementations.
> 
> **Overview**
> Adds **host-agnostic contracts in `:core`** so pure-Kotlin consumers can build plugins without depending on `:android`.
> 
> **`AnalyticsIdentity`**, **`AnalyticsClient`**, and **`UniversalPlugin`** are new public APIs. **`Amplitude`** now implements **`AnalyticsClient`** (identity snapshot, default **`sessionId`** of `-1`, **`optOut`**, and a void **`track(eventType, properties)`** overload). Android **`Amplitude.sessionId`** is an **`override`** of that contract.
> 
> **`Plugin`** extends **`UniversalPlugin`**; existing plugins keep working via default no-ops and a **`setup(AnalyticsClient)`** bridge that delegates to **`setup(Amplitude)`** when the client is an **`Amplitude`**. Identity fan-out now also calls **`onIdentityChanged`** after **`onUserIdChanged`** / **`onDeviceIdChanged`** on **`setUserId`**, **`setDeviceId`**, and **`reset`**. **`optOut`** skips plugin notification when the value is unchanged.
> 
> Android lifecycle tests were adjusted to match the **`track`** overloads used in autocapture. **`UniversalPluginTest`** covers the new wiring and **`AnalyticsClient`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab8bfc6a0e856b1849997514d5e049a86d297e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->