### PR TITLE
fix(core): avoid snapshot race in Mediator during concurrent remove

### DIFF
--- a/core/src/main/java/com/amplitude/core/platform/Mediator.kt
+++ b/core/src/main/java/com/amplitude/core/platform/Mediator.kt
@@ -15,7 +15,9 @@ internal class Mediator(
 
     fun remove(plugin: Plugin) = plugins.removeAll { it === plugin }
 
-    fun snapshot(): List<Plugin> = plugins.toList()
+    // Iterator-based copy: Iterable.toList() uses elementAt() for size==1, which races with
+    // concurrent remove() on CopyOnWriteArrayList (ArrayIndexOutOfBoundsException).
+    fun snapshot(): List<Plugin> = plugins.toMutableList()
 
     fun execute(event: BaseEvent): BaseEvent? {
         var result: BaseEvent? = event


### PR DESCRIPTION
### Describe what this PR is addressing
CI flake in `PluginContractTest > notification during remove does not crash` (failed on repetition 13/20 in [Release run 28186546695](https://github.com/amplitude/Amplitude-Kotlin/actions/runs/28186546695/job/83490519069)). Concurrent `setUserId` (which snapshots plugins to notify) and `remove(plugin)` could throw `ArrayIndexOutOfBoundsException` from `CopyOnWriteArrayList`.

### Describe the solution
`Mediator.snapshot()` used `plugins.toList()`. Kotlin's `Iterable.toList()` optimizes the single-element case with `elementAt(0)` instead of iterating. If another thread removes that element between the size check and `elementAt`, the snapshot throws. Switched to `toMutableList()`, which copies via iterator and is safe for `CopyOnWriteArrayList` under concurrent modification.

### Steps to verify the change
```bash
./gradlew :core:test --tests "com.amplitude.core.platform.PluginContractTest.notification during remove does not crash"
```
Ran 30 consecutive times locally — all passed.

### Useful links and documentation (optional)
- Failing CI job: https://github.com/amplitude/Amplitude-Kotlin/actions/runs/28186546695/job/83490519069

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?

<details>
<summary>AI Prompt</summary>

fix flake? https://github.com/amplitude/Amplitude-Kotlin/actions/runs/28186546695/job/83490519069

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line concurrency fix in plugin snapshotting with no API or behavior change beyond eliminating the race.
> 
> **Overview**
> Fixes a CI flake where concurrent `remove(plugin)` and code that snapshots plugins (e.g. `setUserId` notifications) could crash with `ArrayIndexOutOfBoundsException` on a `CopyOnWriteArrayList`.
> 
> **`Mediator.snapshot()`** now uses `toMutableList()` instead of `toList()`. Kotlin’s `toList()` fast-path for a single element uses `elementAt(0)`, which can race with a concurrent remove; iterator-based `toMutableList()` is safe for this list type under concurrent modification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c64f35384265293d92bd5905c66baddcfc224c4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->