### PR TITLE
fix(android): stop autocapture after logout by fully tearing down the instance (SDK-171)

### DIFF
--- a/analytics-core/api/analytics-core.api
+++ b/analytics-core/api/analytics-core.api
@@ -86,9 +86,11 @@ public class com/amplitude/core/Amplitude : com/amplitude/core/platform/PluginHo
 	public static synthetic fun identify$default (Lcom/amplitude/core/Amplitude;Lcom/amplitude/core/events/Identify;Lcom/amplitude/core/events/EventOptions;ILjava/lang/Object;)Lcom/amplitude/core/Amplitude;
 	public static synthetic fun identify$default (Lcom/amplitude/core/Amplitude;Ljava/util/Map;Lcom/amplitude/core/events/EventOptions;ILjava/lang/Object;)Lcom/amplitude/core/Amplitude;
 	public final fun isBuilt ()Lkotlinx/coroutines/Deferred;
+	protected final fun isShutdown ()Z
 	public final fun logEvent (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/Amplitude;
 	public final fun logRevenue (Lcom/amplitude/core/events/Revenue;)Lcom/amplitude/core/Amplitude;
 	protected final fun notifyAllPlugins (Lkotlin/jvm/functions/Function1;)V
+	protected fun performShutdown ()V
 	public fun plugin (Ljava/lang/String;)Lcom/amplitude/core/platform/UniversalPlugin;
 	public fun plugins (Ljava/lang/Class;)Ljava/util/List;
 	public final fun remove (Lcom/amplitude/core/platform/Plugin;)Lcom/amplitude/core/Amplitude;
@@ -107,6 +109,7 @@ public class com/amplitude/core/Amplitude : com/amplitude/core/platform/PluginHo
 	public static synthetic fun setGroup$default (Lcom/amplitude/core/Amplitude;Ljava/lang/String;[Ljava/lang/String;Lcom/amplitude/core/events/EventOptions;ILjava/lang/Object;)Lcom/amplitude/core/Amplitude;
 	public fun setOptOut (Z)V
 	public final fun setUserId (Ljava/lang/String;)Lcom/amplitude/core/Amplitude;
+	public fun shutdown ()V
 	public final fun track (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/Amplitude;
 	public final fun track (Lcom/amplitude/core/events/BaseEvent;Lcom/amplitude/core/events/EventOptions;)Lcom/amplitude/core/Amplitude;
 	public final fun track (Lcom/amplitude/core/events/BaseEvent;Lcom/amplitude/core/events/EventOptions;Lkotlin/jvm/functions/Function3;)Lcom/amplitude/core/Amplitude;
@@ -901,6 +904,7 @@ public class com/amplitude/core/platform/Timeline {
 	public fun process (Lcom/amplitude/core/events/BaseEvent;)V
 	public final fun remove (Lcom/amplitude/core/platform/UniversalPlugin;)V
 	public final fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
+	public fun stop ()V
 }
 
 public abstract interface class com/amplitude/core/platform/UniversalPlugin {
@@ -977,6 +981,7 @@ public final class com/amplitude/core/platform/plugins/AmplitudeDestination : co
 	public fun identify (Lcom/amplitude/core/events/IdentifyEvent;)Lcom/amplitude/core/events/IdentifyEvent;
 	public fun revenue (Lcom/amplitude/core/events/RevenueEvent;)Lcom/amplitude/core/events/RevenueEvent;
 	public fun setup (Lcom/amplitude/core/Amplitude;)V
+	public fun teardown ()V
 	public fun track (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;
 }
 

--- a/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -35,9 +35,11 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -45,6 +47,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import java.io.File
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * <h1>Amplitude</h1>
@@ -88,6 +91,11 @@ open class Amplitude(
     val isBuilt: Deferred<Boolean>
     val diagnostics = Diagnostics()
     internal val identityCoordinator = IdentityCoordinator(store)
+
+    private val shutdownState = AtomicBoolean(false)
+
+    /** Whether [shutdown] has been invoked. Readable by platform subclasses. */
+    protected fun isShutdown(): Boolean = shutdownState.get()
 
     @RestrictedAmplitudeFeature
     val diagnosticsClient: DiagnosticsClient by lazy {
@@ -226,6 +234,12 @@ open class Amplitude(
         add(ContextPlugin())
         add(GetAmpliExtrasPlugin())
         add(AmplitudeDestination())
+
+        // Tear down if shutdown() raced this async build. Keep no suspension point between the
+        // last add() above and this check, or a racing scope cancel could leak those plugins.
+        if (shutdownState.get()) {
+            performShutdown()
+        }
     }
 
     protected open fun diagnosticsContextProvider(): DiagnosticsContextProvider? {
@@ -551,6 +565,11 @@ open class Amplitude(
     }
 
     private fun process(event: BaseEvent) {
+        if (shutdownState.get()) {
+            logger.info("SDK is shut down; dropping event.")
+            return
+        }
+
         if (optOut) {
             logger.info("Skip event for opt out config.")
             return
@@ -579,6 +598,11 @@ open class Amplitude(
      * @return the Amplitude instance
      */
     fun add(plugin: Plugin): Amplitude {
+        if (isShutdown()) {
+            logger.debug("SDK is shut down; ignoring add().")
+            safelyTeardown(plugin)
+            return this
+        }
         timeline.add(plugin)
         return this
     }
@@ -588,6 +612,11 @@ open class Amplitude(
      * Otherwise it is hosted in the enrichment stage.
      */
     fun add(plugin: UniversalPlugin): Amplitude {
+        if (isShutdown()) {
+            logger.debug("SDK is shut down; ignoring add().")
+            safelyTeardown(plugin)
+            return this
+        }
         timeline.add(plugin)
         return this
     }
@@ -624,6 +653,11 @@ open class Amplitude(
     }
 
     fun flush() {
+        if (shutdownState.get()) {
+            logger.info("SDK is shut down; dropping event.")
+            return
+        }
+
         amplitudeScope.launch(amplitudeDispatcher) {
             isBuilt.await()
 
@@ -631,6 +665,36 @@ open class Amplitude(
                 (it as? EventPlugin)?.flush()
             }
         }
+    }
+
+    /**
+     * Permanently shuts down this instance: stops autocapture, tears down all plugins, and stops
+     * background work. [track] and [flush] no-op afterwards. Idempotent. Discard your reference
+     * to the instance after calling this.
+     */
+    open fun shutdown() {
+        if (shutdownState.compareAndSet(false, true)) {
+            performShutdown()
+        }
+    }
+
+    /** Teardown steps; platform SDKs may override to add their own (call `super`). Idempotent. */
+    @Synchronized
+    protected open fun performShutdown() {
+        // Serialized: shutdown() and the buildInternal tail-check can both call this off different threads.
+        try {
+            timeline.stop()
+        } catch (e: Exception) {
+            logger.warn("timeline stop failed: $e")
+        } finally {
+            // finally, so an Error from a plugin's teardown() still cancels the scope.
+            amplitudeScope.cancel()
+        }
+
+        // Graceful close (no join — shutdown() may run on the main thread; a join risks an ANR).
+        (amplitudeDispatcher as? ExecutorCoroutineDispatcher)?.close()
+        (networkIODispatcher as? ExecutorCoroutineDispatcher)?.close()
+        (storageIODispatcher as? ExecutorCoroutineDispatcher)?.close()
     }
 
     /**
@@ -653,6 +717,18 @@ open class Amplitude(
             block(plugin)
         } catch (e: Exception) {
             logger.warn("Plugin '${plugin.identifier()}' threw during state callback: $e")
+        }
+    }
+
+    /**
+     * Tears down a plugin that was rejected by [add] because the SDK is already shut down.
+     * The plugin was never registered with the timeline, so this is the only teardown it'll get.
+     */
+    private fun safelyTeardown(plugin: UniversalPlugin) {
+        try {
+            plugin.teardown()
+        } catch (e: Exception) {
+            logger.warn("Plugin '${plugin.identifier()}' threw during teardown: $e")
         }
     }
 

--- a/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
@@ -39,6 +39,12 @@ class EventPipeline(
     private var scheduled: Boolean
     var flushSizeDivider: AtomicInteger = AtomicInteger(1)
 
+    /**
+     * Only visible for testing.
+     */
+    @Volatile
+    internal var shutdownHookThread: Thread? = null
+
     private val responseHandler by lazy {
         overrideResponseHandler ?: storage.getResponseHandler(
             this@EventPipeline,
@@ -79,6 +85,7 @@ class EventPipeline(
         uploadChannel.cancel()
         writeChannel.cancel()
         running = false
+        removeShutdownHook()
     }
 
     private fun write() =
@@ -184,18 +191,30 @@ class EventPipeline(
     private fun registerShutdownHook() {
         // close the stream if the app shuts down
         try {
-            Runtime.getRuntime().addShutdownHook(
+            val thread =
                 object : Thread() {
                     override fun run() {
                         this@EventPipeline.stop()
                     }
-                },
-            )
+                }
+            Runtime.getRuntime().addShutdownHook(thread)
+            shutdownHookThread = thread
         } catch (_: IllegalStateException) {
             // Once the shutdown sequence has begun it is impossible to register a shutdown hook,
             // so we just ignore the IllegalStateException that's thrown.
             // https://developer.android.com/reference/java/lang/Runtime#addShutdownHook(java.lang.Thread)
         }
+    }
+
+    private fun removeShutdownHook() {
+        val thread = shutdownHookThread ?: return
+        try {
+            Runtime.getRuntime().removeShutdownHook(thread)
+        } catch (_: IllegalStateException) {
+            // The JVM is already shutting down; hooks can no longer be removed at that point.
+            // https://developer.android.com/reference/java/lang/Runtime#removeShutdownHook(java.lang.Thread)
+        }
+        shutdownHookThread = null
     }
 }
 

--- a/analytics-core/src/main/java/com/amplitude/core/platform/Timeline.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/Timeline.kt
@@ -83,6 +83,21 @@ open class Timeline {
 
     internal fun pluginsSnapshot(): List<UniversalPlugin> = plugins.values.flatMap { it.snapshot() }
 
+    /** Tears down every registered plugin, isolating each so one throwing can't skip the rest. */
+    open fun stop() {
+        // Iterate mediators directly (not applyClosure, which is Plugin-only) so bare
+        // UniversalPlugins are torn down too. Does not cascade into a DestinationPlugin's Timeline.
+        plugins.forEach { (_, mediator) ->
+            mediator.applyClosure { plugin ->
+                try {
+                    plugin.teardown()
+                } catch (e: Exception) {
+                    amplitude.logger.warn("Plugin '${plugin.name ?: plugin::class.java.name}' threw during teardown: $e")
+                }
+            }
+        }
+    }
+
     inline fun <reified T : Plugin> findPlugin(): T? {
         var match: T? = null
         applyClosure { plugin ->

--- a/analytics-core/src/main/java/com/amplitude/core/platform/UniversalPlugin.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/UniversalPlugin.kt
@@ -42,7 +42,7 @@ interface UniversalPlugin {
      */
     fun <T : AnalyticsEvent> execute(event: T): T? = event
 
-    /** Releases any resources acquired in [setup]. */
+    /** Releases resources acquired in [setup]. Must be idempotent (may be called more than once). */
     fun teardown() {}
 
     /** Called when the user id or device id changes. */

--- a/analytics-core/src/main/java/com/amplitude/core/platform/plugins/AmplitudeDestination.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/plugins/AmplitudeDestination.kt
@@ -41,6 +41,10 @@ class AmplitudeDestination : DestinationPlugin() {
         }
     }
 
+    override fun teardown() {
+        if (::pipeline.isInitialized) pipeline.stop()
+    }
+
     private fun enqueue(payload: BaseEvent?) {
         payload?.let { event ->
             if (!event.isValid()) {

--- a/analytics-core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
@@ -15,16 +15,21 @@ import com.amplitude.core.platform.Plugin
 import com.amplitude.core.utilities.JSONUtil
 import com.amplitude.core.utils.FakeAmplitude
 import com.amplitude.core.utils.StubPlugin
+import com.amplitude.core.utils.StubUniversalPlugin
 import com.amplitude.core.utils.TestRunPlugin
+import io.mockk.every
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertNull
@@ -37,6 +42,7 @@ import org.junit.jupiter.api.TestInstance
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -603,6 +609,175 @@ internal class AmplitudeTest {
                 assertEquals(null, it.userId)
                 assertNotEquals("old-device", it.deviceId)
             }
+        }
+    }
+
+    @Nested
+    inner class TestShutdown {
+        @Test
+        fun `shutdown cancels amplitudeScope`() {
+            assertTrue(amplitude.amplitudeScope.isActive)
+            amplitude.shutdown()
+            assertFalse(amplitude.amplitudeScope.isActive)
+        }
+
+        @Test
+        fun `track after shutdown is a no-op`() {
+            val mockPlugin = spyk(StubPlugin())
+            amplitude.add(mockPlugin)
+
+            amplitude.shutdown()
+            amplitude.track("test event")
+
+            verify(exactly = 0) { mockPlugin.track(any()) }
+        }
+
+        @Test
+        fun `flush after shutdown is a no-op`() {
+            val mockPlugin = spyk(StubPlugin())
+            amplitude.add(mockPlugin)
+
+            amplitude.shutdown()
+            amplitude.flush()
+
+            verify(exactly = 0) { mockPlugin.flush() }
+        }
+
+        @Test
+        fun `shutdown is idempotent`() {
+            val mockPlugin = spyk(StubPlugin())
+            amplitude.add(mockPlugin)
+
+            amplitude.shutdown()
+            amplitude.shutdown()
+
+            verify(exactly = 1) { mockPlugin.teardown() }
+        }
+
+        @Test
+        fun `concurrent shutdown from multiple threads only tears down once`() {
+            val mockPlugin = spyk(StubPlugin())
+            amplitude.add(mockPlugin)
+
+            val threadCount = 20
+            val ready = CountDownLatch(threadCount)
+            val go = CountDownLatch(1)
+            val done = CountDownLatch(threadCount)
+            repeat(threadCount) {
+                thread {
+                    ready.countDown()
+                    go.await()
+                    amplitude.shutdown()
+                    done.countDown()
+                }
+            }
+            ready.await()
+            go.countDown()
+            assertTrue(done.await(5, TimeUnit.SECONDS))
+
+            verify(exactly = 1) { mockPlugin.teardown() }
+            assertFalse(amplitude.amplitudeScope.isActive)
+        }
+
+        @Test
+        fun `shutdown tears down bare UniversalPlugins too, not just Plugins`() {
+            val universalPlugin = spyk(StubUniversalPlugin())
+            amplitude.add(universalPlugin)
+
+            amplitude.shutdown()
+
+            verify(exactly = 1) { universalPlugin.teardown() }
+        }
+
+        @Test
+        fun `plugin teardown throwing still cancels scope and tears down other plugins`() {
+            val throwingPlugin = spyk(StubPlugin())
+            every { throwingPlugin.teardown() } throws RuntimeException("boom")
+            val otherPlugin = spyk(StubPlugin())
+            amplitude.add(throwingPlugin)
+            amplitude.add(otherPlugin)
+
+            amplitude.shutdown()
+
+            verify(exactly = 1) { throwingPlugin.teardown() }
+            verify(exactly = 1) { otherPlugin.teardown() }
+            assertFalse(amplitude.amplitudeScope.isActive)
+        }
+
+        @Test
+        fun `real threads contending on a blocking teardown still tear down exactly once`() {
+            // The "concurrent shutdown from multiple threads" test above completes almost
+            // instantly, so losing threads typically short-circuit on the AtomicBoolean CAS
+            // before the winner's performShutdown() call is even underway — it doesn't exercise
+            // real contention on the @Synchronized monitor that also guards the buildInternal
+            // tail-check's re-entry into performShutdown(). Widening the window with a plugin
+            // whose teardown() blocks makes the other threads genuinely queue up instead.
+            val teardownCount = AtomicInteger(0)
+            val teardownStarted = CountDownLatch(1)
+            val releaseTeardown = CountDownLatch(1)
+            val blockingPlugin =
+                object : StubPlugin() {
+                    override fun teardown() {
+                        teardownCount.incrementAndGet()
+                        teardownStarted.countDown()
+                        releaseTeardown.await(2, TimeUnit.SECONDS)
+                    }
+                }
+            amplitude.add(blockingPlugin)
+
+            val threadCount = 10
+            val errors = Collections.synchronizedList(mutableListOf<Throwable>())
+            val ready = CountDownLatch(threadCount)
+            val go = CountDownLatch(1)
+            val done = CountDownLatch(threadCount)
+            repeat(threadCount) {
+                thread {
+                    ready.countDown()
+                    go.await()
+                    try {
+                        amplitude.shutdown()
+                    } catch (e: Throwable) {
+                        errors.add(e)
+                    } finally {
+                        done.countDown()
+                    }
+                }
+            }
+            ready.await()
+            go.countDown()
+
+            // Let the winning thread reach the blocking teardown() before releasing it, so the
+            // other threads pile up instead of short-circuiting on an already-false CAS.
+            assertTrue(teardownStarted.await(2, TimeUnit.SECONDS))
+            releaseTeardown.countDown()
+
+            assertTrue(done.await(5, TimeUnit.SECONDS))
+
+            assertTrue(errors.isEmpty(), "Expected no errors but got: $errors")
+            assertEquals(1, teardownCount.get())
+            assertFalse(amplitude.amplitudeScope.isActive)
+        }
+
+        @Test
+        fun `shutdown immediately after construction fully tears down once the async build catches up`() {
+            val testDispatcher = StandardTestDispatcher()
+            val earlyShutdownAmplitude =
+                FakeAmplitude(
+                    Configuration("test-key", serverUrl = server.url("/").toString()),
+                    testDispatcher = testDispatcher,
+                )
+
+            earlyShutdownAmplitude.shutdown()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            assertTrue(earlyShutdownAmplitude.isBuilt.isCompleted)
+            assertFalse(earlyShutdownAmplitude.amplitudeScope.isActive)
+
+            val mockPlugin = spyk(StubPlugin())
+            earlyShutdownAmplitude.add(mockPlugin)
+            earlyShutdownAmplitude.track("test_event")
+
+            verify(exactly = 0) { mockPlugin.track(any()) }
         }
     }
 }

--- a/analytics-core/src/test/kotlin/com/amplitude/core/platform/EventPipelineTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/platform/EventPipelineTest.kt
@@ -33,6 +33,9 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 @ExperimentalCoroutinesApi
@@ -253,5 +256,20 @@ class EventPipelineTest {
             // this is because the InMemoryStorage will clear the buffer and the second call to
             // readEventsContent() will return an empty list and will stop the processing
             verify(exactly = 1) { retryUploadHandler.reset() }
+        }
+
+    @Test
+    fun `stop removes the runtime shutdown hook`() =
+        runTest(testDispatcher) {
+            amplitude.isBuilt.await()
+            val eventPipeline = EventPipeline(amplitude)
+            val hookThread = eventPipeline.shutdownHookThread
+            assertNotNull(hookThread)
+
+            eventPipeline.stop()
+
+            assertNull(eventPipeline.shutdownHookThread)
+            // The hook is no longer registered, so removing it again is a no-op, not a crash.
+            assertFalse(Runtime.getRuntime().removeShutdownHook(hookThread!!))
         }
 }

--- a/analytics-core/src/test/kotlin/com/amplitude/core/platform/plugins/AmplitudeDestinationTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/platform/plugins/AmplitudeDestinationTest.kt
@@ -1,0 +1,58 @@
+package com.amplitude.core.platform.plugins
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.platform.EventPipeline
+import com.amplitude.core.utils.FakeAmplitude
+import io.mockk.every
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@ExperimentalCoroutinesApi
+class AmplitudeDestinationTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var amplitude: Amplitude
+
+    @BeforeEach
+    fun setup() {
+        amplitude =
+            FakeAmplitude(
+                testDispatcher = testDispatcher,
+                amplitudeScope = TestScope(testDispatcher),
+            )
+        mockkConstructor(EventPipeline::class)
+        every { anyConstructed<EventPipeline>().start() } returns Unit
+        every { anyConstructed<EventPipeline>().stop() } returns Unit
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkConstructor(EventPipeline::class)
+    }
+
+    @Test
+    fun `teardown stops the pipeline`() =
+        runTest(testDispatcher) {
+            amplitude.isBuilt.await()
+
+            val destination = AmplitudeDestination()
+            destination.setup(amplitude)
+
+            destination.teardown()
+
+            verify { anyConstructed<EventPipeline>().stop() }
+        }
+
+    @Test
+    fun `teardown before setup does not crash`() {
+        val destination = AmplitudeDestination()
+        destination.teardown()
+    }
+}

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utils/Plugins.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utils/Plugins.kt
@@ -7,11 +7,15 @@ import com.amplitude.core.events.IdentifyEvent
 import com.amplitude.core.events.RevenueEvent
 import com.amplitude.core.platform.EventPlugin
 import com.amplitude.core.platform.Plugin
+import com.amplitude.core.platform.UniversalPlugin
 
 open class StubPlugin : EventPlugin {
     override val type: Plugin.Type = Plugin.Type.Before
     override lateinit var amplitude: Amplitude
 }
+
+/** A bare [UniversalPlugin] (not a [Plugin]) — registered into the Enrichment mediator. */
+open class StubUniversalPlugin : UniversalPlugin
 
 class TestRunPlugin(var closure: (BaseEvent?) -> Unit) : EventPlugin {
     override val type: Plugin.Type = Plugin.Type.Before

--- a/android/api/android.api
+++ b/android/api/android.api
@@ -13,6 +13,7 @@ public class com/amplitude/android/Amplitude : com/amplitude/core/Amplitude {
 	public fun getSessionId ()J
 	public final fun onEnterForeground (J)V
 	public final fun onExitForeground (J)V
+	protected fun performShutdown ()V
 	public fun reset ()Lcom/amplitude/android/Amplitude;
 	public synthetic fun reset ()Lcom/amplitude/core/Amplitude;
 }
@@ -478,6 +479,7 @@ public final class com/amplitude/android/Timeline : com/amplitude/core/platform/
 	public synthetic fun <init> (Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getSessionId ()J
 	public fun process (Lcom/amplitude/core/events/BaseEvent;)V
+	public fun stop ()V
 }
 
 public final class com/amplitude/android/TrackingOptions {

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -120,6 +120,12 @@ open class Amplitude internal constructor(
         add(AmplitudeDestination())
 
         (timeline as Timeline).start()
+
+        // Tear down if shutdown() raced this async build. Keep no suspension point between the
+        // last add() above and this check, or a racing scope cancel could leak those plugins.
+        if (isShutdown()) {
+            performShutdown()
+        }
     }
 
     override fun diagnosticsContextProvider(): DiagnosticsContextProvider? {
@@ -158,21 +164,48 @@ open class Amplitude internal constructor(
         (timeline as Timeline).onExitForeground(timestamp)
     }
 
+    /**
+     * Only visible for testing.
+     */
+    @Volatile
+    internal var shutdownHookThread: Thread? = null
+
     private fun registerShutdownHook() {
         // close the stream if the app shuts down
         try {
-            Runtime.getRuntime().addShutdownHook(
+            val thread =
                 object : Thread() {
                     override fun run() {
                         (this@Amplitude.timeline as Timeline).stop()
                     }
-                },
-            )
+                }
+            Runtime.getRuntime().addShutdownHook(thread)
+            shutdownHookThread = thread
         } catch (e: IllegalStateException) {
             // Once the shutdown sequence has begun it is impossible to register a shutdown hook,
             // so we just ignore the IllegalStateException that's thrown.
             // https://developer.android.com/reference/java/lang/Runtime#addShutdownHook(java.lang.Thread)
         }
+    }
+
+    private fun removeShutdownHook() {
+        val thread = shutdownHookThread ?: return
+        try {
+            Runtime.getRuntime().removeShutdownHook(thread)
+        } catch (e: IllegalStateException) {
+            // The JVM is already shutting down; hooks can no longer be removed at that point.
+            // https://developer.android.com/reference/java/lang/Runtime#removeShutdownHook(java.lang.Thread)
+        }
+        shutdownHookThread = null
+    }
+
+    // Unregister lifecycle callbacks (stops autocapture) + remove the shutdown hook, then core teardown.
+    @Synchronized
+    override fun performShutdown() {
+        val context = (configuration as Configuration).context
+        (context as? Application)?.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        removeShutdownHook()
+        super.performShutdown()
     }
 
     companion object {

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -59,7 +59,8 @@ class Timeline(
         }
     }
 
-    internal fun stop() {
+    override fun stop() {
+        super.stop()
         this.eventMessageChannel.cancel()
     }
 

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -42,6 +42,11 @@ class AndroidLifecyclePlugin(
     private var frustrationInteractionsDetector: FrustrationInteractionsDetector? = null
     private var windowCallbackManager: WindowCallbackManager? = null
 
+    // Guards `created`, `fragmentTrackingActivities`, `started`, and `processedDeepLinkIntents`.
+    // These are normally only ever mutated on the main thread (via eventJob), but `teardown()`
+    // can be invoked from an arbitrary thread by `shutdown()`, which can race an in-flight
+    // lifecycle callback and corrupt these plain collections.
+    private val lifecycleStateLock = Any()
     private val created: MutableMap<Int, WeakReference<Activity>> = mutableMapOf()
     private val fragmentTrackingActivities: MutableSet<Int> = mutableSetOf()
     private val started: MutableSet<Int> = mutableSetOf()
@@ -117,7 +122,9 @@ class AndroidLifecyclePlugin(
         activity: Activity,
         bundle: Bundle?,
     ) {
-        created[activity.hashCode()] = WeakReference(activity)
+        synchronized(lifecycleStateLock) {
+            created[activity.hashCode()] = WeakReference(activity)
+        }
 
         if (autocaptureState.screenViews) {
             registerFragmentTracking(activity)
@@ -125,24 +132,30 @@ class AndroidLifecyclePlugin(
     }
 
     override fun onActivityStarted(activity: Activity) {
-        if (!created.containsKey(activity.hashCode())) {
+        val alreadyCreated = synchronized(lifecycleStateLock) { created.containsKey(activity.hashCode()) }
+        if (!alreadyCreated) {
             // We check for On Create in case if sdk was initialised in Main Activity
             onActivityCreated(activity, activity.intent?.extras)
         }
 
-        if (started.isEmpty()) {
+        val wasEmptyBeforeStart = synchronized(lifecycleStateLock) { started.isEmpty() }
+        if (wasEmptyBeforeStart) {
             androidAmplitude.onEnterForeground(System.currentTimeMillis())
         }
 
-        started.add(activity.hashCode())
+        val startedCount =
+            synchronized(lifecycleStateLock) {
+                started.add(activity.hashCode())
+                started.size
+            }
 
-        if (autocaptureState.appLifecycles && started.size == 1) {
+        if (autocaptureState.appLifecycles && startedCount == 1) {
             DefaultEventUtils(androidAmplitude).trackAppOpenedEvent(
                 packageInfo = packageInfo,
                 isFromBackground = appInBackground,
             )
         }
-        if (started.size == 1) {
+        if (startedCount == 1) {
             appInBackground = false
         }
 
@@ -166,13 +179,17 @@ class AndroidLifecyclePlugin(
     override fun onActivityPaused(activity: Activity) = Unit
 
     override fun onActivityStopped(activity: Activity) {
-        started.remove(activity.hashCode())
+        val isEmptyAfterStop =
+            synchronized(lifecycleStateLock) {
+                started.remove(activity.hashCode())
+                started.isEmpty()
+            }
 
-        if (autocaptureState.appLifecycles && started.isEmpty()) {
+        if (autocaptureState.appLifecycles && isEmptyAfterStop) {
             DefaultEventUtils(androidAmplitude).trackAppBackgroundedEvent()
         }
 
-        if (started.isEmpty()) {
+        if (isEmptyAfterStop) {
             appInBackground = true
             with(androidAmplitude) {
                 onExitForeground(System.currentTimeMillis())
@@ -191,9 +208,11 @@ class AndroidLifecyclePlugin(
 
     override fun onActivityDestroyed(activity: Activity) {
         val hash = activity.hashCode()
-        created.remove(hash)
-        fragmentTrackingActivities.remove(hash)
-        processedDeepLinkIntents.remove(hash)
+        synchronized(lifecycleStateLock) {
+            created.remove(hash)
+            fragmentTrackingActivities.remove(hash)
+            processedDeepLinkIntents.remove(hash)
+        }
 
         // Always unregister — screenViews may have been disabled by remote config since
         // callbacks were registered, so we cannot gate this on current state.
@@ -210,11 +229,17 @@ class AndroidLifecyclePlugin(
         val intentIdentity = System.identityHashCode(intent)
         val activityHash = activity.hashCode()
 
-        if (processedDeepLinkIntents[activityHash] == intentIdentity) {
-            return
-        }
+        val isNewIntent =
+            synchronized(lifecycleStateLock) {
+                if (processedDeepLinkIntents[activityHash] == intentIdentity) {
+                    false
+                } else {
+                    processedDeepLinkIntents[activityHash] = intentIdentity
+                    true
+                }
+            }
+        if (!isNewIntent) return
 
-        processedDeepLinkIntents[activityHash] = intentIdentity
         DefaultEventUtils(androidAmplitude).trackDeepLinkOpenedEvent(activity)
     }
 
@@ -224,8 +249,17 @@ class AndroidLifecyclePlugin(
      */
     private fun registerFragmentTracking(activity: Activity) {
         val hash = activity.hashCode()
-        if (hash in fragmentTrackingActivities) return
-        fragmentTrackingActivities.add(hash)
+        val alreadyTracked =
+            synchronized(lifecycleStateLock) {
+                if (hash in fragmentTrackingActivities) {
+                    true
+                } else {
+                    fragmentTrackingActivities.add(hash)
+                    false
+                }
+            }
+        if (alreadyTracked) return
+
         DefaultEventUtils(androidAmplitude).startFragmentViewedEventTracking(
             activity,
             screenViewsEnabled = { autocaptureState.screenViews },
@@ -268,7 +302,8 @@ class AndroidLifecyclePlugin(
      */
     private fun startFragmentTrackingIfNeeded() {
         if (!autocaptureState.screenViews) return
-        for ((_, ref) in created) {
+        val createdActivities = synchronized(lifecycleStateLock) { created.values.toList() }
+        for (ref in createdActivities) {
             val activity = ref.get() ?: continue
             registerFragmentTracking(activity)
         }
@@ -326,5 +361,21 @@ class AndroidLifecyclePlugin(
         eventJob?.cancel()
         windowCallbackManager?.stop()
         frustrationInteractionsDetector?.stop()
+
+        // Stop fragment tracking on still-alive activities so it doesn't outlive the plugin.
+        // Snapshot + clear under the lock (teardown may run off the main thread), then call out.
+        val activitiesToStopTracking =
+            synchronized(lifecycleStateLock) {
+                val activities = fragmentTrackingActivities.mapNotNull { hash -> created[hash]?.get() }
+                created.clear()
+                fragmentTrackingActivities.clear()
+                started.clear()
+                processedDeepLinkIntents.clear()
+                activities
+            }
+
+        for (activity in activitiesToStopTracking) {
+            DefaultEventUtils(androidAmplitude).stopFragmentViewedEventTracking(activity)
+        }
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeTest.kt
@@ -1,5 +1,6 @@
 package com.amplitude.android
 
+import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.net.ConnectivityManager
@@ -18,10 +19,13 @@ import com.amplitude.id.IMIdentityStorageProvider
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -443,6 +447,150 @@ class AmplitudeTest {
             assertNull(event.userId)
             assertNotEquals("old-device", event.deviceId)
             assertNotNull(event.deviceId)
+        }
+
+    @Test
+    fun shutdown_unregisters_activityLifecycleCallbacks() =
+        runTest {
+            val configuration = createConfiguration()
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = configuration,
+                )
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            val application = configuration.context as Application
+            val registeredSlot = slot<Application.ActivityLifecycleCallbacks>()
+            verify { application.registerActivityLifecycleCallbacks(capture(registeredSlot)) }
+
+            amplitude.shutdown()
+
+            val unregisteredSlot = slot<Application.ActivityLifecycleCallbacks>()
+            verify { application.unregisterActivityLifecycleCallbacks(capture(unregisteredSlot)) }
+            assertEquals(registeredSlot.captured, unregisteredSlot.captured)
+        }
+
+    @Test
+    fun no_autocapture_events_after_shutdown() =
+        runTest {
+            val configuration = createConfiguration().apply { autocapture = setOf(AutocaptureOption.SCREEN_VIEWS) }
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = configuration,
+                )
+            val fakeEventPlugin = FakeEventPlugin()
+            amplitude.add(fakeEventPlugin)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            val application = configuration.context as Application
+            val registeredSlot = slot<Application.ActivityLifecycleCallbacks>()
+            verify { application.registerActivityLifecycleCallbacks(capture(registeredSlot)) }
+            val lifecycleCallbacks = registeredSlot.captured
+
+            amplitude.shutdown()
+            advanceUntilIdle()
+
+            // Drive an activity lifecycle transition that would normally trigger a screen-viewed
+            // event; teardown should have stopped autocapture from processing it.
+            val activity = mockk<Activity>(relaxed = true)
+            lifecycleCallbacks.onActivityCreated(activity, null)
+            lifecycleCallbacks.onActivityStarted(activity)
+            advanceUntilIdle()
+
+            assertTrue(fakeEventPlugin.trackedEvents.isEmpty())
+        }
+
+    @Test
+    fun shutdown_removes_runtime_shutdown_hook() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = createConfiguration(),
+                )
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            val hookThread = amplitude.shutdownHookThread
+            assertNotNull(hookThread)
+
+            amplitude.shutdown()
+
+            assertNull(amplitude.shutdownHookThread)
+            // The hook is no longer registered, so removing it again is a no-op, not a crash.
+            assertFalse(Runtime.getRuntime().removeShutdownHook(hookThread!!))
+        }
+
+    @Test
+    fun shutdown_is_idempotent() =
+        runTest {
+            val configuration = createConfiguration()
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = configuration,
+                )
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            amplitude.shutdown()
+            amplitude.shutdown()
+
+            // A second call must be a genuine no-op: teardown work like unregistering the
+            // activity lifecycle callbacks should only happen once.
+            val application = configuration.context as Application
+            verify(exactly = 1) { application.unregisterActivityLifecycleCallbacks(any()) }
+        }
+
+    @Test
+    fun shutdown_immediately_after_construction_fully_tears_down_after_build_catches_up() =
+        runTest {
+            val configuration = createConfiguration()
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = configuration,
+                )
+
+            amplitude.shutdown()
+            advanceUntilIdle()
+
+            assertTrue(amplitude.isBuilt.isCompleted)
+            assertFalse(amplitude.amplitudeScope.isActive)
+
+            val application = configuration.context as Application
+            verify { application.unregisterActivityLifecycleCallbacks(any()) }
+
+            val fakeEventPlugin = FakeEventPlugin()
+            amplitude.add(fakeEventPlugin)
+            amplitude.track("test_event")
+            advanceUntilIdle()
+
+            assertTrue(fakeEventPlugin.trackedEvents.isEmpty())
+        }
+
+    @Test
+    fun track_after_shutdown_does_not_crash() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = createConfiguration(),
+                )
+            val fakeEventPlugin = FakeEventPlugin()
+            amplitude.add(fakeEventPlugin)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            amplitude.shutdown()
+            amplitude.track("test_event")
+            advanceUntilIdle()
+
+            assertTrue(fakeEventPlugin.trackedEvents.isEmpty())
         }
 
     companion object {

--- a/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
@@ -11,12 +11,15 @@ import android.net.Uri
 import com.amplitude.android.Amplitude
 import com.amplitude.android.AutocaptureManager
 import com.amplitude.android.AutocaptureOption
+import com.amplitude.android.AutocaptureState
 import com.amplitude.android.Configuration
 import com.amplitude.android.Constants.EventTypes
+import com.amplitude.android.FrustrationInteractionsDetector
 import com.amplitude.android.InteractionsOptions
 import com.amplitude.android.internal.fragments.FragmentActivityHandler
 import com.amplitude.android.internal.fragments.FragmentActivityHandler.registerFragmentLifecycleCallbacks
 import com.amplitude.android.internal.fragments.FragmentActivityHandler.unregisterFragmentLifecycleCallbacks
+import com.amplitude.android.internal.gestures.WindowCallbackManager
 import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.Storage
@@ -817,6 +820,115 @@ class AndroidLifecyclePluginTest {
 
             close()
         }
+
+    @Test
+    fun `test teardown cancels jobs and stops interaction detectors`() =
+        runTest {
+            mockAutocapture(emptySet())
+            every { mockedAmplitude.amplitudeScope } returns this
+
+            plugin.setup(mockedAmplitude)
+            advanceUntilIdle()
+
+            // Inject spies for the detectors directly (bypassing the lazy creation path in
+            // startInteractionTrackingIfNeeded, which requires a real Main-thread event loop)
+            // so we can verify `stop()` is called by `teardown()`.
+            val spiedFrustrationDetector =
+                spyk(
+                    FrustrationInteractionsDetector(
+                        amplitude = mockedAmplitude,
+                        logger = mockk(relaxed = true),
+                        density = 1f,
+                        autocaptureStateProvider = { AutocaptureState() },
+                    ),
+                )
+            val spiedWindowCallbackManager =
+                spyk(
+                    WindowCallbackManager(
+                        track = { _, _ -> },
+                        frustrationDetector = spiedFrustrationDetector,
+                        autocaptureStateProvider = { AutocaptureState() },
+                        logger = mockk(relaxed = true),
+                    ),
+                )
+
+            val windowCallbackManagerField =
+                AndroidLifecyclePlugin::class.java.getDeclaredField("windowCallbackManager")
+                    .apply { isAccessible = true }
+            val frustrationDetectorField =
+                AndroidLifecyclePlugin::class.java.getDeclaredField("frustrationInteractionsDetector")
+                    .apply { isAccessible = true }
+            windowCallbackManagerField.set(plugin, spiedWindowCallbackManager)
+            frustrationDetectorField.set(plugin, spiedFrustrationDetector)
+
+            plugin.teardown()
+
+            verify(exactly = 1) { spiedWindowCallbackManager.stop() }
+            verify(exactly = 1) { spiedFrustrationDetector.stop() }
+            assert(plugin.eventJob?.isCancelled == true) { "eventJob should be cancelled after teardown" }
+
+            observer.eventChannel.close()
+        }
+
+    @Test
+    fun `test teardown clears lifecycle collections and unregisters fragment callbacks`() =
+        runTest {
+            mockAutocapture(
+                setOf(
+                    AutocaptureOption.APP_LIFECYCLES,
+                    AutocaptureOption.SCREEN_VIEWS,
+                    AutocaptureOption.DEEP_LINKS,
+                ),
+            )
+            every { mockedAmplitude.amplitudeScope } returns this
+
+            val activity = mockk<Activity>(relaxed = true)
+            every { activity.intent } returns Intent()
+
+            plugin.setup(mockedAmplitude)
+
+            every { activity.registerFragmentLifecycleCallbacks(any(), any(), any()) } returns Unit
+            every { activity.unregisterFragmentLifecycleCallbacks(any()) } returns Unit
+
+            // Drive create + start (but not destroy) so created/fragmentTrackingActivities/
+            // started/processedDeepLinkIntents are all populated when teardown() runs.
+            observer.onActivityCreated(activity, mockk())
+            observer.onActivityStarted(activity)
+
+            advanceUntilIdle()
+
+            assert(fieldValue<Map<Int, *>>("created").isNotEmpty()) { "created should be populated before teardown" }
+            assert(
+                fieldValue<Set<Int>>("fragmentTrackingActivities").isNotEmpty(),
+            ) { "fragmentTrackingActivities should be populated before teardown" }
+            assert(fieldValue<Set<Int>>("started").isNotEmpty()) { "started should be populated before teardown" }
+            assert(
+                fieldValue<Map<Int, Int>>("processedDeepLinkIntents").isNotEmpty(),
+            ) { "processedDeepLinkIntents should be populated before teardown" }
+
+            plugin.teardown()
+
+            verify(exactly = 1) {
+                activity.unregisterFragmentLifecycleCallbacks(any())
+            }
+
+            assert(fieldValue<Map<Int, *>>("created").isEmpty()) { "created should be cleared after teardown" }
+            assert(
+                fieldValue<Set<Int>>("fragmentTrackingActivities").isEmpty(),
+            ) { "fragmentTrackingActivities should be cleared after teardown" }
+            assert(fieldValue<Set<Int>>("started").isEmpty()) { "started should be cleared after teardown" }
+            assert(
+                fieldValue<Map<Int, Int>>("processedDeepLinkIntents").isEmpty(),
+            ) { "processedDeepLinkIntents should be cleared after teardown" }
+
+            observer.eventChannel.close()
+        }
+
+    private fun <T> fieldValue(name: String): T {
+        val field = AndroidLifecyclePlugin::class.java.getDeclaredField(name).apply { isAccessible = true }
+        @Suppress("UNCHECKED_CAST")
+        return field.get(plugin) as T
+    }
 
     private fun mockAutocapture(options: Set<AutocaptureOption>) {
         every { mockedConfig.autocapture } returns options


### PR DESCRIPTION
### Describe what this PR is addressing
Autocapture keeps firing after a user logs out and the app re-initializes with autocapture disabled. `flush()` + `reset()` + dropping the reference never tears the instance down: the constructor registers `ActivityLifecycleCallbacks` on the `Application` and never unregisters them, per-instance `Runtime` shutdown hooks are never removed, and the coroutine scope / executors keep running. So the old instance leaks and keeps autocapturing. iOS is unaffected. (SDK-171)

### Why an explicit teardown API (context for iOS / wider team)
iOS gets this for free through **ARC**: dropping the last reference deallocs the instance, and its `NotificationCenter` observers are zeroing-weak, so autocapture stops automatically — no teardown API needed. The JVM has **no ARC**, and the `Application` holds a **strong** reference to the registered lifecycle callbacks, so simply dropping the reference leaks the instance instead of tearing it down:

```
Android (today)   Application ──strong──▶ ActivityLifecycleCallbacks ──▶ Amplitude
                  drop reference ▶ still retained ▶ keeps autocapturing  ✗

iOS (ARC)         drop reference ▶ dealloc ▶ observers auto-removed ▶ stops  ✓
```

We evaluated automatic alternatives (weak self-unregistering callbacks; an instance registry that supersedes a same-name instance) — without ARC none are both complete and low-risk. The SDK can't reliably detect "this instance is done," so **the app has to signal it.** `shutdown()` is that signal. Practical takeaway: a single long-lived instance needs no change; **multi-instance / teardown-and-recreate usage must call `shutdown()`** before dropping the old instance.

### Describe the solution
Add a public `shutdown()` that permanently tears the instance down: unregister lifecycle + per-activity fragment callbacks, remove the `Runtime` shutdown hook, stop the timeline (tearing down every plugin), cancel `amplitudeScope`, and close the executor dispatchers. Idempotent (single-entry via `AtomicBoolean`); `track()`/`flush()` no-op afterwards; a `shutdown()` racing an in-flight async `build()` re-runs teardown. Stacked with #422, which frees the global EventBridge receiver so a same-`instanceName` rebuild works.

### Steps to verify the change
`./gradlew :analytics-core:test :android:test`. New tests assert no autocapture fires after `shutdown()`, `ActivityLifecycleCallbacks` are unregistered, and teardown is idempotent / safe when called before `build()` completes.

### Checklist
* [x] Does your PR title have the correct title format?
* [ ] Does your PR have a breaking change? No — additions-only public API (`apiCheck` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
