### PR TITLE
fix(core): clear global EventBridge receiver on shutdown so instances can be recreated (SDK-171)

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -97,6 +97,9 @@ open class Amplitude(
     /** Whether [shutdown] has been invoked. Readable by platform subclasses. */
     protected fun isShutdown(): Boolean = shutdownState.get()
 
+    // The EventBridge container this instance registered on; freed (ownership-checked) on shutdown.
+    @Volatile private var eventBridgeContainer: EventBridgeContainer? = null
+
     @RestrictedAmplitudeFeature
     val diagnosticsClient: DiagnosticsClient by lazy {
         DiagnosticsClientImpl(
@@ -228,9 +231,9 @@ open class Amplitude(
 
     protected open suspend fun buildInternal(identityConfiguration: IdentityConfiguration) {
         createIdentityContainer(identityConfiguration)
-        EventBridgeContainer.getInstance(
-            configuration.instanceName,
-        ).eventBridge.setEventReceiver(EventChannel.EVENT, AnalyticsEventReceiver(this))
+        val eventBridgeContainer = EventBridgeContainer.getInstance(configuration.instanceName)
+        this.eventBridgeContainer = eventBridgeContainer
+        eventBridgeContainer.eventBridge.setEventReceiver(EventChannel.EVENT, AnalyticsEventReceiver(this))
         add(ContextPlugin())
         add(GetAmpliExtrasPlugin())
         add(AmplitudeDestination())
@@ -690,6 +693,9 @@ open class Amplitude(
             // finally, so an Error from a plugin's teardown() still cancels the scope.
             amplitudeScope.cancel()
         }
+
+        // Free the instanceName slot (ownership-checked) so a same-named rebuild gets its own receiver.
+        eventBridgeContainer?.let { EventBridgeContainer.remove(configuration.instanceName, it) }
 
         // Graceful close (no join — shutdown() may run on the main thread; a join risks an ANR).
         (amplitudeDispatcher as? ExecutorCoroutineDispatcher)?.close()

--- a/analytics-core/src/main/java/com/amplitude/eventbridge/EventBridgeContainer.kt
+++ b/analytics-core/src/main/java/com/amplitude/eventbridge/EventBridgeContainer.kt
@@ -16,6 +16,18 @@ class EventBridgeContainer {
                 }
             }
         }
+
+        /** Removes the container for [instanceName], but only if it is still [expected]. */
+        internal fun remove(
+            instanceName: String,
+            expected: EventBridgeContainer,
+        ) {
+            synchronized(instancesLock) {
+                if (instances[instanceName] === expected) {
+                    instances.remove(instanceName)
+                }
+            }
+        }
     }
 
     val eventBridge: EventBridge = EventBridgeImpl()

--- a/analytics-core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/AmplitudeTest.kt
@@ -17,6 +17,9 @@ import com.amplitude.core.utils.FakeAmplitude
 import com.amplitude.core.utils.StubPlugin
 import com.amplitude.core.utils.StubUniversalPlugin
 import com.amplitude.core.utils.TestRunPlugin
+import com.amplitude.eventbridge.Event
+import com.amplitude.eventbridge.EventBridgeContainer
+import com.amplitude.eventbridge.EventChannel
 import io.mockk.every
 import io.mockk.slot
 import io.mockk.spyk
@@ -756,6 +759,34 @@ internal class AmplitudeTest {
             assertTrue(errors.isEmpty(), "Expected no errors but got: $errors")
             assertEquals(1, teardownCount.get())
             assertFalse(amplitude.amplitudeScope.isActive)
+        }
+
+        @Test
+        fun `after shutdown, a same-named rebuild registers its own EventBridge receiver`() {
+            val instanceName = "reused-instance-name"
+
+            fun newConfiguration() =
+                Configuration(
+                    "test-key",
+                    instanceName = instanceName,
+                    serverUrl = server.url("/").toString(),
+                )
+
+            val first = FakeAmplitude(newConfiguration(), testDispatcher = UnconfinedTestDispatcher())
+            first.shutdown()
+
+            val second = FakeAmplitude(newConfiguration(), testDispatcher = UnconfinedTestDispatcher())
+            val mockPlugin = spyk(StubPlugin())
+            second.add(mockPlugin)
+
+            val bridge = EventBridgeContainer.getInstance(instanceName).eventBridge
+            bridge.sendEvent(EventChannel.EVENT, Event("bridged_event"))
+
+            val track = slot<BaseEvent>()
+            verify { mockPlugin.track(capture(track)) }
+            assertEquals("bridged_event", track.captured.eventType)
+
+            second.shutdown()
         }
 
         @Test

--- a/analytics-core/src/test/kotlin/com/amplitude/eventbridge/EventBridgeContainerTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/eventbridge/EventBridgeContainerTest.kt
@@ -12,4 +12,19 @@ class EventBridgeContainerTest {
         val eventBridge2 = EventBridgeContainer.getInstance("testInstance")
         Assertions.assertEquals(eventBridge1, eventBridge2)
     }
+
+    @Test
+    fun `remove only drops the container when it is still the expected one`() {
+        val name = "ownership-instance"
+        val first = EventBridgeContainer.getInstance(name)
+
+        // First instance shuts down and frees its slot; a same-named rebuild gets a fresh one.
+        EventBridgeContainer.remove(name, first)
+        val second = EventBridgeContainer.getInstance(name)
+        Assertions.assertNotSame(first, second)
+
+        // A late teardown from the superseded first instance must NOT delete the new container.
+        EventBridgeContainer.remove(name, first)
+        Assertions.assertSame(second, EventBridgeContainer.getInstance(name))
+    }
 }


### PR DESCRIPTION
### Describe what this PR is addressing
> 📚 Stacked on #421 — review/merge that first. Diff is against its branch.

`EventBridgeContainer` keeps one global container per `instanceName`, and `EventBridge` only ever accepts a single receiver (once set it can't be replaced or cleared). So after an instance is shut down its slot leaks (retaining the instance), and rebuilding with the same `instanceName` silently drops the new instance's receiver — breaking cross-SDK / Experiment bridge events on the recreated instance. (SDK-171)

### Describe the solution
`shutdown()` now removes the container for its `instanceName`, freeing the slot so a same-named rebuild registers its own receiver and the old instance can be garbage collected.

### Steps to verify the change
`./gradlew :analytics-core:test`. New test: after `shutdown()`, a same-`instanceName` rebuild successfully receives a bridged event.

### Checklist
* [x] Does your PR title have the correct title format?
* [ ] Does your PR have a breaking change? No — `EventBridgeContainer.remove()` is `internal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, internal lifecycle fix with a focused test; no public API change beyond expected shutdown behavior.
> 
> **Overview**
> **Shutdown now drops the per-`instanceName` `EventBridgeContainer` entry** so a new `Amplitude` with the same name can register its own bridge receiver instead of reusing a dead instance’s slot.
> 
> `performShutdown()` calls new internal `EventBridgeContainer.remove(configuration.instanceName)` after timeline/scope teardown. That addresses SDK-171: `EventBridge` only allows one receiver per channel, so without removal, shutdown leaked the old container and cross-SDK / Experiment bridged events could be lost on recreate.
> 
> A test asserts shutdown → rebuild with the same `instanceName` → `sendEvent` on the bridge reaches the new instance’s plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 461a59d4bdd721bec0623105f182c5b28c4a9e21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->