### PR TITLE
fix(core): null-safe filename filter in EventsFileManager (SDK-176)

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/utilities/EventsFileManager.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/EventsFileManager.kt
@@ -80,14 +80,29 @@ class EventsFileManager(
     }
 
     /**
+     * Lists this storage's files, applying [matches] to the file name.
+     * Returns an empty array if the directory can't be enumerated.
+     */
+    private fun listStorageFiles(matches: (name: String) -> Boolean): Array<File> =
+        directory.listFiles { _, name -> matchesStorageFile(name, matches) } ?: emptyArray()
+
+    /**
+     * True if [name] belongs to this storage and satisfies [matches].
+     *
+     * [name] is nullable because the platform can hand a null entry to the
+     * [java.io.FilenameFilter] callback on some devices/filesystems (SDK-176).
+     */
+    internal fun matchesStorageFile(
+        name: String?,
+        matches: (name: String) -> Boolean,
+    ): Boolean = name != null && name.contains(storageKey) && matches(name)
+
+    /**
      * Returns a sorted list of file paths that are not yet uploaded
      */
     fun read(): List<String> {
         // we need to filter out .temp file, since it's operating on the writing thread
-        val fileList =
-            directory.listFiles { _, name ->
-                name.contains(storageKey) && !name.endsWith(".tmp") && !name.endsWith(".properties")
-            } ?: emptyArray()
+        val fileList = listStorageFiles { !it.endsWith(".tmp") && !it.endsWith(".properties") }
 
         return fileList
             .sortedBy { file ->
@@ -279,10 +294,7 @@ class EventsFileManager(
         val file =
             curFile[storageKey] ?: run {
                 // check leftover tmp file
-                val fileList =
-                    directory.listFiles { _, name ->
-                        name.contains(storageKey) && name.endsWith(".tmp")
-                    } ?: emptyArray()
+                val fileList = listStorageFiles { it.endsWith(".tmp") }
 
                 fileList.getOrNull(0)
             }
@@ -369,10 +381,7 @@ class EventsFileManager(
             if (kvs.getLong(storageVersionKey, 1L) > 1L) {
                 return@withLock
             }
-            val unFinishedFiles =
-                directory.listFiles { _, name ->
-                    name.contains(storageKey) && !name.endsWith(".properties")
-                } ?: emptyArray()
+            val unFinishedFiles = listStorageFiles { !it.endsWith(".properties") }
             unFinishedFiles
                 .filter { it.exists() }
                 .forEach {

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/EventsFileManagerTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/EventsFileManagerTest.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -478,6 +480,32 @@ class EventsFileManagerTest {
             }
             assertEquals(101 * 11, eventsCount)
         }
+
+    @Nested
+    inner class MatchesStorageFile {
+        @Test
+        fun `should not throw when platform passes a null file name`() {
+            // SDK-176: File.listFiles can hand the FilenameFilter callback a null name
+            assertFalse(eventsFileManager.matchesStorageFile(null) { true })
+        }
+
+        @Test
+        fun `should match files for this storage key that satisfy the predicate`() {
+            assertTrue(eventsFileManager.matchesStorageFile("$STORAGE_KEY-0") { true })
+        }
+
+        @Test
+        fun `should reject files for a different storage key`() {
+            assertFalse(eventsFileManager.matchesStorageFile("other-key-0") { true })
+        }
+
+        @Test
+        fun `should reject files that fail the predicate`() {
+            assertFalse(
+                eventsFileManager.matchesStorageFile("$STORAGE_KEY-0.tmp") { !it.endsWith(".tmp") },
+            )
+        }
+    }
 
     private fun createEarlierVersionEventFiles() {
         val file0 = File(tempDir, "$STORAGE_KEY-0")


### PR DESCRIPTION
### Describe what this PR is addressing
A customer on `analytics-android` v1.21.4 reported an intermittent `NullPointerException` (~0.05% of users) during `flush()` while transferring persisted Identify events. Root cause: `File.listFiles()` can hand our `FilenameFilter` callback a **null** file name on some devices/filesystems. The callback dereferenced `name` without a null check, so Kotlin's non-null parameter intrinsic threw. Tracked as SDK-176.

### Describe the solution
Guard the filter callback against a null name, and collapse the three duplicated `listFiles` predicates in `EventsFileManager` into a single null-safe helper (`listStorageFiles`) plus a testable `internal matchesStorageFile(name: String?, ...)`.

### Steps to verify the change
* `./gradlew :analytics-core:test --tests "*EventsFileManagerTest"` — added 4 cases covering the null name and predicate matching.
* `./gradlew :analytics-core:apiCheck` — no public API change (new member is `internal`).

### Useful links and documentation (optional)
SDK-176

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change? No.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted defensive fix in local event file enumeration with no public API change and regression tests; behavior unchanged except avoiding the null-name crash.
> 
> **Overview**
> Fixes an intermittent **NullPointerException** during event flush (SDK-176) when `File.listFiles()` passes a **null** name into the `FilenameFilter` callback on some devices/filesystems.
> 
> **`EventsFileManager`** now routes all directory listing through **`listStorageFiles`** and an **`internal matchesStorageFile(name: String?, …)`** helper that rejects null names before applying the storage-key and predicate checks. **`read()`**, **`currentFile()`**, and **`handleV1Files()`** use this helper instead of three duplicated inline filters.
> 
> Tests add a **`MatchesStorageFile`** nested suite covering null names, storage-key matching, and predicate behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a678061719005c8ab58a47a512d37db2334da8fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->