### PR TITLE
fix: allow garbage collection of abandoned Amplitude instances

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.FileNotFoundException
+import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicInteger
 
 class EventPipeline(
@@ -184,10 +185,11 @@ class EventPipeline(
     private fun registerShutdownHook() {
         // close the stream if the app shuts down
         try {
+            val weakRef = WeakReference(this)
             Runtime.getRuntime().addShutdownHook(
                 object : Thread() {
                     override fun run() {
-                        this@EventPipeline.stop()
+                        weakRef.get()?.stop()
                     }
                 },
             )

--- a/analytics-core/src/main/java/com/amplitude/core/utilities/AnalyticsEventReceiver.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/AnalyticsEventReceiver.kt
@@ -5,12 +5,16 @@ import com.amplitude.core.events.BaseEvent
 import com.amplitude.eventbridge.Event
 import com.amplitude.eventbridge.EventChannel
 import com.amplitude.eventbridge.EventReceiver
+import java.lang.ref.WeakReference
 
-internal class AnalyticsEventReceiver(val amplitude: Amplitude) : EventReceiver {
+internal class AnalyticsEventReceiver(amplitude: Amplitude) : EventReceiver {
+    private val amplitudeRef = WeakReference(amplitude)
+
     override fun receive(
         channel: EventChannel,
         event: Event,
     ) {
+        val amplitude = amplitudeRef.get() ?: return
         amplitude.logger.debug("Receive event from event bridge ${event.eventType}")
         amplitude.track(event.toBaseEvent())
     }

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.io.File
+import java.lang.ref.WeakReference
 import java.util.concurrent.Executors
 import com.amplitude.core.Amplitude as CoreAmplitude
 
@@ -161,10 +162,11 @@ open class Amplitude internal constructor(
     private fun registerShutdownHook() {
         // close the stream if the app shuts down
         try {
+            val weakRef = WeakReference(this)
             Runtime.getRuntime().addShutdownHook(
                 object : Thread() {
                     override fun run() {
-                        (this@Amplitude.timeline as Timeline).stop()
+                        (weakRef.get()?.timeline as? Timeline)?.stop()
                     }
                 },
             )

--- a/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorPlugin.kt
@@ -5,6 +5,7 @@ import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
 import java.lang.ClassCastException
+import java.lang.ref.WeakReference
 
 internal class AnalyticsConnectorPlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
@@ -17,12 +18,15 @@ internal class AnalyticsConnectorPlugin : Plugin {
         connector = AnalyticsConnector.getInstance(instanceName)
 
         // set up listener to core package to receive exposure events from Experiment
+        val amplitudeRef = WeakReference(amplitude)
         connector.eventBridge.setEventReceiver { (eventType, eventProperties, userProperties) ->
-            val event = BaseEvent()
-            event.eventType = eventType
-            event.eventProperties = eventProperties?.toMutableMap()
-            event.userProperties = userProperties?.toMutableMap()
-            amplitude.track(event)
+            amplitudeRef.get()?.let { amplitude ->
+                val event = BaseEvent()
+                event.eventType = eventType
+                event.eventProperties = eventProperties?.toMutableMap()
+                event.userProperties = userProperties?.toMutableMap()
+                amplitude.track(event)
+            }
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -92,21 +92,35 @@ class AndroidLifecyclePlugin(
                 }
             }
 
+        // The observer is registered on the Application (process-lifetime) and its channel
+        // roots this consumer coroutine. Hold the plugin weakly so that chain can't pin the
+        // Amplitude instance after the app drops its reference.
+        val eventChannel = activityLifecycleObserver.eventChannel
+        val observer = activityLifecycleObserver
+        val weakPlugin = WeakReference(this)
         eventJob =
             amplitude.amplitudeScope.launch(Dispatchers.Main) {
-                for (event in activityLifecycleObserver.eventChannel) {
+                for (event in eventChannel) {
+                    val plugin = weakPlugin.get()
+                    if (plugin == null) {
+                        // The plugin has been collected; unregister the observer and cancel
+                        // its channel so the abandoned instance leaves nothing behind.
+                        application.unregisterActivityLifecycleCallbacks(observer)
+                        eventChannel.cancel()
+                        break
+                    }
                     event.activity.get()?.let { activity ->
                         when (event.type) {
                             ActivityCallbackType.Created ->
-                                onActivityCreated(
+                                plugin.onActivityCreated(
                                     activity,
                                     activity.intent?.extras,
                                 )
-                            ActivityCallbackType.Started -> onActivityStarted(activity)
-                            ActivityCallbackType.Resumed -> onActivityResumed(activity)
-                            ActivityCallbackType.Paused -> onActivityPaused(activity)
-                            ActivityCallbackType.Stopped -> onActivityStopped(activity)
-                            ActivityCallbackType.Destroyed -> onActivityDestroyed(activity)
+                            ActivityCallbackType.Started -> plugin.onActivityStarted(activity)
+                            ActivityCallbackType.Resumed -> plugin.onActivityResumed(activity)
+                            ActivityCallbackType.Paused -> plugin.onActivityPaused(activity)
+                            ActivityCallbackType.Stopped -> plugin.onActivityStopped(activity)
+                            ActivityCallbackType.Destroyed -> plugin.onActivityDestroyed(activity)
                         }
                     }
                 }


### PR DESCRIPTION
### Describe what this PR is addressing

When a consuming app drops its reference to an `Amplitude` instance, the instance is never garbage-collected: several process-lifetime / static objects keep a strong reference to it, leaking the entire SDK object graph. For same-instance-name re-initialization this can also route event-bridge traffic to a dead instance.

Retention roots:
- **JVM shutdown hooks** in `Amplitude` and `EventPipeline` hold their instance strongly (unlike `DiagnosticsClientImpl`, which already uses a weak reference).
- **Core `EventBridge` receiver** — `AnalyticsEventReceiver` lives in a process-wide static `EventBridgeContainer` and holds `amplitude` strongly.
- **Android `AnalyticsConnector`** — the exposure-event receiver lambda captures `amplitude` and is held by a static singleton.
- **Android lifecycle consumer** — the `AndroidLifecyclePlugin` consumer coroutine is rooted by the `Application`-registered `ActivityLifecycleObserver`'s channel, capturing the plugin (and thus `amplitude`).

### Describe the solution

Sever the strong reference at each boundary so an abandoned instance becomes collectible without the app calling anything — following the existing `WeakReference` precedent in `DiagnosticsClientImpl`:

- Shutdown hooks in `Amplitude`/`EventPipeline` hold the instance via `WeakReference`.
- The core `EventBridge` receiver, the Android connector exposure-event receiver, and the Android lifecycle consumer each hold the instance/plugin weakly and no-op once the referent is collected.
- When the lifecycle plugin is collected, its consumer unregisters the `ActivityLifecycleObserver` from the `Application` and cancels the channel, so nothing accumulates behind the abandoned instance.

All edited classes are `internal`, so there is no public API change (`apiCheck` clean, no `apiDump` churn).

**Known limitations (out of scope):**
- Cleanup is GC-triggered, not deterministic — the lifecycle-observer teardown fires on the first lifecycle event after the plugin is collected. Fully deterministic teardown would require an explicit `close()`, intentionally deprioritized.
- The re-init/misrouting edge (a new same-instance-name `Amplitude` has its receiver rejected because the bridge refuses to replace an existing receiver) is not fully fixed; it needs a `removeEventReceiver`/teardown path.

### Steps to verify the change

- `./gradlew :analytics-core:test :android:test` — full suites pass.
- `./gradlew apiCheck` — passes with no `.api` changes, confirming purely behavioral.

### Useful links and documentation (optional)

Linear: [SDKA-25](https://linear.app/amplitude/issue/SDKA-25/allow-garbage-collection-of-abandoned-amplitude-instances)

### Checklist
* [x] Does your PR title have the correct title format?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lifecycle teardown and event delivery paths; behavior change is intentional (no-op after GC) but misrouting on same-name re-init remains a known limitation.
> 
> **Overview**
> **Fixes memory leaks** when apps drop their `Amplitude` reference without calling teardown. Process-lifetime holders no longer keep the SDK graph alive.
> 
> **Shutdown hooks** in `EventPipeline` and Android `Amplitude` now call `stop()` via `WeakReference` instead of capturing `this` strongly.
> 
> **Event bridge and connector callbacks** (`AnalyticsEventReceiver`, `AnalyticsConnectorPlugin` exposure receiver) hold `Amplitude` weakly and no-op if the instance was collected.
> 
> **Android lifecycle consumer** in `AndroidLifecyclePlugin` holds the plugin weakly; when it is collected, the coroutine unregisters the `ActivityLifecycleObserver` from the `Application` and cancels the event channel so nothing keeps running for a dead instance.
> 
> No public API changes (internal classes only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c73c52637203b5117ee4221c9fc3d0112c81126. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->