### PR TITLE
perf: use shared Dispatchers.IO instead of SDK-owned thread pools

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -35,8 +35,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -44,20 +45,20 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import java.io.File
-import java.util.concurrent.Executors
 
 /**
  * <h1>Amplitude</h1>
  * This is the SDK instance class that contains all of the SDK functionality.<br><br>
  * Many of the SDK functions return the SDK instance back, allowing you to chain multiple methods calls together.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 public open class Amplitude(
     public val configuration: Configuration,
     public val store: State,
     public val amplitudeScope: CoroutineScope = CoroutineScope(SupervisorJob()),
-    public val amplitudeDispatcher: CoroutineDispatcher = Executors.newCachedThreadPool().asCoroutineDispatcher(),
-    public val networkIODispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
-    public val storageIODispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
+    public val amplitudeDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    public val networkIODispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1),
+    public val storageIODispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1),
 ) : PluginHost {
     public open val identity: AnalyticsIdentity
         get() =

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -21,21 +21,21 @@ import com.amplitude.id.IdentityConfiguration
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
 import java.io.File
 import java.lang.ref.WeakReference
-import java.util.concurrent.Executors
 import com.amplitude.core.Amplitude as CoreAmplitude
 
-@OptIn(RestrictedAmplitudeFeature::class)
+@OptIn(ExperimentalCoroutinesApi::class, RestrictedAmplitudeFeature::class)
 open class Amplitude internal constructor(
     configuration: Configuration,
     state: State,
     amplitudeScope: CoroutineScope = CoroutineScope(SupervisorJob()),
-    amplitudeDispatcher: CoroutineDispatcher = Executors.newCachedThreadPool().asCoroutineDispatcher(),
-    networkIODispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
-    storageIODispatcher: CoroutineDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher(),
+    amplitudeDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    networkIODispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1),
+    storageIODispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1),
 ) : CoreAmplitude(
         configuration = configuration,
         store = state,


### PR DESCRIPTION
Closes amplitude/Amplitude-Kotlin#388

### Describe what this PR is addressing

Every `Amplitude` instance created three of its own thread pools — a cached pool for `amplitudeDispatcher` and two single-thread executors for `networkIODispatcher` and `storageIODispatcher`. The SDK never shuts these down, so the threads live for the lifetime of the process, and apps that already run a coroutine dispatcher pay for a second, redundant set of threads (multiplied per instance).

### Describe the solution

Default the three dispatchers to `Dispatchers.IO` — the JVM-wide elastic pool that the host app's coroutines already share — instead of allocating SDK-owned executors.

`networkIODispatcher` and `storageIODispatcher` use `Dispatchers.IO.limitedParallelism(1)`, preserving the sequential-access guarantee the single-thread executors provided (at most one coroutine at a time), while borrowing threads from the shared pool rather than reserving dedicated ones.

Trade-offs considered:

* `limitedParallelism` **is** `@ExperimentalCoroutinesApi`, so both classes gained an `@OptIn`. The API has been stable in practice for several coroutines releases; the alternative — keeping dedicated single-thread executors — is exactly the overhead this change removes.
* `limitedParallelism(1)` **serializes execution but does not pin work to one fixed thread.** Successive tasks may land on different threads from the pool. Anything relying on thread affinity (`ThreadLocal`, thread-confined non-thread-safe state, or lock reentrancy across suspension) would break. I grepped `analytics-core` and `android` main sources: the only `Thread.currentThread()` use is `ViewHierarchyScanner`'s main-looper check, which is unrelated to these dispatchers. Nothing on the storage or network paths depends on thread identity.
* `amplitudeDispatcher` **goes from unbounded (cached pool) to** `Dispatchers.IO`**'s 64-thread cap.** The pipeline is not thread-count-bound, so this is a ceiling on runaway growth rather than a throughput regression.

The dispatchers remain constructor parameters, so an app can still inject its own — this changes only the defaults. No public signatures changed, so no `apiDump` update is required (`apiCheck` passes).

### Steps to verify the change

* `./gradlew :analytics-core:test :android:test` — both suites pass (run locally, `BUILD SUCCESSFUL`).
* `./gradlew apiCheck` — passes; committed `.api` dumps are unchanged.
* Behavioral check worth doing on-device: thread-dump an app using the SDK before and after and confirm the `pool-N-thread-*` executors backing the old dispatchers are gone, with SDK work now appearing on `DefaultDispatcher-worker-*`.

### Useful links and documentation (optional)

* Issue: [https://github.com/amplitude/Amplitude-Kotlin/issues/388](<https://github.com/amplitude/Amplitude-Kotlin/issues/388>)
* [`limitedParallelism` docs](<https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-coroutine-dispatcher/limited-parallelism.html>)

### Checklist

- [X] Does your PR title have the correct [title format](<https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions>)?
- [ ] Does your PR have a breaking change?

---

> < />!NOTE< />  <br>**Medium Risk**  <br>Changes default threading for all SDK I/O and background work; serial network/storage behavior is preserved but work may run on different pool threads over time, and amplitude work is capped by [Dispatchers.IO](<http://Dispatchers.IO>)’s parallelism instead of an unbounded cached pool.
>
> **Overview**< />< />  <br>< />< />< />< />Replaces per-< />< />`Amplitude` **instance thread pools with the JVM-wide** `Dispatchers.IO` **pool**, addressing leaked/redundant threads when multiple SDK instances exist (closes amplitude/Amplitude-Kotlin#388).
>
> Default `amplitudeDispatcher` is now `Dispatchers.IO` instead of a cached `Executor` thread pool. `networkIODispatcher` and `storageIODispatcher` default to `Dispatchers.IO.limitedParallelism(1)` instead of dedicated single-thread executors, keeping at-most-one concurrent task per channel while sharing pool threads.
>
> Both **core** and **Android** `Amplitude` constructors gain `@OptIn(ExperimentalCoroutinesApi::class)` for `limitedParallelism`. Constructor parameters are unchanged, so apps can still inject custom dispatchers; only defaults change.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 32585e1bd2f959d0e5e5c5f2e77a4640f0f5afa1. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).

---

> \[!NOTE\]<br>**Medium Risk**<br>Default threading for all SDK background, network, and storage work changes; serial network/storage behavior is preserved but tasks may run on different pool threads over time, and general amplitude work is capped by [Dispatchers.IO](<http://Dispatchers.IO>) parallelism instead of an unbounded cached pool.
>
> **Overview****<br>****Replaces per-**`Amplitude` **instance executor thread pools with the shared** `Dispatchers.IO` **pool**, addressing redundant/leaked threads when multiple SDK instances exist (closes amplitude/Amplitude-Kotlin#388).
>
> Default `amplitudeDispatcher` is now `Dispatchers.IO` instead of a cached `Executor` pool. `networkIODispatcher` and `storageIODispatcher` default to `Dispatchers.IO.limitedParallelism(1)` instead of dedicated single-thread executors, keeping at-most-one concurrent task per channel while borrowing pool threads rather than reserving dedicated ones.
>
> Core and Android `Amplitude` constructors add `@OptIn(ExperimentalCoroutinesApi::class)` for `limitedParallelism`. Constructor parameters are unchanged—only defaults change—so apps can still inject custom dispatchers.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 3f3697e8dce9f104e526942006e0cff49b9ae1eb. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).