### PR TITLE
fix(android): replace same-name instances automatically (SDK-171)

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
@@ -9,6 +9,7 @@ import com.amplitude.core.utilities.http.HttpClientInterface
 import com.amplitude.core.utilities.http.ResponseHandler
 import com.amplitude.core.utilities.logWithStackTrace
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.consumeEach
@@ -17,6 +18,7 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.FileNotFoundException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class EventPipeline(
@@ -37,6 +39,8 @@ class EventPipeline(
 ) {
     private var running: Boolean
     private var scheduled: Boolean
+    private val stopped = AtomicBoolean(false)
+    private var shutdownHook: Thread? = null
     var flushSizeDivider: AtomicInteger = AtomicInteger(1)
 
     private val responseHandler by lazy {
@@ -58,6 +62,9 @@ class EventPipeline(
         scheduled = false
 
         registerShutdownHook()
+        scope.coroutineContext[Job]?.invokeOnCompletion {
+            stop()
+        }
     }
 
     fun put(event: BaseEvent) {
@@ -70,15 +77,22 @@ class EventPipeline(
     }
 
     fun start() {
+        if (stopped.get()) {
+            return
+        }
         running = true
         write()
         upload()
     }
 
     fun stop() {
+        if (!stopped.compareAndSet(false, true)) {
+            return
+        }
         uploadChannel.cancel()
         writeChannel.cancel()
         running = false
+        removeShutdownHook()
     }
 
     private fun write() =
@@ -183,18 +197,31 @@ class EventPipeline(
 
     private fun registerShutdownHook() {
         // close the stream if the app shuts down
+        val hook =
+            object : Thread() {
+                override fun run() {
+                    this@EventPipeline.stop()
+                }
+            }
         try {
-            Runtime.getRuntime().addShutdownHook(
-                object : Thread() {
-                    override fun run() {
-                        this@EventPipeline.stop()
-                    }
-                },
-            )
+            Runtime.getRuntime().addShutdownHook(hook)
+            shutdownHook = hook
         } catch (_: IllegalStateException) {
             // Once the shutdown sequence has begun it is impossible to register a shutdown hook,
             // so we just ignore the IllegalStateException that's thrown.
             // https://developer.android.com/reference/java/lang/Runtime#addShutdownHook(java.lang.Thread)
+        }
+    }
+
+    private fun removeShutdownHook() {
+        val hook = shutdownHook ?: return
+        shutdownHook = null
+        try {
+            Runtime.getRuntime().removeShutdownHook(hook)
+        } catch (_: IllegalStateException) {
+            // The runtime is already shutting down.
+        } catch (_: SecurityException) {
+            // The runtime does not allow shutdown-hook removal.
         }
     }
 }

--- a/android/src/main/java/com/amplitude/android/ActiveAmplitudeInstances.kt
+++ b/android/src/main/java/com/amplitude/android/ActiveAmplitudeInstances.kt
@@ -44,23 +44,25 @@ internal object ActiveAmplitudeInstances {
                     .getOrPut(ApplicationKey(amplitude.replacementApplication)) { mutableMapOf() }
                     .getOrPut(amplitude.replacementInstanceName) { Slot() }
             }
-        var previous: Amplitude? = null
-
-        try {
-            synchronized(slot) {
-                previous = slot.activeInstance?.get()?.takeUnless { it === amplitude }
-                previous?.deactivateForReplacement()
-                amplitude.activateForReplacement()
-                slot.activeInstance = WeakReference(amplitude)
-            }
-        } finally {
-            val previousInstance = previous
-            if (previousInstance == null) {
-                amplitude.startAfterReplacementCleanup()
-            } else {
-                previousInstance.finishReplacementCleanup {
-                    amplitude.startAfterReplacementCleanup()
+        val previous =
+            try {
+                synchronized(slot) {
+                    val activeInstance = slot.activeInstance?.get()?.takeUnless { it === amplitude }
+                    amplitude.activateForReplacement()
+                    activeInstance?.deactivateForReplacement()
+                    slot.activeInstance = WeakReference(amplitude)
+                    activeInstance
                 }
+            } catch (error: Exception) {
+                amplitude.finishReplacementCleanup()
+                throw error
+            }
+
+        if (previous == null) {
+            amplitude.startAfterReplacementCleanup()
+        } else {
+            previous.finishReplacementCleanup {
+                amplitude.startAfterReplacementCleanup()
             }
         }
     }

--- a/android/src/main/java/com/amplitude/android/ActiveAmplitudeInstances.kt
+++ b/android/src/main/java/com/amplitude/android/ActiveAmplitudeInstances.kt
@@ -1,0 +1,73 @@
+package com.amplitude.android
+
+import android.app.Application
+import java.lang.ref.WeakReference
+
+/**
+ * Coordinates the single active Android [Amplitude] for each application and logical instance
+ * name.
+ *
+ * Amplitude's storage, identity, and connector state are already keyed by `instanceName`.
+ * Reusing that name therefore replaces the previous logical instance instead of allowing two
+ * partially shared instances to remain active.
+ */
+internal object ActiveAmplitudeInstances {
+    private class Slot {
+        var activeInstance: WeakReference<Amplitude>? = null
+    }
+
+    private class ApplicationKey(application: Application) {
+        private val application = WeakReference(application)
+        private val identityHashCode = System.identityHashCode(application)
+
+        fun isCleared(): Boolean = application.get() == null
+
+        override fun hashCode(): Int = identityHashCode
+
+        override fun equals(other: Any?): Boolean {
+            if (other !is ApplicationKey) {
+                return false
+            }
+            val thisApplication = application.get() ?: return false
+            return thisApplication === other.application.get()
+        }
+    }
+
+    private val slotsLock = Any()
+    private val slots = mutableMapOf<ApplicationKey, MutableMap<String, Slot>>()
+
+    fun install(amplitude: Amplitude) {
+        val slot =
+            synchronized(slotsLock) {
+                slots.keys.removeAll { it.isCleared() }
+                slots
+                    .getOrPut(ApplicationKey(amplitude.replacementApplication)) { mutableMapOf() }
+                    .getOrPut(amplitude.replacementInstanceName) { Slot() }
+            }
+        var previous: Amplitude? = null
+
+        try {
+            synchronized(slot) {
+                previous = slot.activeInstance?.get()?.takeUnless { it === amplitude }
+                previous?.deactivateForReplacement()
+                amplitude.activateForReplacement()
+                slot.activeInstance = WeakReference(amplitude)
+            }
+        } finally {
+            previous?.finishReplacementCleanup()
+        }
+    }
+
+    internal fun activeInstance(
+        application: Application,
+        instanceName: String,
+    ): Amplitude? {
+        return synchronized(slotsLock) {
+            slots[ApplicationKey(application)]?.get(instanceName)?.let { slot ->
+                synchronized(slot) {
+                    slot.activeInstance?.get()
+                }
+            }
+        }
+    }
+}

--- a/android/src/main/java/com/amplitude/android/ActiveAmplitudeInstances.kt
+++ b/android/src/main/java/com/amplitude/android/ActiveAmplitudeInstances.kt
@@ -54,7 +54,14 @@ internal object ActiveAmplitudeInstances {
                 slot.activeInstance = WeakReference(amplitude)
             }
         } finally {
-            previous?.finishReplacementCleanup()
+            val previousInstance = previous
+            if (previousInstance == null) {
+                amplitude.startAfterReplacementCleanup()
+            } else {
+                previousInstance.finishReplacementCleanup {
+                    amplitude.startAfterReplacementCleanup()
+                }
+            }
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -2,6 +2,7 @@ package com.amplitude.android
 
 import android.app.Application
 import android.content.Context
+import com.amplitude.analytics.connector.AnalyticsConnector
 import com.amplitude.android.diagnostics.AndroidDiagnosticsContextProvider
 import com.amplitude.android.migration.MigrationManager
 import com.amplitude.android.plugins.AnalyticsConnectorIdentityPlugin
@@ -14,17 +15,24 @@ import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.State
 import com.amplitude.core.diagnostics.DiagnosticsContextProvider
+import com.amplitude.core.platform.UniversalPlugin
 import com.amplitude.core.platform.plugins.AmplitudeDestination
 import com.amplitude.core.platform.plugins.ContextPlugin
 import com.amplitude.core.platform.plugins.GetAmpliExtrasPlugin
 import com.amplitude.id.IdentityConfiguration
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import java.io.File
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 import com.amplitude.core.Amplitude as CoreAmplitude
 
 @OptIn(RestrictedAmplitudeFeature::class)
@@ -57,6 +65,19 @@ open class Amplitude internal constructor(
     internal lateinit var autocaptureManager: AutocaptureManager
         private set
 
+    internal lateinit var replacementInstanceName: String
+        private set
+
+    internal lateinit var replacementApplication: Application
+        private set
+    private lateinit var replacementBuildGate: CompletableDeferred<Unit>
+    private val replacementLifecycleLock = Any()
+    private val active = AtomicBoolean(true)
+    private val cleanupStarted = AtomicBoolean(false)
+    private var lifecycleCallbacksRegistered = false
+    private var shutdownHook: Thread? = null
+    private var androidLifecyclePlugin: AndroidLifecyclePlugin? = null
+
     /**
      * Init-order trap: [CoreAmplitude]'s `init` calls [build] before this class's field
      * initializers run, and [buildInternal] may already be on a background thread.
@@ -67,6 +88,9 @@ open class Amplitude internal constructor(
         activityLifecycleCallbacks = ActivityLifecycleObserver()
         androidContextPlugin = AndroidContextPlugin()
         val androidConfig = configuration as Configuration
+        replacementApplication = androidConfig.context as Application
+        replacementInstanceName = androidConfig.instanceName
+        replacementBuildGate = CompletableDeferred()
         autocaptureManager =
             AutocaptureManager(
                 initialAutocapture = androidConfig.autocapture,
@@ -75,14 +99,22 @@ open class Amplitude internal constructor(
                 logger = logger,
                 diagnosticsClient = diagnosticsClient,
             )
-        return super.build()
+        val build = super.build()
+        return amplitudeScope.async(amplitudeDispatcher, CoroutineStart.LAZY) {
+            replacementBuildGate.await()
+            build.await()
+        }
     }
 
     init {
-        registerShutdownHook()
-
-        with(configuration.context as Application) {
-            registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        try {
+            ActiveAmplitudeInstances.install(this)
+        } finally {
+            if (active.get()) {
+                replacementBuildGate.complete(Unit)
+            } else {
+                replacementBuildGate.cancel()
+            }
         }
     }
 
@@ -107,19 +139,27 @@ open class Amplitude internal constructor(
         val migrationManager = MigrationManager(this)
         migrationManager.migrateOldStorage()
 
-        this.createIdentityContainer(identityConfiguration)
+        synchronized(replacementLifecycleLock) {
+            if (!active.get()) {
+                return
+            }
 
-        if (this.configuration.offline != AndroidNetworkConnectivityCheckerPlugin.Disabled) {
-            add(AndroidNetworkConnectivityCheckerPlugin())
+            this.createIdentityContainer(identityConfiguration)
+
+            if (this.configuration.offline != AndroidNetworkConnectivityCheckerPlugin.Disabled) {
+                add(AndroidNetworkConnectivityCheckerPlugin())
+            }
+            add(androidContextPlugin)
+            add(GetAmpliExtrasPlugin())
+            val lifecyclePlugin = AndroidLifecyclePlugin(activityLifecycleCallbacks)
+            add(lifecyclePlugin)
+            androidLifecyclePlugin = lifecyclePlugin
+            add(AnalyticsConnectorIdentityPlugin())
+            add(AnalyticsConnectorPlugin())
+            add(AmplitudeDestination())
+
+            (timeline as Timeline).start()
         }
-        add(androidContextPlugin)
-        add(GetAmpliExtrasPlugin())
-        add(AndroidLifecyclePlugin(activityLifecycleCallbacks))
-        add(AnalyticsConnectorIdentityPlugin())
-        add(AnalyticsConnectorPlugin())
-        add(AmplitudeDestination())
-
-        (timeline as Timeline).start()
     }
 
     override fun diagnosticsContextProvider(): DiagnosticsContextProvider? {
@@ -158,20 +198,126 @@ open class Amplitude internal constructor(
         (timeline as Timeline).onExitForeground(timestamp)
     }
 
+    internal fun activateForReplacement() {
+        synchronized(replacementLifecycleLock) {
+            check(active.get()) { "Cannot activate a retired Amplitude instance." }
+            try {
+                replacementApplication.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+                lifecycleCallbacksRegistered = true
+                registerShutdownHook()
+            } catch (e: Exception) {
+                active.set(false)
+                cleanupSafely("roll back lifecycle callback registration") {
+                    unregisterLifecycleCallbacks()
+                }
+                cleanupSafely("roll back the runtime shutdown hook") {
+                    removeShutdownHook()
+                }
+                cleanupSafely("stop lifecycle observation") {
+                    activityLifecycleCallbacks.stop()
+                }
+                cleanupSafely("stop event processing") {
+                    (timeline as Timeline).stop()
+                }
+                amplitudeScope.cancel()
+                throw e
+            }
+        }
+    }
+
+    internal fun deactivateForReplacement() {
+        synchronized(replacementLifecycleLock) {
+            if (!active.compareAndSet(true, false)) {
+                return
+            }
+
+            cleanupSafely("unregister lifecycle callbacks") {
+                unregisterLifecycleCallbacks()
+            }
+            cleanupSafely("stop lifecycle observation") {
+                activityLifecycleCallbacks.stop()
+            }
+            cleanupSafely("stop Android autocapture") {
+                androidLifecyclePlugin?.stopAutocapture()
+            }
+            cleanupSafely("stop event processing") {
+                (timeline as Timeline).stop()
+            }
+            cleanupSafely("detach Analytics Connector") {
+                AnalyticsConnector.getInstance(replacementInstanceName).eventBridge.setEventReceiver(null)
+            }
+            cleanupSafely("remove the runtime shutdown hook") {
+                removeShutdownHook()
+            }
+            amplitudeScope.cancel()
+        }
+    }
+
+    internal fun finishReplacementCleanup() {
+        if (!cleanupStarted.compareAndSet(false, true)) {
+            return
+        }
+
+        plugins(UniversalPlugin::class.java).forEach { plugin ->
+            cleanupSafely("tear down plugin '${plugin.name ?: plugin::class.java.name}'") {
+                plugin.teardown()
+            }
+        }
+
+        setOf(amplitudeDispatcher, networkIODispatcher, storageIODispatcher).forEach { dispatcher ->
+            cleanupSafely("close an SDK dispatcher") {
+                (dispatcher as? ExecutorCoroutineDispatcher)?.close()
+            }
+        }
+    }
+
+    internal fun isActiveForReplacement(): Boolean = active.get()
+
     private fun registerShutdownHook() {
-        // close the stream if the app shuts down
+        val hook =
+            object : Thread() {
+                override fun run() {
+                    (this@Amplitude.timeline as Timeline).stop()
+                }
+            }
         try {
-            Runtime.getRuntime().addShutdownHook(
-                object : Thread() {
-                    override fun run() {
-                        (this@Amplitude.timeline as Timeline).stop()
-                    }
-                },
-            )
+            Runtime.getRuntime().addShutdownHook(hook)
+            shutdownHook = hook
         } catch (e: IllegalStateException) {
             // Once the shutdown sequence has begun it is impossible to register a shutdown hook,
             // so we just ignore the IllegalStateException that's thrown.
             // https://developer.android.com/reference/java/lang/Runtime#addShutdownHook(java.lang.Thread)
+        }
+    }
+
+    private fun removeShutdownHook() {
+        val hook = shutdownHook ?: return
+        shutdownHook = null
+        try {
+            Runtime.getRuntime().removeShutdownHook(hook)
+        } catch (_: IllegalStateException) {
+            // The runtime is already shutting down.
+        } catch (_: SecurityException) {
+            // The runtime does not allow shutdown-hook removal.
+        }
+    }
+
+    private fun unregisterLifecycleCallbacks() {
+        if (!lifecycleCallbacksRegistered) {
+            return
+        }
+        replacementApplication.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+        lifecycleCallbacksRegistered = false
+    }
+
+    private inline fun cleanupSafely(
+        operation: String,
+        cleanup: () -> Unit,
+    ) {
+        try {
+            cleanup()
+        } catch (e: Exception) {
+            logger.warn("Failed to $operation while replacing Amplitude instance '$replacementInstanceName': $e")
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -75,6 +75,7 @@ open class Amplitude internal constructor(
     private val replacementLifecycleLock = Any()
     private val active = AtomicBoolean(true)
     private val cleanupStarted = AtomicBoolean(false)
+    private val cleanupFinished = CompletableDeferred<Unit>()
     private var lifecycleCallbacksRegistered = false
     private var shutdownHook: Thread? = null
     private var androidLifecyclePlugin: AndroidLifecyclePlugin? = null
@@ -247,8 +248,10 @@ open class Amplitude internal constructor(
     }
 
     internal fun finishReplacementCleanup(onFinished: () -> Unit = {}) {
-        if (!cleanupStarted.compareAndSet(false, true)) {
+        cleanupFinished.invokeOnCompletion {
             onFinished()
+        }
+        if (!cleanupStarted.compareAndSet(false, true)) {
             return
         }
 
@@ -266,7 +269,7 @@ open class Amplitude internal constructor(
                     }
                 }
             } finally {
-                onFinished()
+                cleanupFinished.complete(Unit)
             }
         }
     }

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -71,6 +71,7 @@ open class Amplitude internal constructor(
     internal lateinit var replacementApplication: Application
         private set
     private lateinit var replacementBuildGate: CompletableDeferred<Unit>
+    private lateinit var internalBuild: Deferred<Boolean>
     private val replacementLifecycleLock = Any()
     private val active = AtomicBoolean(true)
     private val cleanupStarted = AtomicBoolean(false)
@@ -99,23 +100,15 @@ open class Amplitude internal constructor(
                 logger = logger,
                 diagnosticsClient = diagnosticsClient,
             )
-        val build = super.build()
+        internalBuild = super.build()
         return amplitudeScope.async(amplitudeDispatcher, CoroutineStart.LAZY) {
             replacementBuildGate.await()
-            build.await()
+            internalBuild.await()
         }
     }
 
     init {
-        try {
-            ActiveAmplitudeInstances.install(this)
-        } finally {
-            if (active.get()) {
-                replacementBuildGate.complete(Unit)
-            } else {
-                replacementBuildGate.cancel()
-            }
-        }
+        ActiveAmplitudeInstances.install(this)
     }
 
     override fun createTimeline(): Timeline {
@@ -253,21 +246,36 @@ open class Amplitude internal constructor(
         }
     }
 
-    internal fun finishReplacementCleanup() {
+    internal fun finishReplacementCleanup(onFinished: () -> Unit = {}) {
         if (!cleanupStarted.compareAndSet(false, true)) {
+            onFinished()
             return
         }
 
-        plugins(UniversalPlugin::class.java).forEach { plugin ->
-            cleanupSafely("tear down plugin '${plugin.name ?: plugin::class.java.name}'") {
-                plugin.teardown()
+        internalBuild.invokeOnCompletion {
+            try {
+                plugins(UniversalPlugin::class.java).forEach { plugin ->
+                    cleanupSafely("tear down plugin '${plugin.name ?: plugin::class.java.name}'") {
+                        plugin.teardown()
+                    }
+                }
+
+                setOf(amplitudeDispatcher, networkIODispatcher, storageIODispatcher).forEach { dispatcher ->
+                    cleanupSafely("close an SDK dispatcher") {
+                        (dispatcher as? ExecutorCoroutineDispatcher)?.close()
+                    }
+                }
+            } finally {
+                onFinished()
             }
         }
+    }
 
-        setOf(amplitudeDispatcher, networkIODispatcher, storageIODispatcher).forEach { dispatcher ->
-            cleanupSafely("close an SDK dispatcher") {
-                (dispatcher as? ExecutorCoroutineDispatcher)?.close()
-            }
+    internal fun startAfterReplacementCleanup() {
+        if (active.get()) {
+            replacementBuildGate.complete(Unit)
+        } else {
+            replacementBuildGate.cancel()
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
+++ b/android/src/main/java/com/amplitude/android/internal/fragments/FragmentActivityHandler.kt
@@ -8,7 +8,7 @@ import java.util.WeakHashMap
 
 internal object FragmentActivityHandler {
     private val callbacksMap =
-        WeakHashMap<FragmentActivity, MutableList<AutocaptureFragmentLifecycleCallbacks>>()
+        WeakHashMap<FragmentActivity, MutableMap<TrackFunction, AutocaptureFragmentLifecycleCallbacks>>()
 
     fun Activity.registerFragmentLifecycleCallbacks(
         track: TrackFunction,
@@ -16,17 +16,27 @@ internal object FragmentActivityHandler {
         screenViewsEnabled: () -> Boolean = { true },
     ) {
         (this as? FragmentActivity)?.apply {
+            val callbacks = callbacksMap.getOrPut(this) { mutableMapOf() }
+            if (track in callbacks) {
+                return
+            }
             val callback = AutocaptureFragmentLifecycleCallbacks(track, logger, screenViewsEnabled)
             supportFragmentManager.registerFragmentLifecycleCallbacks(callback, true)
-            callbacksMap.getOrPut(this) { mutableListOf() }.add(callback)
+            callbacks[track] = callback
         } ?: logger.debug("Activity is not a FragmentActivity")
     }
 
-    fun Activity.unregisterFragmentLifecycleCallbacks(logger: Logger) {
+    fun Activity.unregisterFragmentLifecycleCallbacks(
+        track: TrackFunction,
+        logger: Logger,
+    ) {
         (this as? FragmentActivity)?.apply {
-            callbacksMap.remove(this)?.let { callbacks ->
-                for (callback in callbacks) {
+            callbacksMap[this]?.let { callbacks ->
+                callbacks.remove(track)?.let { callback ->
                     supportFragmentManager.unregisterFragmentLifecycleCallbacks(callback)
+                }
+                if (callbacks.isEmpty()) {
+                    callbacksMap.remove(this)
                 }
             }
         } ?: logger.debug("Activity is not a FragmentActivity")

--- a/android/src/main/java/com/amplitude/android/internal/gestures/WindowCallbackAdapter.kt
+++ b/android/src/main/java/com/amplitude/android/internal/gestures/WindowCallbackAdapter.kt
@@ -12,7 +12,7 @@ import android.view.Window
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 
-internal open class WindowCallbackAdapter(val delegate: Window.Callback) : Window.Callback {
+internal open class WindowCallbackAdapter(internal var delegate: Window.Callback) : Window.Callback {
     override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
         return delegate.dispatchKeyEvent(event)
     }

--- a/android/src/main/java/com/amplitude/android/internal/gestures/WindowCallbackManager.kt
+++ b/android/src/main/java/com/amplitude/android/internal/gestures/WindowCallbackManager.kt
@@ -32,7 +32,7 @@ internal class WindowCallbackManager(
     private val autocaptureStateProvider: () -> AutocaptureState,
     private val logger: Logger,
 ) {
-    private val wrappedWindows = mutableMapOf<Window, Window.Callback?>()
+    private val wrappedWindows = mutableMapOf<Window, AutocaptureWindowCallback>()
     private var started = false
 
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -107,9 +107,6 @@ internal class WindowCallbackManager(
 
         val originalCallback = window.callback ?: NoCaptureWindowCallback()
 
-        // Store original callback before wrapping
-        wrappedWindows[window] = window.callback
-
         val wrappedCallback =
             if (frustrationDetector != null) {
                 FrustrationAwareWindowCallback(
@@ -134,23 +131,44 @@ internal class WindowCallbackManager(
                 )
             }
 
+        wrappedWindows[window] = wrappedCallback
         window.callback = wrappedCallback
 
         logger.debug("Wrapped window callback for $activityName")
     }
 
     private fun unwrapWindow(window: Window) {
-        if (!wrappedWindows.containsKey(window)) return
-        val originalCallback = wrappedWindows.remove(window)
-
-        // Only unwrap if the current callback is our wrapper
-        val currentCallback = window.callback
-        if (currentCallback is AutocaptureWindowCallback) {
-            // Restore original callback, or null if it was NoCaptureWindowCallback
-            window.callback = originalCallback.takeUnless { it is NoCaptureWindowCallback }
-            logger.debug("Unwrapped window callback")
+        val wrappedCallback = wrappedWindows.remove(window) ?: return
+        val currentCallback = window.callback ?: return
+        val result = currentCallback.removeFromChain(wrappedCallback)
+        if (!result.removed) {
+            return
         }
+
+        if (result.callback !== currentCallback) {
+            window.callback = result.callback.takeUnless { it is NoCaptureWindowCallback }
+        }
+        logger.debug("Unwrapped window callback")
     }
+
+    private fun Window.Callback.removeFromChain(target: AutocaptureWindowCallback): CallbackRemoval {
+        if (this === target) {
+            return CallbackRemoval(target.delegate, true)
+        }
+        if (this is WindowCallbackAdapter) {
+            val nestedResult = delegate.removeFromChain(target)
+            if (nestedResult.removed) {
+                delegate = nestedResult.callback
+                return CallbackRemoval(this, true)
+            }
+        }
+        return CallbackRemoval(this, false)
+    }
+
+    private data class CallbackRemoval(
+        val callback: Window.Callback,
+        val removed: Boolean,
+    )
 
     /**
      * Traverses the context chain to find the Activity.

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -5,6 +5,8 @@ import android.app.Application
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.VisibleForTesting
 import com.amplitude.android.AutocaptureState
 import com.amplitude.android.Configuration
@@ -25,6 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicBoolean
 import com.amplitude.android.Amplitude as AndroidAmplitude
 
 @OptIn(GuardedAmplitudeFeature::class, RestrictedAmplitudeFeature::class)
@@ -59,6 +62,8 @@ class AndroidLifecyclePlugin(
 
     @VisibleForTesting
     internal var eventJob: Job? = null
+
+    private val stopped = AtomicBoolean(false)
 
     override fun setup(amplitude: Amplitude) {
         super.setup(amplitude)
@@ -320,11 +325,42 @@ class AndroidLifecyclePlugin(
         }
     }
 
-    override fun teardown() {
-        super.teardown()
+    internal fun stopAutocapture() {
+        if (!stopped.compareAndSet(false, true)) {
+            return
+        }
+
         stateObserverJob?.cancel()
         eventJob?.cancel()
+        activityLifecycleObserver.stop()
         windowCallbackManager?.stop()
         frustrationInteractionsDetector?.stop()
+        clearActivityTracking()
+    }
+
+    override fun teardown() {
+        stopAutocapture()
+        super.teardown()
+    }
+
+    private fun clearActivityTracking() {
+        val cleanup =
+            Runnable {
+                created.values.forEach { activity ->
+                    activity.get()?.let {
+                        DefaultEventUtils(androidAmplitude).stopFragmentViewedEventTracking(it)
+                    }
+                }
+                created.clear()
+                fragmentTrackingActivities.clear()
+                started.clear()
+                processedDeepLinkIntents.clear()
+            }
+
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            cleanup.run()
+        } else {
+            Handler(Looper.getMainLooper()).post(cleanup)
+        }
     }
 }

--- a/android/src/main/java/com/amplitude/android/utilities/ActivityLifecycleObserver.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/ActivityLifecycleObserver.kt
@@ -5,56 +5,33 @@ import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
 import kotlinx.coroutines.channels.Channel
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicBoolean
 
 class ActivityLifecycleObserver : ActivityLifecycleCallbacks {
     internal val eventChannel = Channel<ActivityCallbackEvent>(Channel.UNLIMITED)
+    private val active = AtomicBoolean(true)
 
     override fun onActivityCreated(
         activity: Activity,
         savedInstanceState: Bundle?,
     ) {
-        eventChannel.trySend(
-            ActivityCallbackEvent(
-                WeakReference(activity),
-                ActivityCallbackType.Created,
-            ),
-        )
+        send(activity, ActivityCallbackType.Created)
     }
 
     override fun onActivityStarted(activity: Activity) {
-        eventChannel.trySend(
-            ActivityCallbackEvent(
-                WeakReference(activity),
-                ActivityCallbackType.Started,
-            ),
-        )
+        send(activity, ActivityCallbackType.Started)
     }
 
     override fun onActivityResumed(activity: Activity) {
-        eventChannel.trySend(
-            ActivityCallbackEvent(
-                WeakReference(activity),
-                ActivityCallbackType.Resumed,
-            ),
-        )
+        send(activity, ActivityCallbackType.Resumed)
     }
 
     override fun onActivityPaused(activity: Activity) {
-        eventChannel.trySend(
-            ActivityCallbackEvent(
-                WeakReference(activity),
-                ActivityCallbackType.Paused,
-            ),
-        )
+        send(activity, ActivityCallbackType.Paused)
     }
 
     override fun onActivityStopped(activity: Activity) {
-        eventChannel.trySend(
-            ActivityCallbackEvent(
-                WeakReference(activity),
-                ActivityCallbackType.Stopped,
-            ),
-        )
+        send(activity, ActivityCallbackType.Stopped)
     }
 
     override fun onActivitySaveInstanceState(
@@ -64,10 +41,26 @@ class ActivityLifecycleObserver : ActivityLifecycleCallbacks {
     }
 
     override fun onActivityDestroyed(activity: Activity) {
+        send(activity, ActivityCallbackType.Destroyed)
+    }
+
+    internal fun stop() {
+        if (active.compareAndSet(true, false)) {
+            eventChannel.cancel()
+        }
+    }
+
+    private fun send(
+        activity: Activity,
+        type: ActivityCallbackType,
+    ) {
+        if (!active.get()) {
+            return
+        }
         eventChannel.trySend(
             ActivityCallbackEvent(
                 WeakReference(activity),
-                ActivityCallbackType.Destroyed,
+                type,
             ),
         )
     }

--- a/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/DefaultEventUtils.kt
@@ -121,7 +121,7 @@ class DefaultEventUtils(private val amplitude: Amplitude) {
 
     fun stopFragmentViewedEventTracking(activity: Activity) {
         if (isFragmentActivityAvailable) {
-            activity.unregisterFragmentLifecycleCallbacks(amplitude.logger)
+            activity.unregisterFragmentLifecycleCallbacks(amplitude::track, amplitude.logger)
         }
     }
 

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
@@ -22,9 +22,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -244,7 +246,14 @@ class AmplitudeReplacementTest {
             assertTrue(buildEntered.await(5, TimeUnit.SECONDS))
 
             val second = track(Amplitude(configuration(application, instanceName)))
+            assertFalse(second.isBuilt.isCompleted)
+
             releaseBuild.countDown()
+            runBlocking {
+                withTimeout(5_000) {
+                    second.isBuilt.await()
+                }
+            }
 
             assertFalse(first.isActiveForReplacement())
             assertTrue(second.isActiveForReplacement())

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
@@ -31,6 +31,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -225,6 +226,40 @@ class AmplitudeReplacementTest {
         }
 
     @Test
+    fun `failed replacement activation keeps previous instance active`() =
+        runTest {
+            val application = TestApplication()
+            val instanceName = "replacement-activation-failure"
+            val first =
+                track(
+                    FakeAndroidAmplitude(
+                        configuration = configuration(application, instanceName),
+                        androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                    ),
+                )
+            val firstEvents = FakeEventPlugin()
+            val teardownPlugin = RecordingTeardownPlugin()
+            first.add(firstEvents)
+            first.add(teardownPlugin)
+            first.isBuilt.await()
+
+            application.failRegistration = true
+            assertThrows(IllegalStateException::class.java) {
+                Amplitude(configuration(application, instanceName))
+            }
+            application.failRegistration = false
+
+            first.track("after failed replacement")
+            advanceUntilIdle()
+
+            assertTrue(first.isActiveForReplacement())
+            assertSame(first, ActiveAmplitudeInstances.activeInstance(application, instanceName))
+            assertFalse(teardownPlugin.tornDown)
+            assertEquals(listOf("after failed replacement"), firstEvents.trackedEvents.map { it.eventType })
+            assertEquals(1, application.registeredCallbacks.size)
+        }
+
+    @Test
     fun `an in-flight build cannot install after replacement`() {
         val application = TestApplication()
         val instanceName = "replacement-in-flight"
@@ -246,9 +281,15 @@ class AmplitudeReplacementTest {
             assertTrue(buildEntered.await(5, TimeUnit.SECONDS))
 
             val second = track(Amplitude(configuration(application, instanceName)))
+            val additionalCleanupFinished = CountDownLatch(1)
+            first.finishReplacementCleanup {
+                additionalCleanupFinished.countDown()
+            }
             assertFalse(second.isBuilt.isCompleted)
+            assertFalse(additionalCleanupFinished.await(100, TimeUnit.MILLISECONDS))
 
             releaseBuild.countDown()
+            assertTrue(additionalCleanupFinished.await(5, TimeUnit.SECONDS))
             runBlocking {
                 withTimeout(5_000) {
                     second.isBuilt.await()
@@ -341,12 +382,16 @@ class AmplitudeReplacementTest {
     private class TestApplication : Application() {
         val registeredCallbacks = CopyOnWriteArrayList<Application.ActivityLifecycleCallbacks>()
         val unregisteredCallbacks = CopyOnWriteArrayList<Application.ActivityLifecycleCallbacks>()
+        var failRegistration = false
 
         init {
             attachBaseContext(ApplicationProvider.getApplicationContext())
         }
 
         override fun registerActivityLifecycleCallbacks(callback: ActivityLifecycleCallbacks) {
+            if (failRegistration) {
+                throw IllegalStateException("expected registration failure")
+            }
             registeredCallbacks += callback
         }
 

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
@@ -1,0 +1,388 @@
+package com.amplitude.android
+
+import android.app.Activity
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.amplitude.MainDispatcherRule
+import com.amplitude.analytics.connector.AnalyticsConnector
+import com.amplitude.analytics.connector.AnalyticsEvent
+import com.amplitude.android.plugins.AndroidNetworkConnectivityCheckerPlugin
+import com.amplitude.android.utilities.FakeAndroidAmplitude
+import com.amplitude.core.State
+import com.amplitude.core.platform.Plugin
+import com.amplitude.core.utilities.ConsoleLoggerProvider
+import com.amplitude.core.utilities.InMemoryStorageProvider
+import com.amplitude.core.utilities.http.AnalyticsResponse
+import com.amplitude.core.utilities.http.HttpClientInterface
+import com.amplitude.id.IMIdentityStorageProvider
+import com.amplitude.id.IdentityConfiguration
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class AmplitudeReplacementTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val instancesToClean = ConcurrentLinkedQueue<Amplitude>()
+
+    @After
+    fun tearDown() {
+        instancesToClean.forEach { amplitude ->
+            amplitude.deactivateForReplacement()
+            amplitude.finishReplacementCleanup()
+        }
+    }
+
+    @Test
+    fun `same-name construction automatically retires the previous instance`() =
+        runTest {
+            val application = TestApplication()
+            val instanceName = "replacement-customer-flow"
+            val first =
+                track(
+                    FakeAndroidAmplitude(
+                        configuration =
+                            configuration(
+                                application,
+                                instanceName,
+                                autocapture = setOf(AutocaptureOption.SCREEN_VIEWS),
+                            ),
+                        androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                    ),
+                )
+            val firstEvents = FakeEventPlugin()
+            first.add(firstEvents)
+            first.isBuilt.await()
+
+            val activity = mockk<Activity>(relaxed = true)
+            val firstCallback = application.registeredCallbacks.single()
+            firstCallback.onActivityStarted(activity)
+            advanceUntilIdle()
+            assertEquals(
+                listOf(Constants.EventTypes.SCREEN_VIEWED),
+                firstEvents.trackedEvents.map { it.eventType },
+            )
+
+            first.flush()
+            first.reset()
+
+            val second =
+                track(
+                    FakeAndroidAmplitude(
+                        configuration = configuration(application, instanceName),
+                        androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                    ),
+                )
+            val secondEvents = FakeEventPlugin()
+            second.add(secondEvents)
+            second.isBuilt.await()
+
+            firstCallback.onActivityStarted(activity)
+            application.registeredCallbacks.single().onActivityStarted(activity)
+            first.track("after replacement")
+            second.track("new instance")
+            advanceUntilIdle()
+
+            assertFalse(first.isActiveForReplacement())
+            assertTrue(second.isActiveForReplacement())
+            assertEquals(
+                listOf(Constants.EventTypes.SCREEN_VIEWED),
+                firstEvents.trackedEvents.map { it.eventType },
+            )
+            assertEquals(listOf("new instance"), secondEvents.trackedEvents.map { it.eventType })
+            assertEquals(1, application.registeredCallbacks.size)
+            assertSame(firstCallback, application.unregisteredCallbacks.single())
+        }
+
+    @Test
+    fun `different instance names remain active`() =
+        runTest {
+            val application = TestApplication()
+            val first =
+                track(
+                    FakeAndroidAmplitude(
+                        configuration = configuration(application, "replacement-first"),
+                        androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                    ),
+                )
+            val second =
+                track(
+                    FakeAndroidAmplitude(
+                        configuration = configuration(application, "replacement-second"),
+                        androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                    ),
+                )
+            val firstEvents = FakeEventPlugin()
+            val secondEvents = FakeEventPlugin()
+            first.add(firstEvents)
+            second.add(secondEvents)
+            first.isBuilt.await()
+            second.isBuilt.await()
+
+            first.track("first")
+            second.track("second")
+            advanceUntilIdle()
+
+            assertTrue(first.isActiveForReplacement())
+            assertTrue(second.isActiveForReplacement())
+            assertEquals(listOf("first"), firstEvents.trackedEvents.map { it.eventType })
+            assertEquals(listOf("second"), secondEvents.trackedEvents.map { it.eventType })
+            assertEquals(2, application.registeredCallbacks.size)
+            assertTrue(application.unregisteredCallbacks.isEmpty())
+        }
+
+    @Test
+    fun `Analytics Connector events are routed only to the replacement`() =
+        runTest {
+            val application = TestApplication()
+            val instanceName = "replacement-connector"
+            val first =
+                track(
+                    FakeAndroidAmplitude(
+                        configuration = configuration(application, instanceName),
+                        androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                    ),
+                )
+            val firstEvents = FakeEventPlugin()
+            first.add(firstEvents)
+            first.isBuilt.await()
+
+            val second =
+                track(
+                    FakeAndroidAmplitude(
+                        configuration = configuration(application, instanceName),
+                        androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                    ),
+                )
+            val secondEvents = FakeEventPlugin()
+            second.add(secondEvents)
+            second.isBuilt.await()
+
+            AnalyticsConnector.getInstance(instanceName).eventBridge.logEvent(
+                AnalyticsEvent("connector event"),
+            )
+            advanceUntilIdle()
+
+            assertTrue(firstEvents.trackedEvents.isEmpty())
+            assertEquals(listOf("connector event"), secondEvents.trackedEvents.map { it.eventType })
+        }
+
+    @Test
+    fun `plugin teardown failure does not block replacement`() =
+        runTest {
+            val application = TestApplication()
+            val instanceName = "replacement-teardown-failure"
+            val recordingPlugin = RecordingTeardownPlugin()
+            val first =
+                track(
+                    FakeAndroidAmplitude(
+                        configuration = configuration(application, instanceName),
+                        androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                    ),
+                )
+            first.add(ThrowingTeardownPlugin())
+            first.add(recordingPlugin)
+            first.isBuilt.await()
+
+            val second =
+                track(
+                    FakeAndroidAmplitude(
+                        configuration = configuration(application, instanceName),
+                        androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                    ),
+                )
+            second.isBuilt.await()
+
+            assertFalse(first.isActiveForReplacement())
+            assertTrue(second.isActiveForReplacement())
+            assertTrue(recordingPlugin.tornDown)
+            assertEquals(1, application.registeredCallbacks.size)
+        }
+
+    @Test
+    fun `an in-flight build cannot install after replacement`() {
+        val application = TestApplication()
+        val instanceName = "replacement-in-flight"
+        val buildEntered = CountDownLatch(1)
+        val releaseBuild = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        val dispatcher = executor.asCoroutineDispatcher()
+
+        try {
+            val first =
+                track(
+                    PausedBuildAmplitude(
+                        configuration = configuration(application, instanceName),
+                        dispatcher = dispatcher,
+                        buildEntered = buildEntered,
+                        releaseBuild = releaseBuild,
+                    ),
+                )
+            assertTrue(buildEntered.await(5, TimeUnit.SECONDS))
+
+            val second = track(Amplitude(configuration(application, instanceName)))
+            releaseBuild.countDown()
+
+            assertFalse(first.isActiveForReplacement())
+            assertTrue(second.isActiveForReplacement())
+            assertEquals(1, application.registeredCallbacks.size)
+        } finally {
+            releaseBuild.countDown()
+            instancesToClean.forEach { amplitude ->
+                amplitude.deactivateForReplacement()
+                amplitude.finishReplacementCleanup()
+            }
+            executor.shutdown()
+            executor.awaitTermination(5, TimeUnit.SECONDS)
+        }
+    }
+
+    @Test
+    fun `concurrent same-name construction leaves one active instance`() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val instanceName = "replacement-concurrent"
+        val start = CountDownLatch(1)
+        val instances = ConcurrentLinkedQueue<Amplitude>()
+        val errors = ConcurrentLinkedQueue<Throwable>()
+        val configurations =
+            List(8) {
+                configuration(application, instanceName)
+            }
+        val threads =
+            configurations.map { configuration ->
+                Thread {
+                    try {
+                        start.await()
+                        val amplitude = track(Amplitude(configuration))
+                        instances += amplitude
+                    } catch (error: Throwable) {
+                        errors += error
+                    }
+                }.apply { start() }
+            }
+
+        start.countDown()
+        threads.forEach { it.join(10_000) }
+
+        assertTrue(threads.none { it.isAlive })
+        assertTrue(errors.toString(), errors.isEmpty())
+        assertEquals(1, instances.count { it.isActiveForReplacement() })
+        assertSame(
+            ActiveAmplitudeInstances.activeInstance(application, instanceName),
+            instances.single { it.isActiveForReplacement() },
+        )
+    }
+
+    private fun <T : Amplitude> track(amplitude: T): T {
+        instancesToClean += amplitude
+        return amplitude
+    }
+
+    private fun configuration(
+        application: Application,
+        instanceName: String,
+        autocapture: Set<AutocaptureOption> = setOf(),
+    ): Configuration {
+        return Configuration(
+            apiKey = "api-key",
+            context = application,
+            instanceName = instanceName,
+            storageProvider = InMemoryStorageProvider(),
+            loggerProvider = ConsoleLoggerProvider(),
+            identifyInterceptStorageProvider = InMemoryStorageProvider(),
+            identityStorageProvider = IMIdentityStorageProvider(),
+            autocapture = autocapture,
+            migrateLegacyData = false,
+            offline = AndroidNetworkConnectivityCheckerPlugin.Disabled,
+            enableDiagnostics = false,
+            enableAutocaptureRemoteConfig = false,
+            httpClient =
+                object : HttpClientInterface {
+                    override fun upload(
+                        events: String,
+                        diagnostics: String?,
+                    ): AnalyticsResponse = AnalyticsResponse.create(200, null)
+                },
+        )
+    }
+
+    private class TestApplication : Application() {
+        val registeredCallbacks = CopyOnWriteArrayList<Application.ActivityLifecycleCallbacks>()
+        val unregisteredCallbacks = CopyOnWriteArrayList<Application.ActivityLifecycleCallbacks>()
+
+        init {
+            attachBaseContext(ApplicationProvider.getApplicationContext())
+        }
+
+        override fun registerActivityLifecycleCallbacks(callback: ActivityLifecycleCallbacks) {
+            registeredCallbacks += callback
+        }
+
+        override fun unregisterActivityLifecycleCallbacks(callback: ActivityLifecycleCallbacks) {
+            registeredCallbacks.remove(callback)
+            unregisteredCallbacks += callback
+        }
+    }
+
+    private class PausedBuildAmplitude(
+        configuration: Configuration,
+        dispatcher: CoroutineDispatcher,
+        private val buildEntered: CountDownLatch,
+        private val releaseBuild: CountDownLatch,
+    ) : Amplitude(
+            configuration = configuration,
+            state = State(),
+            amplitudeScope = CoroutineScope(SupervisorJob()),
+            amplitudeDispatcher = dispatcher,
+            networkIODispatcher = dispatcher,
+            storageIODispatcher = dispatcher,
+        ) {
+        override suspend fun buildInternal(identityConfiguration: IdentityConfiguration) {
+            buildEntered.countDown()
+            releaseBuild.await()
+            super.buildInternal(identityConfiguration)
+        }
+    }
+
+    private class ThrowingTeardownPlugin : Plugin {
+        override val type = Plugin.Type.Before
+        override lateinit var amplitude: com.amplitude.core.Amplitude
+
+        override fun teardown() {
+            error("expected teardown failure")
+        }
+    }
+
+    private class RecordingTeardownPlugin : Plugin {
+        override val type = Plugin.Type.Enrichment
+        override lateinit var amplitude: com.amplitude.core.Amplitude
+        var tornDown = false
+
+        override fun teardown() {
+            tornDown = true
+        }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/internal/fragments/FragmentActivityHandlerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/internal/fragments/FragmentActivityHandlerTest.kt
@@ -1,0 +1,60 @@
+package com.amplitude.android.internal.fragments
+
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+import com.amplitude.android.internal.fragments.FragmentActivityHandler.registerFragmentLifecycleCallbacks
+import com.amplitude.android.internal.fragments.FragmentActivityHandler.unregisterFragmentLifecycleCallbacks
+import com.amplitude.common.Logger
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class FragmentActivityHandlerTest {
+    @Test
+    fun `unregister removes callbacks only for the matching tracker`() {
+        val activity = mockk<FragmentActivity>()
+        val fragmentManager = mockk<FragmentManager>(relaxed = true)
+        val logger = mockk<Logger>(relaxed = true)
+        val registeredCallbacks = mutableListOf<FragmentManager.FragmentLifecycleCallbacks>()
+        val firstTracker = Tracker()
+        val secondTracker = Tracker()
+
+        every { activity.supportFragmentManager } returns fragmentManager
+        every {
+            fragmentManager.registerFragmentLifecycleCallbacks(capture(registeredCallbacks), true)
+        } returns Unit
+
+        activity.registerFragmentLifecycleCallbacks(firstTracker::track, logger)
+        activity.registerFragmentLifecycleCallbacks(secondTracker::track, logger)
+
+        val firstCallback = registeredCallbacks[0]
+        val secondCallback = registeredCallbacks[1]
+
+        activity.unregisterFragmentLifecycleCallbacks(firstTracker::track, logger)
+
+        verify(exactly = 1) {
+            fragmentManager.unregisterFragmentLifecycleCallbacks(firstCallback)
+        }
+        verify(exactly = 0) {
+            fragmentManager.unregisterFragmentLifecycleCallbacks(secondCallback)
+        }
+
+        activity.unregisterFragmentLifecycleCallbacks(secondTracker::track, logger)
+
+        verify(exactly = 1) {
+            fragmentManager.unregisterFragmentLifecycleCallbacks(secondCallback)
+        }
+    }
+
+    private class Tracker {
+        private val events = mutableListOf<Pair<String, Map<String, Any?>>>()
+
+        fun track(
+            eventType: String,
+            eventProperties: Map<String, Any?>,
+        ) {
+            events += eventType to eventProperties
+        }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/internal/gestures/WindowCallbackManagerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/internal/gestures/WindowCallbackManagerTest.kt
@@ -13,6 +13,7 @@ import com.amplitude.common.Logger
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertSame
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -139,9 +140,13 @@ class WindowCallbackManagerTest {
         val window = mockk<Window>(relaxed = true)
         val decorView = mockk<View>(relaxed = true)
         val originalCallback = mockk<Window.Callback>(relaxed = true)
+        var currentCallback = originalCallback
 
         every { window.context } returns activity
-        every { window.callback } returns originalCallback
+        every { window.callback } answers { currentCallback }
+        every { window.callback = any() } answers {
+            currentCallback = firstArg()
+        }
         every { decorView.context } returns appContext
 
         val sut =
@@ -158,12 +163,57 @@ class WindowCallbackManagerTest {
         // Wrap
         sut.wrapWindowForTesting(window, decorView)
 
-        // Simulate that window.callback returns our wrapper now
-        every { window.callback } returns mockk<AutocaptureWindowCallback>(relaxed = true)
-
         // Unwrap
         sut.unwrapWindowForTesting(window)
 
-        verify { window.callback = originalCallback }
+        assertSame(originalCallback, currentCallback)
+    }
+
+    @Test
+    fun `stopping one manager preserves another manager's callback`() {
+        val activity = mockk<Activity>(relaxed = true)
+        val window = mockk<Window>(relaxed = true)
+        val decorView = mockk<View>(relaxed = true)
+        val originalCallback = mockk<Window.Callback>(relaxed = true)
+        var currentCallback: Window.Callback = originalCallback
+
+        every { window.context } returns activity
+        every { window.callback } answers { currentCallback }
+        every { window.callback = any() } answers {
+            currentCallback = firstArg()
+        }
+        every { decorView.context } returns appContext
+
+        val firstManager =
+            WindowCallbackManager(
+                track = track,
+                frustrationDetector = null,
+                autocaptureStateProvider = { autocaptureState },
+                logger = logger,
+            )
+        val secondManager =
+            WindowCallbackManager(
+                track = mockk(relaxed = true),
+                frustrationDetector = null,
+                autocaptureStateProvider = { autocaptureState },
+                logger = logger,
+            )
+
+        firstManager.start()
+        secondManager.start()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        firstManager.wrapWindowForTesting(window, decorView)
+        secondManager.wrapWindowForTesting(window, decorView)
+        val secondCallback = currentCallback as AutocaptureWindowCallback
+
+        firstManager.unwrapWindowForTesting(window)
+
+        assertSame(secondCallback, currentCallback)
+        assertSame(originalCallback, secondCallback.delegate)
+
+        secondManager.unwrapWindowForTesting(window)
+
+        assertSame(originalCallback, currentCallback)
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/plugins/AndroidLifecyclePluginTest.kt
@@ -272,7 +272,7 @@ class AndroidLifecyclePluginTest {
             plugin.setup(mockedAmplitude)
 
             every { activity.registerFragmentLifecycleCallbacks(any(), any(), any()) } returns Unit
-            every { activity.unregisterFragmentLifecycleCallbacks(any()) } returns Unit
+            every { activity.unregisterFragmentLifecycleCallbacks(any(), any()) } returns Unit
 
             observer.onActivityCreated(activity, mockk())
             observer.onActivityDestroyed(activity)
@@ -284,7 +284,7 @@ class AndroidLifecyclePluginTest {
             }
 
             verify(exactly = 1) {
-                activity.unregisterFragmentLifecycleCallbacks(any())
+                activity.unregisterFragmentLifecycleCallbacks(any(), any())
             }
 
             close()
@@ -306,7 +306,7 @@ class AndroidLifecyclePluginTest {
             plugin.setup(mockedAmplitude)
 
             every { activity.registerFragmentLifecycleCallbacks(any(), any(), any()) } returns Unit
-            every { activity.unregisterFragmentLifecycleCallbacks(any()) } returns Unit
+            every { activity.unregisterFragmentLifecycleCallbacks(any(), any()) } returns Unit
 
             observer.onActivityCreated(activity, mockk())
             observer.onActivityDestroyed(activity)
@@ -319,7 +319,7 @@ class AndroidLifecyclePluginTest {
             // unregister is always called in onActivityDestroyed for safe cleanup,
             // even when screen views are disabled (it's a no-op with no registered callbacks).
             verify(exactly = 1) {
-                activity.unregisterFragmentLifecycleCallbacks(any())
+                activity.unregisterFragmentLifecycleCallbacks(any(), any())
             }
 
             close()
@@ -337,7 +337,7 @@ class AndroidLifecyclePluginTest {
             plugin.setup(mockedAmplitude)
 
             every { activity.registerFragmentLifecycleCallbacks(any(), any(), any()) } returns Unit
-            every { activity.unregisterFragmentLifecycleCallbacks(any()) } returns Unit
+            every { activity.unregisterFragmentLifecycleCallbacks(any(), any()) } returns Unit
 
             observer.onActivityCreated(activity, mockk())
             observer.onActivityDestroyed(activity)
@@ -350,7 +350,7 @@ class AndroidLifecyclePluginTest {
             }
 
             verify(exactly = 1) {
-                activity.unregisterFragmentLifecycleCallbacks(any())
+                activity.unregisterFragmentLifecycleCallbacks(any(), any())
             }
 
             close()
@@ -794,7 +794,7 @@ class AndroidLifecyclePluginTest {
             plugin.setup(mockedAmplitude)
 
             every { activity.registerFragmentLifecycleCallbacks(any(), any(), any()) } returns Unit
-            every { activity.unregisterFragmentLifecycleCallbacks(any()) } returns Unit
+            every { activity.unregisterFragmentLifecycleCallbacks(any(), any()) } returns Unit
 
             // Simulate activity lifecycle
             observer.onActivityCreated(activity, mockk())


### PR DESCRIPTION
### Describe what this PR is addressing

On Android, `flush()` + `reset()` + dropping an `Amplitude` reference does not release the instance because the `Application` still strongly retains its lifecycle callbacks. Reinitializing the same logical instance with autocapture disabled can therefore leave the old instance autocapturing, which caused the customer privacy issue in SDK-171.

This is a clean-slate, no-public-API replacement for the earlier explicit `shutdown()` drafts in #421 and #422.

### Describe the solution

When an Android `Amplitude` is constructed with an `instanceName` already active in the same application, the SDK now automatically retires the previous instance before activating the replacement. Retirement unregisters lifecycle callbacks, stops lifecycle/autocapture observers, closes event processing, detaches the Analytics Connector receiver, tears down plugins, cancels the old scope, and releases executor dispatchers.

The registry uses weak application and instance references, remains isolated by `instanceName`, and serializes concurrent same-name construction. No public API or API dump changes are introduced.

### Steps to verify the change

- `./gradlew ktlintFormat`
- `./gradlew :android:test apiCheck`
- `./gradlew :android:testDebugUnitTest :android:testReleaseUnitTest --tests "com.amplitude.android.AmplitudeReplacementTest"`
- Physical Pixel 8 validation: HSA screen autocapture fired before logout; after `flush()` + `reset()` + same-name FSA reinitialization with autocapture disabled, the HSA plugin was torn down, the FSA custom event fired, and subsequent FSA Activity lifecycle produced no autocapture events.

### Useful links and documentation (optional)

- [SDK-171](https://linear.app/amplitude/issue/SDK-171/autocapture-persists-after-logout-on-android-sdk)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change? No — this adds no public API and `apiCheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Android init, lifecycle registration, and autocapture teardown with race-sensitive build gating; behavior change for apps that relied on multiple same-name instances staying active, but aligns with instanceName semantics and adds broad test coverage.
> 
> **Overview**
> Fixes **autocapture persisting after logout** when apps create a new `Amplitude` with the same `instanceName` without a public shutdown API. Constructing another client with that name now **retires the previous instance** instead of leaving two active logical clients.
> 
> **`ActiveAmplitudeInstances`** registers one active Android `Amplitude` per application + `instanceName`, deactivates the prior instance, and only then completes the replacement’s build via a **`replacementBuildGate`**. Retirement unregisters `Application` lifecycle callbacks, stops autocapture (`AndroidLifecyclePlugin.stopAutocapture`, observer channel cancel), stops the timeline, clears Analytics Connector receivers, tears down plugins and executor dispatchers, and cancels the old coroutine scope. **`buildInternal`** bails out if the instance was retired mid-build.
> 
> Supporting teardown changes: **`EventPipeline`** is idempotent on `stop`, removes shutdown hooks, and stops when its scope completes; **fragment** callbacks are keyed by `TrackFunction` so only the retiring instance unregisters; **`WindowCallbackManager`** unwraps nested callback chains so stopping one autocapture manager does not break another on the same window.
> 
> No new public API. **`AmplitudeReplacementTest`** covers same-name replacement, connector routing, concurrent construction, and in-flight builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569a0749e8edccebc16b6e775a29ef5cf6cd017d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->