### PR TITLE
refactor(core): avoid non-SDK JSONObject.keySet() in 429 parsing

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/utilities/JSONUtil.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/JSONUtil.kt
@@ -157,6 +157,14 @@ internal fun JSONObject.collectIndices(): Set<Int> {
     return indices.toSet()
 }
 
+/**
+ * keySet() is not part of the public Android SDK's org.json.JSONObject, so referencing it
+ * makes R8 warn about a missing method. keys() is in the SDK on every API level.
+ */
+internal fun JSONObject.toKeySet(): Set<String> {
+    return keys().asSequence().toSet()
+}
+
 internal fun JSONArray.toIntArray(): IntArray {
     val intArray = IntArray(this.length())
     for (i in intArray.indices) {

--- a/analytics-core/src/main/java/com/amplitude/core/utilities/http/AnalyticsResponse.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/http/AnalyticsResponse.kt
@@ -9,6 +9,7 @@ import com.amplitude.core.utilities.http.HttpStatus.SUCCESS
 import com.amplitude.core.utilities.http.HttpStatus.TIMEOUT
 import com.amplitude.core.utilities.http.HttpStatus.TOO_MANY_REQUESTS
 import com.amplitude.core.utilities.toIntArray
+import com.amplitude.core.utilities.toKeySet
 import org.json.JSONObject
 
 public sealed class AnalyticsResponse(public val status: HttpStatus) {
@@ -107,20 +108,20 @@ public class TooManyRequestsResponse(response: JSONObject) :
 
     init {
         if (response.has("exceeded_daily_quota_users")) {
-            exceededDailyQuotaUsers = response.getJSONObject("exceeded_daily_quota_users").keySet()
+            exceededDailyQuotaUsers = response.getJSONObject("exceeded_daily_quota_users").toKeySet()
         }
         if (response.has("exceeded_daily_quota_devices")) {
             exceededDailyQuotaDevices =
-                response.getJSONObject("exceeded_daily_quota_devices").keySet()
+                response.getJSONObject("exceeded_daily_quota_devices").toKeySet()
         }
         if (response.has("throttled_events")) {
             throttledEvents = response.getJSONArray("throttled_events").toIntArray().toSet()
         }
         if (response.has("throttled_users")) {
-            throttledUsers = response.getJSONObject("throttled_users").keySet()
+            throttledUsers = response.getJSONObject("throttled_users").toKeySet()
         }
         if (response.has("throttled_devices")) {
-            throttledDevices = response.getJSONObject("throttled_devices").keySet()
+            throttledDevices = response.getJSONObject("throttled_devices").toKeySet()
         }
     }
 

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/http/AnalyticsResponseTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/http/AnalyticsResponseTest.kt
@@ -1,7 +1,10 @@
 package com.amplitude.core.utilities.http
 
+import com.amplitude.core.events.BaseEvent
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -26,6 +29,29 @@ class AnalyticsResponseTest {
         assertTrue(response is PayloadTooLargeResponse)
         assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, response.status)
         assertEquals("Payload too large", (response as PayloadTooLargeResponse).error)
+    }
+
+    @Test
+    fun `test create too many requests response parses quota and throttle fields`() {
+        val responseBody =
+            JSONObject().apply {
+                put("error", "Too many requests")
+                put("exceeded_daily_quota_users", JSONObject().put("user-1", 1))
+                put("exceeded_daily_quota_devices", JSONObject().put("device-1", 1))
+                put("throttled_users", JSONObject().put("user-2", 10))
+                put("throttled_devices", JSONObject().put("device-2", 10))
+                put("throttled_events", JSONArray().put(0).put(2))
+            }.toString()
+
+        val response = AnalyticsResponse.create(429, responseBody)
+        assertTrue(response is TooManyRequestsResponse)
+        response as TooManyRequestsResponse
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS, response.status)
+        assertEquals("Too many requests", response.error)
+        assertEquals(setOf(0, 2), response.throttledEvents)
+        assertTrue(response.isEventExceedDailyQuota(BaseEvent().apply { userId = "user-1" }))
+        assertTrue(response.isEventExceedDailyQuota(BaseEvent().apply { deviceId = "device-1" }))
+        assertFalse(response.isEventExceedDailyQuota(BaseEvent().apply { userId = "user-2" }))
     }
 
     @Test


### PR DESCRIPTION
### Describe what this PR is addressing

`TooManyRequestsResponse` calls `JSONObject.keySet()` when parsing the quota/throttle fields of an HTTP 429 response. `keySet()` is **not exposed by the public Android SDK's `org.json.JSONObject`** — it is absent from `android.jar` at every API level (verified 31–36) — so R8 reports:

```
Missing method java.util.Set org.json.JSONObject.keySet()
  (referenced from: void com.amplitude.core.utilities.TooManyRequestsResponse.<init>(org.json.JSONObject))
```

**This is not a crash fix.** The linked issue speculated the warning could cause a runtime crash. It does not — `keySet()` exists in the Android *runtime* framework even though it is missing from the compile-time stub. See "Steps to verify" for how this was confirmed on the reporter's own API level.

Refs #194 · SDKA-28

### Describe the solution

Replaced the four `keySet()` call sites with an `internal` `JSONObject.toKeySet()` helper built on `keys()`, which *is* part of the SDK on every API level.

* **Why this way:** `keys()` is the SDK-sanctioned equivalent and works identically on both Android's framework `org.json` and the standalone `org.json:json` used by JVM tests. A helper keeps the four call sites readable and gives the constraint one documented home, so it isn't "simplified" back later.
* **Future impact:** none on behavior or public API — the helper is `internal`, and `apiCheck` passes without an `apiDump`. It removes a non-SDK API reference, which Google actively discourages.

Root cause worth noting for follow-up: `analytics-core` declares `compileOnly(org.json:json)`, whose API is a *superset* of Android's. Anything in that delta compiles green and passes JVM tests (which run against that same standalone jar), surfacing only as an R8 warning in consumer apps — which is how this shipped and went unnoticed for ~2 years. A CI check to catch the next one is worth a separate ticket.

### Steps to verify the change

Automated:
* `./gradlew ktlintCheck :analytics-core:test apiCheck` — all pass.
* Adds a unit test for 429 quota/throttle parsing; that path previously had **no** coverage.

Manual (how the "no crash" claim was confirmed):
1. Revert this commit so the `keySet()` code is back.
2. Point the sample app's `httpClient` at a stub returning a canned 429 whose body includes `exceeded_daily_quota_users`, and set `flushQueueSize = 1`.
3. Build the **R8-minified release** APK (`assembleRelease`, `isMinifyEnabled = true`) and install on emulators at **API 26** (the reporter's level) and **API 29**.
4. Result on both: no `NoSuchMethodError`, no crash. logcat shows `Handle response, status: TOO_MANY_REQUESTS` and the process stays alive.

Note that modern R8 no longer prints the warning at all, so the original report is only reproducible on older tooling.

### Useful links and documentation (optional)

* GitHub issue: https://github.com/amplitude/Amplitude-Kotlin/issues/194
* Linear: SDKA-28

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change? — No. No public API change; `apiCheck` passes with no `apiDump`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal-only JSON key extraction with equivalent semantics; no public API or runtime behavior change intended.
> 
> **Overview**
> Fixes R8 **missing method** warnings when minifying apps that use analytics-core by stopping use of `JSONObject.keySet()`, which is not on the public Android SDK stub (though it exists at runtime).
> 
> Adds an internal **`JSONObject.toKeySet()`** helper in `JSONUtil.kt` that builds a `Set<String>` from **`keys()`**, and switches the four quota/throttle object parses in **`TooManyRequestsResponse`** to use it instead of `keySet()`. Behavior and public API are unchanged.
> 
> Adds a unit test that exercises HTTP **429** parsing (`throttled_events`, daily quota user/device keys, and `isEventExceedDailyQuota`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11244fea0bc7b40f203c6f820ac350981108a336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->