### PR TITLE
test(android): cover opt-out to opt-in session id (SDKA-30)

### DIFF
--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeSessionTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeSessionTest.kt
@@ -36,6 +36,7 @@ class AmplitudeSessionTest {
     private fun createConfiguration(
         storageProvider: StorageProvider? = null,
         shouldTrackSessions: Boolean = true,
+        optOut: Boolean = false,
     ): Configuration {
         setupMockAndroidContext()
         val context = mockk<Application>(relaxed = true)
@@ -51,6 +52,7 @@ class AmplitudeSessionTest {
             context = context,
             instanceName = "testInstance",
             minTimeBetweenSessionsMillis = 100,
+            optOut = optOut,
             storageProvider = storageProvider ?: InMemoryStorageProvider(),
             autocapture =
                 autocaptureOptions {
@@ -724,6 +726,162 @@ class AmplitudeSessionTest {
                 mockedPlugin.track(capture(tracks))
             }
             assertEquals(1, tracks.count())
+        }
+
+    @Test
+    fun amplitude_optInAfterForegroundWhileOptedOutShouldStartSession() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = createConfiguration(optOut = true),
+                )
+
+            val fakeEventPlugin = FakeEventPlugin()
+            amplitude.add(fakeEventPlugin)
+
+            amplitude.isBuilt.await()
+
+            // The app foregrounds while opted out, so no session is started. Regression guard for
+            // issue #154: the foreground signal must still leave the timeline able to open a session
+            // once the user opts in, even though it produced nothing at the time.
+            enterForeground(amplitude, 1000L)
+            amplitude.track(createEvent(1050L, "opted out event"))
+
+            advanceUntilIdle()
+            Thread.sleep(100)
+
+            assertEquals(0, fakeEventPlugin.trackedEvents.count())
+            assertEquals(-1L, amplitude.sessionId)
+
+            amplitude.optOut = false
+            amplitude.track(createEvent(2000L, "opted in event"))
+
+            advanceUntilIdle()
+            Thread.sleep(100)
+
+            val trackedEvents = fakeEventPlugin.trackedEvents
+
+            trackedEvents.sortBy { event -> event.eventId }
+
+            assertEquals(2, trackedEvents.count())
+
+            var event = trackedEvents[0]
+            assertEquals(Amplitude.START_SESSION_EVENT, event.eventType)
+            assertEquals(2000L, event.sessionId)
+            assertEquals(2000L, event.timestamp)
+
+            event = trackedEvents[1]
+            assertEquals("opted in event", event.eventType)
+            assertEquals(2000L, event.sessionId)
+            assertEquals(2000L, event.timestamp)
+
+            assertEquals(2000L, amplitude.sessionId)
+        }
+
+    @Test
+    fun amplitude_optInAfterForegroundWhileOptedOutShouldRotateSessionNormally() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = createConfiguration(optOut = true),
+                )
+
+            val fakeEventPlugin = FakeEventPlugin()
+            amplitude.add(fakeEventPlugin)
+
+            amplitude.isBuilt.await()
+
+            enterForeground(amplitude, 1000L)
+            amplitude.optOut = false
+            amplitude.track(createEvent(2000L, "test event 1"))
+            exitForeground(amplitude, 2100L)
+            amplitude.track(createEvent(5000L, "test event 2"))
+
+            advanceUntilIdle()
+            Thread.sleep(100)
+
+            val trackedEvents = fakeEventPlugin.trackedEvents
+
+            trackedEvents.sortBy { event -> event.eventId }
+
+            // The session recovered on opt-in behaves like any other: it times out in the
+            // background and rotates.
+            assertEquals(5, trackedEvents.count())
+
+            var event = trackedEvents[0]
+            assertEquals(Amplitude.START_SESSION_EVENT, event.eventType)
+            assertEquals(2000L, event.sessionId)
+            assertEquals(2000L, event.timestamp)
+
+            event = trackedEvents[1]
+            assertEquals("test event 1", event.eventType)
+            assertEquals(2000L, event.sessionId)
+            assertEquals(2000L, event.timestamp)
+
+            event = trackedEvents[2]
+            assertEquals(Amplitude.END_SESSION_EVENT, event.eventType)
+            assertEquals(2000L, event.sessionId)
+            assertEquals(2100L, event.timestamp)
+
+            event = trackedEvents[3]
+            assertEquals(Amplitude.START_SESSION_EVENT, event.eventType)
+            assertEquals(5000L, event.sessionId)
+            assertEquals(5000L, event.timestamp)
+
+            event = trackedEvents[4]
+            assertEquals("test event 2", event.eventType)
+            assertEquals(5000L, event.sessionId)
+            assertEquals(5000L, event.timestamp)
+        }
+
+    @Test
+    fun amplitude_optOutMidSessionShouldPreserveSessionId() =
+        runTest {
+            val amplitude =
+                createFakeAmplitude(
+                    scheduler = testScheduler,
+                    configuration = createConfiguration(),
+                )
+
+            val fakeEventPlugin = FakeEventPlugin()
+            amplitude.add(fakeEventPlugin)
+
+            amplitude.isBuilt.await()
+
+            enterForeground(amplitude, 1000L)
+            amplitude.track(createEvent(1050L, "test event 1"))
+            amplitude.optOut = true
+            amplitude.track(createEvent(1100L, "opted out event"))
+            amplitude.optOut = false
+            amplitude.track(createEvent(1150L, "test event 2"))
+
+            advanceUntilIdle()
+            Thread.sleep(100)
+
+            val trackedEvents = fakeEventPlugin.trackedEvents
+
+            trackedEvents.sortBy { event -> event.eventId }
+
+            // Opting out drops the event but leaves the live session intact, so opting back in
+            // resumes the same session rather than starting a new one.
+            assertEquals(3, trackedEvents.count())
+
+            var event = trackedEvents[0]
+            assertEquals(Amplitude.START_SESSION_EVENT, event.eventType)
+            assertEquals(1000L, event.sessionId)
+            assertEquals(1000L, event.timestamp)
+
+            event = trackedEvents[1]
+            assertEquals("test event 1", event.eventType)
+            assertEquals(1000L, event.sessionId)
+            assertEquals(1050L, event.timestamp)
+
+            event = trackedEvents[2]
+            assertEquals("test event 2", event.eventType)
+            assertEquals(1000L, event.sessionId)
+            assertEquals(1150L, event.timestamp)
         }
 
     private fun createEvent(


### PR DESCRIPTION
### Describe what this PR is addressing

[#154](<https://github.com/amplitude/Amplitude-Kotlin/issues/154>) reported events carrying<br>`session_id = -1` when the SDK is initialized with `optOut = true` (GDPR consent gate) and<br>flipped to `false` after the user consents. It no longer reproduces on `main` as it was<br>already fixed. This PR adds test coverage which confirms the fix.

### Describe the solution

Three tests in `AmplitudeSessionTest`, plus an `optOut` parameter on the shared<br>`createConfiguration` helper:

* `amplitude_optInAfterForegroundWhileOptedOutShouldStartSession` — the amplitude/Amplitude-Kotlin#154 regression.<br>Foregrounding while opted out emits nothing and leaves `sessionId` at `-1`; the first event<br>after opt-in opens a session, and it and `session_start` both carry a real session id.
* `amplitude_optInAfterForegroundWhileOptedOutShouldRotateSessionNormally` — the recovered<br>session is genuinely healthy: it backgrounds, times out, and rotates like any other.
* `amplitude_optOutMidSessionShouldPreserveSessionId` — opting out mid-session drops the<br>event but leaves the live session intact; opting back in resumes the same session.

Test-only. No production code touched, so no `apiDump` needed. Naming follows this file's<br>existing `amplitude_camelCase` idiom.

### Steps to verify the change

```bash
./gradlew ktlintCheck :android:testDebugUnitTest
```

344 tests, 0 failures.

To confirm the tests aren't passing vacuously, restore the pre-[#326](<https://github.com/amplitude/Amplitude-Kotlin/issues/326>) shape in<br>`android/src/main/java/com/amplitude/android/Timeline.kt:122` (wrap the<br>`startNewSessionIfNeeded` call in `if (!foreground.get()) … else refreshSessionTime(eventTimestamp)`):

```
amplitude_optInAfterForegroundWhileOptedOutShouldStartSession           FAILED
amplitude_optInAfterForegroundWhileOptedOutShouldRotateSessionNormally  FAILED
amplitude_optOutMidSessionShouldPreserveSessionId                       PASSED
```

The third passes either way — it starts from a live session where the foreground branch is<br>harmless, so it guards a neighbouring property rather than the amplitude/Amplitude-Kotlin#154 vector.

### Useful links and documentation (optional)

* Closes [#154](<https://github.com/amplitude/Amplitude-Kotlin/issues/154>)
* amplitude/Amplitude-Kotlin#154

### Checklist

- [X] Does your PR title have the correct [title format](<https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions>)?
- [X] Does your PR have a breaking change?

---

> \[!NOTE\]<br>**Low Risk**<br>Only unit tests and test helpers are modified; no production behavior or API surface changes.
>
> **Overview****<br>****Test-only** regression coverage for [issue #154](<https://github.com/amplitude/Amplitude-Kotlin/issues/154>) (events with `session_id = -1` after consent when the SDK started with `optOut = true`).
>
> `AmplitudeSessionTest` gains an `optOut` parameter on `createConfiguration` and **three** new tests: opt-in after foreground while opted out starts a real session (not `-1`); that recovered session still rotates on background timeout; and toggling opt-out mid-session drops events but **keeps** the same `sessionId` when tracking resumes.
>
> No changes to runtime SDK code.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 0d24625a2a33cff047b735ff4f486089449b1a20. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).