### PR TITLE
fix(android): replace same-name instances automatically (SDK-171)

### DIFF
--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -13,6 +13,9 @@
 }
 -keep class com.google.android.gms.tasks.Task
 
+# Keep the plugin names readable so the log is usable in a minified build.
+-keepnames class com.amplitude.** implements com.amplitude.core.platform.UniversalPlugin
+
 #################### START: Compose Proguard Rules ####################
 
 # The Android SDK checks at runtime if these classes are available via Class.forName

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -14,6 +14,7 @@ import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.State
 import com.amplitude.core.diagnostics.DiagnosticsContextProvider
+import com.amplitude.core.platform.UniversalPlugin
 import com.amplitude.core.platform.plugins.AmplitudeDestination
 import com.amplitude.core.platform.plugins.ContextPlugin
 import com.amplitude.core.platform.plugins.GetAmpliExtrasPlugin
@@ -24,8 +25,10 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import java.io.File
 import java.lang.ref.WeakReference
+import java.util.concurrent.atomic.AtomicBoolean
 import com.amplitude.core.Amplitude as CoreAmplitude
 
 @OptIn(ExperimentalCoroutinesApi::class, RestrictedAmplitudeFeature::class)
@@ -58,6 +61,17 @@ open class Amplitude internal constructor(
     internal lateinit var autocaptureManager: AutocaptureManager
         private set
 
+    // Assigned in [build], not by a field initializer: initializers run after the core constructor,
+    // where they would clobber a retirement from a same-name instance racing this one.
+    private lateinit var retired: AtomicBoolean
+
+    /** Whether this instance still owns its instance name. Gates all work an active instance does. */
+    internal val isActive: Boolean
+        get() = !retired.get()
+
+    internal val application: Application
+        get() = (configuration as Configuration).context as Application
+
     /**
      * Init-order trap: [CoreAmplitude]'s `init` calls [build] before this class's field
      * initializers run, and [buildInternal] may already be on a background thread.
@@ -65,6 +79,7 @@ open class Amplitude internal constructor(
      * initializers, or `init {}`.
      */
     override fun build(): Deferred<Boolean> {
+        retired = AtomicBoolean(false)
         activityLifecycleCallbacks = ActivityLifecycleObserver()
         androidContextPlugin = AndroidContextPlugin()
         val androidConfig = configuration as Configuration
@@ -76,15 +91,10 @@ open class Amplitude internal constructor(
                 logger = logger,
                 diagnosticsClient = diagnosticsClient,
             )
+        // Claim the instance name before the build exists, so nothing the build installs can run
+        // before the claim, and a failed claim leaves no build behind.
+        AmplitudeRegistry.activate(this)
         return super.build()
-    }
-
-    init {
-        registerShutdownHook()
-
-        with(configuration.context as Application) {
-            registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
-        }
     }
 
     override fun createTimeline(): Timeline {
@@ -105,10 +115,18 @@ open class Amplitude internal constructor(
     }
 
     override suspend fun buildInternal(identityConfiguration: IdentityConfiguration) {
+        // A build that outlives its instance must not install plugins or claim shared state:
+        // the replacement owns both by then.
+        if (!isActive) return
+
         val migrationManager = MigrationManager(this)
         migrationManager.migrateOldStorage()
 
+        if (!isActive) return
+
         this.createIdentityContainer(identityConfiguration)
+
+        if (!isActive) return
 
         if (this.configuration.offline != AndroidNetworkConnectivityCheckerPlugin.Disabled) {
             add(AndroidNetworkConnectivityCheckerPlugin())
@@ -134,6 +152,9 @@ open class Amplitude internal constructor(
     }
 
     override fun reset(): Amplitude {
+        // Identity is shared by instance name, so a replaced instance must not rotate it.
+        if (!isActive) return this
+
         val newDeviceId =
             if (isBuilt.isCompleted) {
                 androidContextPlugin.resolveDeviceId(configuration as Configuration, forceRegenerate = true)
@@ -157,6 +178,42 @@ open class Amplitude internal constructor(
     @GuardedAmplitudeFeature
     fun onExitForeground(timestamp: Long) {
         (timeline as Timeline).onExitForeground(timestamp)
+    }
+
+    /** Claims the hooks only the active instance may own. Throwing here leaves the previous instance in place. */
+    internal fun startAsActiveInstance() {
+        registerShutdownHook()
+        application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+    }
+
+    /** Marks this instance inactive, returning false if it already was. */
+    internal fun markRetired(): Boolean = retired.compareAndSet(false, true)
+
+    /**
+     * Releases what an inactive instance must not keep holding. Nothing here waits on this
+     * instance, and queued events still drain to the storage the replacement shares by name.
+     */
+    internal fun retire() {
+        runCatching { application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks) }
+            .onFailure { logger.warn("Failed to unregister activity lifecycle callbacks: $it") }
+        runCatching { (timeline as Timeline).close() }
+            .onFailure { logger.warn("Failed to close the event queue: $it") }
+        // Autocapture holds process-wide resources (window callbacks, a Curtains listener) and
+        // takes no part in draining, so it goes now rather than behind the drain below.
+        runCatching { findPlugin<AndroidLifecyclePlugin>()?.let { remove(it) } }
+            .onFailure { logger.warn("Failed to stop Android autocapture: $it") }
+
+        // The rest go last: they must outlive an in-flight build that is still adding them and the
+        // queued events still draining through them. Off the constructor's thread either way, so
+        // the replacement never waits on this.
+        amplitudeScope.launch(amplitudeDispatcher) {
+            isBuilt.join()
+            (timeline as Timeline).awaitDrained()
+            plugins(UniversalPlugin::class.java).forEach { plugin ->
+                runCatching { remove(plugin) }
+                    .onFailure { logger.warn("Failed to remove ${plugin.name ?: plugin::class.java.simpleName}: $it") }
+            }
+        }
     }
 
     private fun registerShutdownHook() {

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -65,7 +65,10 @@ open class Amplitude internal constructor(
     // where they would clobber a retirement from a same-name instance racing this one.
     private lateinit var retired: AtomicBoolean
 
-    /** Whether this instance still owns its instance name. Gates all work an active instance does. */
+    /**
+     * Whether this instance still owns its instance name. Gates event ingress, session work,
+     * plugin installation, and claims on state shared by name.
+     */
     internal val isActive: Boolean
         get() = !retired.get()
 
@@ -74,9 +77,9 @@ open class Amplitude internal constructor(
 
     /**
      * Init-order trap: [CoreAmplitude]'s `init` calls [build] before this class's field
-     * initializers run, and [buildInternal] may already be on a background thread.
-     * Assign anything [buildInternal] or its plugins read here — never `by lazy`, field
-     * initializers, or `init {}`.
+     * initializers run, and [buildInternal] may already be on a background thread. Assign anything
+     * [buildInternal] or its plugins read here — never `by lazy` or a field initializer. This is
+     * also where the instance claims its name, so ownership settles before the build starts.
      */
     override fun build(): Deferred<Boolean> {
         retired = AtomicBoolean(false)

--- a/android/src/main/java/com/amplitude/android/AmplitudeRegistry.kt
+++ b/android/src/main/java/com/amplitude/android/AmplitudeRegistry.kt
@@ -1,0 +1,59 @@
+package com.amplitude.android
+
+import java.lang.ref.WeakReference
+
+/**
+ * Tracks the single active [Amplitude] per instance name. Storage, identity, and the analytics
+ * connector are all keyed by instance name, so two instances sharing one cannot both own them.
+ */
+internal object AmplitudeRegistry {
+    private val activeInstances = mutableMapOf<String, WeakReference<Amplitude>>()
+
+    /**
+     * Makes [instance] the active owner of its instance name and retires the instance it replaces.
+     * The previous instance is only retired once [instance] has started.
+     */
+    fun activate(instance: Amplitude) {
+        val instanceName = instance.configuration.instanceName
+        val replaced =
+            synchronized(this) {
+                activeInstances.values.removeAll { it.get() == null }
+                val previous = activeInstances[instanceName]?.get()
+                try {
+                    instance.startAsActiveInstance()
+                } catch (error: Throwable) {
+                    // Nothing was claimed and the build does not exist yet, so retiring the
+                    // half-built instance is enough; the previous instance keeps the name.
+                    instance.markRetired()
+                    throw error
+                }
+                activeInstances[instanceName] = WeakReference(instance)
+                // Only instances sharing an Application compete: a different one still holds the
+                // previous instance's lifecycle callbacks, so tearing it down owns nothing.
+                previous
+                    ?.takeIf { it !== instance && it.application === instance.application }
+                    ?.takeIf { it.markRetired() }
+            }
+
+        replaced?.let {
+            it.logger.warn(
+                "Amplitude instance '$instanceName' was replaced by a newer instance with the " +
+                    "same name and is now inactive.",
+            )
+            it.retire()
+        }
+    }
+
+    /**
+     * Runs [block] only while [instance] owns its instance name. Atomic against [activate], so a
+     * build that finishes after its instance was replaced cannot claim shared state.
+     */
+    fun runIfActive(
+        instance: Amplitude,
+        block: () -> Unit,
+    ) {
+        synchronized(this) {
+            if (activeInstances[instance.configuration.instanceName]?.get() === instance) block()
+        }
+    }
+}

--- a/android/src/main/java/com/amplitude/android/AmplitudeRegistry.kt
+++ b/android/src/main/java/com/amplitude/android/AmplitudeRegistry.kt
@@ -1,6 +1,7 @@
 package com.amplitude.android
 
 import java.lang.ref.WeakReference
+import com.amplitude.core.Amplitude as CoreAmplitude
 
 /**
  * Tracks the single active [Amplitude] per instance name. Storage, identity, and the analytics
@@ -45,13 +46,14 @@ internal object AmplitudeRegistry {
     }
 
     /**
-     * Runs [block] only while [instance] owns its instance name. Atomic against [activate], so a
+     * Runs [block] only while [amplitude] owns its instance name. Atomic against [activate], so a
      * build that finishes after its instance was replaced cannot claim shared state.
      */
     fun runIfActive(
-        instance: Amplitude,
+        amplitude: CoreAmplitude,
         block: () -> Unit,
     ) {
+        val instance = amplitude as? Amplitude ?: return block()
         synchronized(this) {
             if (activeInstances[instance.configuration.instanceName]?.get() === instance) block()
         }

--- a/android/src/main/java/com/amplitude/android/Timeline.kt
+++ b/android/src/main/java/com/amplitude/android/Timeline.kt
@@ -9,6 +9,7 @@ import com.amplitude.core.Storage.Constants.LAST_EVENT_TIME
 import com.amplitude.core.Storage.Constants.PREVIOUS_SESSION_ID
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Timeline
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
@@ -34,28 +35,31 @@ class Timeline(
     internal var lastEventTime: Long = DEFAULT_EVENT_ID_OR_TIME
         private set
 
+    private var processingJob: Job? = null
+
     internal fun start() {
         with(amplitude) {
-            amplitudeScope.launch(storageIODispatcher) {
-                // Wait until build (including possible legacy data migration) is finished.
-                isBuilt.await()
+            processingJob =
+                amplitudeScope.launch(storageIODispatcher) {
+                    // Wait until build (including possible legacy data migration) is finished.
+                    isBuilt.await()
 
-                if (initialSessionId == null) {
-                    val restoredSessionId = storage.readLong(PREVIOUS_SESSION_ID, DEFAULT_SESSION_ID)
-                    _sessionId.set(restoredSessionId)
-                    if (restoredSessionId > DEFAULT_SESSION_ID) {
-                        (amplitude as Amplitude).notifySessionIdChanged(restoredSessionId)
+                    if (initialSessionId == null) {
+                        val restoredSessionId = storage.readLong(PREVIOUS_SESSION_ID, DEFAULT_SESSION_ID)
+                        _sessionId.set(restoredSessionId)
+                        if (restoredSessionId > DEFAULT_SESSION_ID) {
+                            (amplitude as Amplitude).notifySessionIdChanged(restoredSessionId)
+                        }
+                    } else if (initialSessionId > DEFAULT_SESSION_ID) {
+                        (amplitude as Amplitude).notifySessionIdChanged(initialSessionId)
                     }
-                } else if (initialSessionId > DEFAULT_SESSION_ID) {
-                    (amplitude as Amplitude).notifySessionIdChanged(initialSessionId)
-                }
-                lastEventId = storage.readLong(LAST_EVENT_ID, DEFAULT_EVENT_ID_OR_TIME)
-                lastEventTime = storage.readLong(LAST_EVENT_TIME, DEFAULT_EVENT_ID_OR_TIME)
+                    lastEventId = storage.readLong(LAST_EVENT_ID, DEFAULT_EVENT_ID_OR_TIME)
+                    lastEventTime = storage.readLong(LAST_EVENT_TIME, DEFAULT_EVENT_ID_OR_TIME)
 
-                for (message in eventMessageChannel) {
-                    processEventMessage(message)
+                    for (message in eventMessageChannel) {
+                        processEventMessage(message)
+                    }
                 }
-            }
         }
     }
 
@@ -63,10 +67,27 @@ class Timeline(
         this.eventMessageChannel.cancel()
     }
 
+    /** Stop accepting new events. Anything already queued still drains to storage. */
+    internal fun close() {
+        this.eventMessageChannel.close()
+    }
+
+    /** Suspends until the events queued at [close] have been processed. */
+    internal suspend fun awaitDrained() {
+        processingJob?.join()
+    }
+
     /**
      * Enqueue an event to be processed by the timeline.
      */
     override fun process(incomingEvent: BaseEvent) {
+        if (!(amplitude as Amplitude).isActive) {
+            amplitude.logger.debug(
+                "Dropping event '${incomingEvent.eventType}': this Amplitude instance was replaced.",
+            )
+            return
+        }
+
         if (incomingEvent.timestamp == null) {
             incomingEvent.timestamp = System.currentTimeMillis()
         }
@@ -91,6 +112,7 @@ class Timeline(
     private suspend fun processEventMessage(message: EventQueueMessage) {
         when (message) {
             is EventQueueMessage.EnterForeground -> {
+                if (!ownsSessions()) return
                 val stopAndStartSessionEvents = startNewSessionIfNeeded(message.timestamp)
                 foreground.set(true)
                 processAndPersistEvents(stopAndStartSessionEvents)
@@ -99,19 +121,28 @@ class Timeline(
                 processEvent(message.event)
             }
             is EventQueueMessage.ExitForeground -> {
+                if (!ownsSessions()) return
                 foreground.set(false)
                 refreshSessionTime(message.timestamp)
             }
         }
     }
 
+    /**
+     * Sessions live in storage shared by instance name, so a replaced instance drains the events it
+     * already accepted without starting, ending, or refreshing a session the replacement now owns.
+     */
+    private fun ownsSessions(): Boolean = (amplitude as Amplitude).isActive
+
     private suspend fun processEvent(event: BaseEvent) {
         val eventTimestamp = event.timestamp ?: System.currentTimeMillis()
 
         when (event.eventType) {
             START_SESSION_EVENT -> {
-                setSessionId(event.sessionId ?: eventTimestamp)
-                refreshSessionTime(eventTimestamp)
+                if (ownsSessions()) {
+                    setSessionId(event.sessionId ?: eventTimestamp)
+                    refreshSessionTime(eventTimestamp)
+                }
             }
 
             END_SESSION_EVENT -> {
@@ -119,7 +150,7 @@ class Timeline(
             }
 
             else -> {
-                if (event.sessionId != DEFAULT_SESSION_ID) {
+                if (event.sessionId != DEFAULT_SESSION_ID && ownsSessions()) {
                     val stopAndStartSessionEvents = startNewSessionIfNeeded(eventTimestamp)
                     processAndPersistEvents(stopAndStartSessionEvents)
                 }

--- a/android/src/main/java/com/amplitude/android/internal/gestures/WindowCallbackAdapter.kt
+++ b/android/src/main/java/com/amplitude/android/internal/gestures/WindowCallbackAdapter.kt
@@ -12,7 +12,7 @@ import android.view.Window
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 
-internal open class WindowCallbackAdapter(val delegate: Window.Callback) : Window.Callback {
+internal open class WindowCallbackAdapter(internal var delegate: Window.Callback) : Window.Callback {
     override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
         return delegate.dispatchKeyEvent(event)
     }

--- a/android/src/main/java/com/amplitude/android/internal/gestures/WindowCallbackManager.kt
+++ b/android/src/main/java/com/amplitude/android/internal/gestures/WindowCallbackManager.kt
@@ -32,7 +32,7 @@ internal class WindowCallbackManager(
     private val autocaptureStateProvider: () -> AutocaptureState,
     private val logger: Logger,
 ) {
-    private val wrappedWindows = mutableMapOf<Window, Window.Callback?>()
+    private val wrappedWindows = mutableMapOf<Window, AutocaptureWindowCallback>()
     private var started = false
 
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -107,9 +107,6 @@ internal class WindowCallbackManager(
 
         val originalCallback = window.callback ?: NoCaptureWindowCallback()
 
-        // Store original callback before wrapping
-        wrappedWindows[window] = window.callback
-
         val wrappedCallback =
             if (frustrationDetector != null) {
                 FrustrationAwareWindowCallback(
@@ -134,22 +131,31 @@ internal class WindowCallbackManager(
                 )
             }
 
+        wrappedWindows[window] = wrappedCallback
         window.callback = wrappedCallback
 
         logger.debug("Wrapped window callback for $activityName")
     }
 
     private fun unwrapWindow(window: Window) {
-        if (!wrappedWindows.containsKey(window)) return
-        val originalCallback = wrappedWindows.remove(window)
+        val ourCallback = wrappedWindows.remove(window) ?: return
 
-        // Only unwrap if the current callback is our wrapper
-        val currentCallback = window.callback
-        if (currentCallback is AutocaptureWindowCallback) {
-            // Restore original callback, or null if it was NoCaptureWindowCallback
-            window.callback = originalCallback.takeUnless { it is NoCaptureWindowCallback }
-            logger.debug("Unwrapped window callback")
+        if (window.callback === ourCallback) {
+            // Restore the callback we wrapped, or null if there wasn't one
+            window.callback = ourCallback.delegate.takeUnless { it is NoCaptureWindowCallback }
+        } else {
+            // Another Amplitude instance wrapped on top of us, so splice ourselves out of its
+            // chain instead of dropping its callback. All of this runs on the main thread.
+            var node = window.callback
+            while (node is WindowCallbackAdapter) {
+                if (node.delegate === ourCallback) {
+                    node.delegate = ourCallback.delegate
+                    break
+                }
+                node = node.delegate
+            }
         }
+        logger.debug("Unwrapped window callback")
     }
 
     /**

--- a/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorIdentityPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorIdentityPlugin.kt
@@ -2,6 +2,7 @@ package com.amplitude.android.plugins
 
 import com.amplitude.analytics.connector.AnalyticsConnector
 import com.amplitude.analytics.connector.Identity
+import com.amplitude.android.AmplitudeRegistry
 import com.amplitude.core.Amplitude
 import com.amplitude.core.platform.ObservePlugin
 
@@ -13,15 +14,22 @@ internal class AnalyticsConnectorIdentityPlugin : ObservePlugin() {
         super.setup(amplitude)
         val instanceName = amplitude.configuration.instanceName
         connector = AnalyticsConnector.getInstance(instanceName)
-        // Set user ID and device ID in core identity store for use in Experiment SDK
-        connector.identityStore.setIdentity(Identity(amplitude.store.userId, amplitude.store.deviceId))
+        // Set user ID and device ID in core identity store for use in Experiment SDK. The store is
+        // shared per instance name, so only the instance that owns the name may write it.
+        AmplitudeRegistry.runIfActive(amplitude) {
+            connector.identityStore.setIdentity(Identity(amplitude.store.userId, amplitude.store.deviceId))
+        }
     }
 
     override fun onUserIdChanged(userId: String?) {
-        connector.identityStore.editIdentity().setUserId(userId).commit()
+        AmplitudeRegistry.runIfActive(amplitude) {
+            connector.identityStore.editIdentity().setUserId(userId).commit()
+        }
     }
 
     override fun onDeviceIdChanged(deviceId: String?) {
-        connector.identityStore.editIdentity().setDeviceId(deviceId).commit()
+        AmplitudeRegistry.runIfActive(amplitude) {
+            connector.identityStore.editIdentity().setDeviceId(deviceId).commit()
+        }
     }
 }

--- a/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorPlugin.kt
@@ -7,7 +7,6 @@ import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
 import java.lang.ClassCastException
 import java.lang.ref.WeakReference
-import com.amplitude.android.Amplitude as AndroidAmplitude
 
 internal class AnalyticsConnectorPlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
@@ -19,9 +18,11 @@ internal class AnalyticsConnectorPlugin : Plugin {
         val instanceName = amplitude.configuration.instanceName
         connector = AnalyticsConnector.getInstance(instanceName)
 
-        // set up listener to core package to receive exposure events from Experiment
+        // set up listener to core package to receive exposure events from Experiment. The connector
+        // has one receiver per instance name, so a build that finishes after its instance was
+        // replaced must not take it from the replacement.
         val amplitudeRef = WeakReference(amplitude)
-        val installReceiver = {
+        AmplitudeRegistry.runIfActive(amplitude) {
             connector.eventBridge.setEventReceiver { (eventType, eventProperties, userProperties) ->
                 amplitudeRef.get()?.let { amplitude ->
                     val event = BaseEvent()
@@ -31,15 +32,6 @@ internal class AnalyticsConnectorPlugin : Plugin {
                     amplitude.track(event)
                 }
             }
-        }
-
-        // The connector has one receiver per instance name, so a build that finishes after its
-        // instance was replaced must not take it from the replacement.
-        val androidAmplitude = amplitude as? AndroidAmplitude
-        if (androidAmplitude != null) {
-            AmplitudeRegistry.runIfActive(androidAmplitude, installReceiver)
-        } else {
-            installReceiver()
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorPlugin.kt
@@ -1,11 +1,13 @@
 package com.amplitude.android.plugins
 
 import com.amplitude.analytics.connector.AnalyticsConnector
+import com.amplitude.android.AmplitudeRegistry
 import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
 import java.lang.ClassCastException
 import java.lang.ref.WeakReference
+import com.amplitude.android.Amplitude as AndroidAmplitude
 
 internal class AnalyticsConnectorPlugin : Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
@@ -19,14 +21,25 @@ internal class AnalyticsConnectorPlugin : Plugin {
 
         // set up listener to core package to receive exposure events from Experiment
         val amplitudeRef = WeakReference(amplitude)
-        connector.eventBridge.setEventReceiver { (eventType, eventProperties, userProperties) ->
-            amplitudeRef.get()?.let { amplitude ->
-                val event = BaseEvent()
-                event.eventType = eventType
-                event.eventProperties = eventProperties?.toMutableMap()
-                event.userProperties = userProperties?.toMutableMap()
-                amplitude.track(event)
+        val installReceiver = {
+            connector.eventBridge.setEventReceiver { (eventType, eventProperties, userProperties) ->
+                amplitudeRef.get()?.let { amplitude ->
+                    val event = BaseEvent()
+                    event.eventType = eventType
+                    event.eventProperties = eventProperties?.toMutableMap()
+                    event.userProperties = userProperties?.toMutableMap()
+                    amplitude.track(event)
+                }
             }
+        }
+
+        // The connector has one receiver per instance name, so a build that finishes after its
+        // instance was replaced must not take it from the replacement.
+        val androidAmplitude = amplitude as? AndroidAmplitude
+        if (androidAmplitude != null) {
+            AmplitudeRegistry.runIfActive(androidAmplitude, installReceiver)
+        } else {
+            installReceiver()
         }
     }
 

--- a/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorPlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AnalyticsConnectorPlugin.kt
@@ -50,9 +50,13 @@ internal class AnalyticsConnectorPlugin : Plugin {
                 }
             }
         }
-        connector.identityStore.editIdentity()
-            .updateUserProperties(userProperties)
-            .commit()
+        // A replaced instance still drains the events it accepted, but the connector's identity
+        // belongs to whichever instance owns the name now.
+        AmplitudeRegistry.runIfActive(amplitude) {
+            connector.identityStore.editIdentity()
+                .updateUserProperties(userProperties)
+                .commit()
+        }
 
         return event
     }

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
@@ -1,0 +1,382 @@
+package com.amplitude.android
+
+import android.app.Application
+import android.content.Context
+import android.net.ConnectivityManager
+import android.os.Looper
+import com.amplitude.MainDispatcherRule
+import com.amplitude.analytics.connector.AnalyticsConnector
+import com.amplitude.analytics.connector.AnalyticsEvent
+import com.amplitude.android.plugins.AndroidLifecyclePlugin
+import com.amplitude.android.utilities.FakeAndroidAmplitude
+import com.amplitude.android.utilities.createFakeAmplitude
+import com.amplitude.android.utilities.setupMockAndroidContext
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.platform.Plugin
+import com.amplitude.core.platform.UniversalPlugin
+import com.amplitude.core.utilities.ConsoleLoggerProvider
+import com.amplitude.core.utilities.InMemoryStorageProvider
+import com.amplitude.id.IMIdentityStorageProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.io.File
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+@ExperimentalCoroutinesApi
+@OptIn(GuardedAmplitudeFeature::class)
+@RunWith(RobolectricTestRunner::class)
+class AmplitudeReplacementTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val application = mockApplication()
+    private val registered = mutableListOf<Application.ActivityLifecycleCallbacks>()
+    private val unregistered = mutableListOf<Application.ActivityLifecycleCallbacks>()
+
+    init {
+        every { application.registerActivityLifecycleCallbacks(capture(registered)) } answers {}
+        every { application.unregisterActivityLifecycleCallbacks(capture(unregistered)) } answers {}
+    }
+
+    @Test
+    fun `newest instance with the same name takes over from the previous one`() =
+        runTest {
+            val first = createAmplitude("takeover")
+            advanceUntilIdle()
+
+            val second = createAmplitude("takeover")
+            advanceUntilIdle()
+
+            assertFalse(first.isActive)
+            assertTrue(second.isActive)
+            // Only the retired instance's own observer is unregistered.
+            assertEquals(1, unregistered.size)
+            assertSame(registered.first(), unregistered.first())
+        }
+
+    @Test
+    fun `instances with different names stay active`() =
+        runTest {
+            val first = createAmplitude("isolated-a")
+            val second = createAmplitude("isolated-b")
+            advanceUntilIdle()
+
+            assertTrue(first.isActive)
+            assertTrue(second.isActive)
+            assertTrue(unregistered.isEmpty())
+        }
+
+    @Test
+    fun `a retired instance stops tracking and cannot come back`() =
+        runTest {
+            val first = createAmplitude("retired-tracking")
+            val recorder = FakeEventPlugin()
+            first.add(recorder)
+            advanceUntilIdle()
+
+            first.track(BaseEvent().apply { eventType = "before" })
+            advanceUntilIdle()
+
+            createAmplitude("retired-tracking")
+            advanceUntilIdle()
+
+            first.track(BaseEvent().apply { eventType = "after" })
+            first.onEnterForeground(1_000L)
+            first.onExitForeground(2_000L)
+            advanceUntilIdle()
+
+            assertEquals(listOf("before"), recorder.trackedEvents.map { it.eventType })
+            assertFalse(first.isActive)
+        }
+
+    @Test
+    fun `a retired instance stops session activity while still draining events`() =
+        runTest {
+            val first =
+                createAmplitude("retired-sessions", autocapture = setOf(AutocaptureOption.SESSIONS))
+            val recorder = FakeEventPlugin()
+            first.add(recorder)
+            advanceUntilIdle()
+            val sessionIdBeforeRetirement = first.sessionId
+
+            // Both are queued before the replacement, so both still reach the retired timeline.
+            first.onEnterForeground(5_000L)
+            first.track(BaseEvent().apply { eventType = "queued" })
+            createAmplitude("retired-sessions")
+            advanceUntilIdle()
+
+            assertEquals(sessionIdBeforeRetirement, first.sessionId)
+            assertEquals(listOf("queued"), recorder.trackedEvents.map { it.eventType })
+        }
+
+    @Test
+    fun `a retired instance cannot rotate the identity it no longer owns`() =
+        runTest {
+            val first = createAmplitude("retired-identity")
+            advanceUntilIdle()
+            val deviceIdBeforeRetirement = first.getDeviceId()
+
+            createAmplitude("retired-identity")
+            advanceUntilIdle()
+
+            first.reset()
+            advanceUntilIdle()
+
+            assertEquals(deviceIdBeforeRetirement, first.getDeviceId())
+        }
+
+    @Test
+    fun `replacing an instance that is still building leaves it inert`() =
+        runTest {
+            // Never advanced before the replacement is created, so the build is still pending.
+            val first = createAmplitude("still-building")
+
+            val second = createAmplitude("still-building")
+            val recorder = FakeEventPlugin()
+            second.add(recorder)
+            advanceUntilIdle()
+
+            // The abandoned build installed nothing, so it owns no plugins, storage, or connector.
+            assertTrue(first.plugins(UniversalPlugin::class.java).isEmpty())
+            assertTrue(second.isActive)
+
+            second.track(BaseEvent().apply { eventType = "after-replacement" })
+            advanceUntilIdle()
+            assertEquals(listOf("after-replacement"), recorder.trackedEvents.map { it.eventType })
+        }
+
+    @Test
+    fun `does not wait for the previous instance's cleanup`() =
+        runTest {
+            val first = createAmplitude("blocked-cleanup")
+            advanceUntilIdle()
+            val teardowns = AtomicInteger()
+            first.add(CountingTeardownPlugin(teardowns))
+
+            val second = createAmplitude("blocked-cleanup")
+
+            // Nothing has run on the previous instance yet — its plugin teardown is still queued —
+            // and the replacement is already the active owner.
+            assertEquals(0, teardowns.get())
+            assertFalse(first.isActive)
+            assertTrue(second.isActive)
+            assertEquals(1, unregistered.size)
+
+            val recorder = FakeEventPlugin()
+            second.add(recorder)
+            second.track(BaseEvent().apply { eventType = "after-replacement" })
+            advanceUntilIdle()
+
+            assertEquals(listOf("after-replacement"), recorder.trackedEvents.map { it.eventType })
+            assertEquals(1, teardowns.get())
+        }
+
+    @Test
+    fun `a failed activation keeps the existing instance active`() =
+        runTest {
+            val first = createAmplitude("failed-activation")
+            val recorder = FakeEventPlugin()
+            first.add(recorder)
+            advanceUntilIdle()
+
+            every {
+                application.registerActivityLifecycleCallbacks(any())
+            } throws IllegalStateException("cannot register")
+
+            try {
+                createAmplitude("failed-activation")
+                fail("Expected the failed activation to propagate")
+            } catch (_: IllegalStateException) {
+                // expected
+            }
+            advanceUntilIdle()
+
+            assertTrue(first.isActive)
+            assertFalse(unregistered.contains(registered.single()))
+
+            first.track(BaseEvent().apply { eventType = "still-working" })
+            advanceUntilIdle()
+            assertEquals(listOf("still-working"), recorder.trackedEvents.map { it.eventType })
+
+            // The half-built instance is retired, so its build cannot take the connector receiver.
+            AnalyticsConnector.getInstance("failed-activation").eventBridge
+                .logEvent(AnalyticsEvent("\$exposure"))
+            advanceUntilIdle()
+            assertEquals(
+                listOf("still-working", "\$exposure"),
+                recorder.trackedEvents.map { it.eventType },
+            )
+        }
+
+    @Test
+    fun `connector events route to the newest instance after replacement`() =
+        runTest {
+            val first = createAmplitude(CONNECTOR_INSTANCE)
+            val firstRecorder = FakeEventPlugin()
+            first.add(firstRecorder)
+            advanceUntilIdle()
+
+            val second = createAmplitude(CONNECTOR_INSTANCE)
+            val secondRecorder = FakeEventPlugin()
+            second.add(secondRecorder)
+            advanceUntilIdle()
+
+            // Retiring the first instance must not clear the receiver the second one installed.
+            AnalyticsConnector.getInstance(CONNECTOR_INSTANCE).eventBridge
+                .logEvent(AnalyticsEvent("\$exposure"))
+            advanceUntilIdle()
+
+            assertEquals(listOf("\$exposure"), secondRecorder.trackedEvents.map { it.eventType })
+            assertTrue(firstRecorder.trackedEvents.isEmpty())
+        }
+
+    @Test
+    fun `events queued before the replacement still get processed`() =
+        runTest {
+            val first = createAmplitude("queued-events")
+            val recorder = FakeEventPlugin()
+            first.add(recorder)
+            advanceUntilIdle()
+
+            // Queued but not yet drained by the timeline when the replacement arrives.
+            first.track(BaseEvent().apply { eventType = "queued" })
+            createAmplitude("queued-events")
+            advanceUntilIdle()
+
+            // Drained through the plugins first, and only then are the plugins removed.
+            assertEquals(listOf("queued"), recorder.trackedEvents.map { it.eventType })
+            assertTrue(first.plugins(UniversalPlugin::class.java).isEmpty())
+        }
+
+    @Test
+    fun `concurrent construction leaves exactly one active instance`() =
+        runTest {
+            val configurations = List(4) { configuration("concurrent") }
+            val instances = mutableListOf<Amplitude>()
+            configurations
+                .map { config ->
+                    thread {
+                        val instance =
+                            FakeAndroidAmplitude(
+                                configuration = config,
+                                androidTestDispatcher = StandardTestDispatcher(testScheduler),
+                            )
+                        synchronized(instances) { instances += instance }
+                    }
+                }.forEach { it.join() }
+            advanceUntilIdle()
+
+            assertEquals(1, instances.count { it.isActive })
+            assertEquals(3, unregistered.size)
+        }
+
+    @Test
+    fun `retirement unregisters the instance's own callbacks and stops autocapture`() =
+        runTest {
+            val first =
+                createAmplitude(
+                    "autocapture-stop",
+                    autocapture = setOf(AutocaptureOption.ELEMENT_INTERACTIONS),
+                )
+            advanceUntilIdle()
+            shadowOf(Looper.getMainLooper()).idle()
+            val lifecyclePlugin = first.findPlugin<AndroidLifecyclePlugin>()
+            assertTrue(lifecyclePlugin != null)
+
+            createAmplitude("autocapture-stop")
+
+            // Both happen synchronously: autocapture must not wait on the event queue draining.
+            assertSame(registered.first(), unregistered.single())
+            assertTrue(lifecyclePlugin!!.eventJob!!.isCancelled)
+
+            advanceUntilIdle()
+            shadowOf(Looper.getMainLooper()).idle()
+        }
+
+    @Test
+    fun `only the active instance may claim shared state`() =
+        runTest {
+            val first = createAmplitude("ownership")
+            advanceUntilIdle()
+
+            var claimedByFirst = false
+            AmplitudeRegistry.runIfActive(first) { claimedByFirst = true }
+            assertTrue(claimedByFirst)
+
+            val second = createAmplitude("ownership")
+            advanceUntilIdle()
+
+            // A build that finishes after its instance was replaced must not claim anything.
+            claimedByFirst = false
+            AmplitudeRegistry.runIfActive(first) { claimedByFirst = true }
+            assertFalse(claimedByFirst)
+
+            var claimedBySecond = false
+            AmplitudeRegistry.runIfActive(second) { claimedBySecond = true }
+            assertTrue(claimedBySecond)
+        }
+
+    private fun TestScope.createAmplitude(
+        instanceName: String,
+        autocapture: Set<AutocaptureOption> = setOf(),
+    ) = createFakeAmplitude(
+        scheduler = testScheduler,
+        configuration = configuration(instanceName, autocapture),
+    )
+
+    private fun configuration(
+        instanceName: String,
+        autocapture: Set<AutocaptureOption> = setOf(),
+    ) = Configuration(
+        apiKey = "api-key",
+        context = application,
+        instanceName = instanceName,
+        autocapture = autocapture,
+        loggerProvider = ConsoleLoggerProvider(),
+        storageProvider = InMemoryStorageProvider(),
+        identifyInterceptStorageProvider = InMemoryStorageProvider(),
+        identityStorageProvider = IMIdentityStorageProvider(),
+    )
+
+    private fun mockApplication(): Application {
+        setupMockAndroidContext()
+        val context = mockk<Application>(relaxed = true)
+        val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
+        every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        val dirNameSlot = slot<String>()
+        every { context.getDir(capture(dirNameSlot), any()) } answers {
+            File("/tmp/amplitude-kotlin/${dirNameSlot.captured}")
+        }
+        return context
+    }
+
+    private companion object {
+        const val CONNECTOR_INSTANCE = "connector-handover"
+    }
+}
+
+private class CountingTeardownPlugin(private val teardowns: AtomicInteger) : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Enrichment
+    override lateinit var amplitude: com.amplitude.core.Amplitude
+
+    override fun teardown() {
+        teardowns.incrementAndGet()
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import com.amplitude.MainDispatcherRule
 import com.amplitude.analytics.connector.AnalyticsConnector
 import com.amplitude.analytics.connector.AnalyticsEvent
+import com.amplitude.analytics.connector.Identity
 import com.amplitude.android.plugins.AndroidLifecyclePlugin
 import com.amplitude.android.utilities.FakeAndroidAmplitude
 import com.amplitude.android.utilities.createFakeAmplitude
@@ -124,6 +125,33 @@ class AmplitudeReplacementTest {
 
             assertEquals(sessionIdBeforeRetirement, first.sessionId)
             assertEquals(listOf("queued"), recorder.trackedEvents.map { it.eventType })
+        }
+
+    @Test
+    fun `a retired instance does not update connector user properties while draining`() =
+        runTest {
+            val first = createAmplitude(CONNECTOR_PROPERTIES_INSTANCE)
+            advanceUntilIdle()
+
+            // Watch every commit: the replacement's own setup resets the identity, which would
+            // hide a stale write if we only looked at the final state.
+            val connector = AnalyticsConnector.getInstance(CONNECTOR_PROPERTIES_INSTANCE)
+            val updates = mutableListOf<Identity>()
+            val listener: (Identity) -> Unit = { updates += it }
+            connector.identityStore.addIdentityListener(listener)
+
+            // Queued before the replacement, so it drains through the retired instance's plugins.
+            first.track(
+                BaseEvent().apply {
+                    eventType = "queued"
+                    userProperties = mutableMapOf("\$set" to mapOf("plan" to "stale"))
+                },
+            )
+            createAmplitude(CONNECTOR_PROPERTIES_INSTANCE)
+            advanceUntilIdle()
+            connector.identityStore.removeIdentityListener(listener)
+
+            assertTrue(updates.none { it.userProperties.containsKey("plan") })
         }
 
     @Test
@@ -369,6 +397,7 @@ class AmplitudeReplacementTest {
 
     private companion object {
         const val CONNECTOR_INSTANCE = "connector-handover"
+        const val CONNECTOR_PROPERTIES_INSTANCE = "connector-user-properties"
     }
 }
 

--- a/android/src/test/kotlin/com/amplitude/android/internal/gestures/WindowCallbackManagerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/internal/gestures/WindowCallbackManagerTest.kt
@@ -12,6 +12,7 @@ import com.amplitude.android.internal.TrackFunction
 import com.amplitude.common.Logger
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -156,14 +157,62 @@ class WindowCallbackManagerTest {
         shadowOf(Looper.getMainLooper()).idle()
 
         // Wrap
+        val wrapper = slot<Window.Callback>()
+        every { window.callback = capture(wrapper) } answers {}
         sut.wrapWindowForTesting(window, decorView)
 
         // Simulate that window.callback returns our wrapper now
-        every { window.callback } returns mockk<AutocaptureWindowCallback>(relaxed = true)
+        every { window.callback } returns wrapper.captured
 
         // Unwrap
         sut.unwrapWindowForTesting(window)
 
         verify { window.callback = originalCallback }
     }
+
+    @Test
+    fun `leaves the chain alone when another manager wrapped on top`() {
+        val activity = mockk<Activity>(relaxed = true)
+        val window = mockk<Window>(relaxed = true)
+        val decorView = mockk<View>(relaxed = true)
+        val originalCallback = mockk<Window.Callback>(relaxed = true)
+
+        every { window.context } returns activity
+        every { window.callback } returns originalCallback
+        every { decorView.context } returns appContext
+
+        val first = newManager()
+        val second = newManager()
+        first.start()
+        second.start()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val firstWrapper = slot<Window.Callback>()
+        every { window.callback = capture(firstWrapper) } answers {}
+        first.wrapWindowForTesting(window, decorView)
+
+        // The second manager wraps the first manager's callback.
+        every { window.callback } returns firstWrapper.captured
+        val secondWrapper = slot<Window.Callback>()
+        every { window.callback = capture(secondWrapper) } answers {}
+        second.wrapWindowForTesting(window, decorView)
+        every { window.callback } returns secondWrapper.captured
+
+        first.unwrapWindowForTesting(window)
+
+        // Restoring the original here would drop the second manager's wrapper.
+        verify(exactly = 0) { window.callback = originalCallback }
+
+        // The first manager spliced itself out, so the second one restores the real original.
+        second.unwrapWindowForTesting(window)
+        verify { window.callback = originalCallback }
+    }
+
+    private fun newManager() =
+        WindowCallbackManager(
+            track = track,
+            frustrationDetector = null,
+            autocaptureStateProvider = { autocaptureState },
+            logger = logger,
+        )
 }


### PR DESCRIPTION
### Describe what this PR is addressing

If you create a second Android `Amplitude` with an `instanceName` that is already in use, the first one keeps running. The `Application` still holds the lifecycle callbacks it registered, so it keeps autocapturing, keeps starting sessions, and keeps owning the analytics connector. Creating a new instance with autocapture turned off does not stop the old one (SDK-171).

### Describe the solution

The rule: for one `Application` and instance name, only the newest instance does any work.

- `AmplitudeRegistry` remembers which instance owns each name. A new instance takes the name in `build()`, before its own setup starts, while holding one lock — so if two are created at once exactly one ends up owning the name, and if taking it fails, the instance already there keeps working.
- Taking over sets a flag on the old instance: from then on it will not accept events, start sessions, install plugins, or write to anything shared.
- The old instance immediately stops receiving Activity callbacks, stops accepting events, and stops autocapture. Its remaining plugins are removed once the events it already accepted have been processed, off the caller's thread.

Nothing waits on the old instance, so a stuck setup or a hanging plugin cannot hold up the new one. 

Where to start reading: `AmplitudeRegistry`, then `Amplitude.build` and `Amplitude.retire`, then the checks in `Timeline`. The first commit is a separate fix this one depends on — `WindowCallbackManager` unwrapped any `AutocaptureWindowCallback` it found, so stopping one instance's manager could remove another instance's wrapper.

No public API change and no api dump change.

### Steps to verify the change

- `./gradlew ktlintFormat :analytics-core:test :android:test apiCheck`
- `AmplitudeReplacementTest` (13 tests) covers replacing a same-name instance, leaving other names alone, a replaced instance going quiet, replacing one that is still setting up, not waiting for its cleanup, failing to take the name, connector ownership, events already queued, and two instances created at once.

### Useful links and documentation (optional)

- [SDK-171](https://linear.app/amplitude/issue/SDK-171)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change? No — no public API change, `apiCheck` passes. Behaviour does change for apps that relied on two same-name instances both staying active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core instance lifecycle and shared-by-name storage, sessions, and connector behavior (no public API change), but behavior breaks apps that depended on multiple same-name instances staying active; coverage is extensive in AmplitudeReplacementTest.
> 
> **Overview**
> Fixes **SDK-171**: creating a second Android `Amplitude` with the same `instanceName` no longer leaves the first instance running autocapture, sessions, and connector ownership.
> 
> **`AmplitudeRegistry`** makes the newest instance per name the sole owner (same `Application` only). Activation happens in `build()` before setup; the previous instance is **retired** without blocking the new one. Retired instances get `isActive == false`, drop new events, skip session side effects while draining the queue, cannot `reset()` shared identity, and bail out of in-flight `buildInternal`. Cleanup unregisters lifecycle callbacks, stops autocapture immediately, closes the timeline, then removes plugins asynchronously after the queue drains.
> 
> **`Timeline`** adds `close()` / `awaitDrained()` and gates `process()` and session handling on active ownership. **Analytics connector** identity and event-bridge setup/writes run only via `AmplitudeRegistry.runIfActive`.
> 
> **`WindowCallbackManager`** splices its wrapper out of a stacked callback chain when another manager wrapped on top, so retiring one instance does not strip another’s autocapture wrapper.
> 
> ProGuard adds `-keepnames` for `UniversalPlugin` implementations for readable retirement logs. **`AmplitudeReplacementTest`** (13 cases) covers takeover, concurrency, failed activation, connector routing, and queued-event drain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271b195882c08873c13ad1168acb38748dae8ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->