### PR TITLE
fix(android): stop network callbacks leaking Amplitude instances (SDKA-31)

### DIFF
--- a/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkCallback.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkCallback.kt
@@ -1,0 +1,136 @@
+package com.amplitude.android.utilities
+
+import android.Manifest.permission.ACCESS_NETWORK_STATE
+import android.net.ConnectivityManager
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
+import android.net.NetworkCapabilities.NET_CAPABILITY_VALIDATED
+import android.net.NetworkRequest
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import androidx.annotation.RequiresPermission
+import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Bridges [ConnectivityManager] network callbacks to a [AndroidNetworkListener.NetworkChangeCallback]
+ * held through a [WeakReference]. The system keeps registered callbacks strongly reachable, so a
+ * strong reference here would pin the delegate — and the Amplitude instance behind it — after the
+ * host app drops the instance without calling [AndroidNetworkListener.stopListening].
+ *
+ * The system also limits an app to 100 outstanding callbacks, so a callback whose delegate has
+ * been garbage collected frees its registration slot: on the next network event it receives, or
+ * when any new [AndroidNetworkListener] starts listening.
+ */
+internal class AndroidNetworkCallback(
+    delegate: AndroidNetworkListener.NetworkChangeCallback,
+    private val connectivityManager: ConnectivityManager,
+) : NetworkCallback() {
+    private val delegateRef = WeakReference(delegate)
+    private var _networkState: AndroidNetworkState? = null
+
+    /**
+     * Returns the tracked network state, or null if no network is tracked yet or the delegate
+     * was garbage collected (in which case this callback's registration is released).
+     */
+    private val networkState: AndroidNetworkState?
+        get() = networkChangeCallback?.let { _networkState }
+
+    /**
+     * The delegate, or null — after releasing this callback's registration — if the delegate,
+     * along with the Amplitude instance that owned it, was garbage collected.
+     */
+    private val networkChangeCallback: AndroidNetworkListener.NetworkChangeCallback?
+        get() =
+            delegateRef.get() ?: run {
+                safeUnregister()
+                null
+            }
+
+    /** Registers this callback with [ConnectivityManager] and starts tracking it. */
+    fun register(networkRequest: NetworkRequest) {
+        connectivityManager.registerNetworkCallback(networkRequest, this)
+        registeredCallbacks.add(this)
+    }
+
+    @RequiresPermission(ACCESS_NETWORK_STATE)
+    override fun onAvailable(network: Network) {
+        networkChangeCallback ?: return
+
+        // A default network is available; the new state notifies the delegate on creation
+        val capabilities = connectivityManager.getNetworkCapabilities(network)
+        _networkState =
+            AndroidNetworkState(
+                network = network,
+                delegateRef = delegateRef,
+                available = capabilities?.available() ?: true,
+                blocked = false,
+            )
+    }
+
+    override fun onUnavailable() {
+        // no network is found
+        networkChangeCallback?.onNetworkUnavailable()
+    }
+
+    override fun onLost(network: Network) {
+        networkState?.update(network, available = false)
+    }
+
+    override fun onCapabilitiesChanged(
+        network: Network,
+        networkCapabilities: NetworkCapabilities,
+    ) {
+        networkState?.update(network, available = networkCapabilities.available())
+    }
+
+    override fun onBlockedStatusChanged(
+        network: Network,
+        blocked: Boolean,
+    ) {
+        networkState?.update(network, blocked = blocked)
+    }
+
+    /** Unregisters this callback from [ConnectivityManager] and stops tracking it. */
+    fun unregister() {
+        registeredCallbacks.remove(this)
+        connectivityManager.unregisterNetworkCallback(this)
+    }
+
+    /** Unregisters, ignoring failures: already unregistered, or the system disallows it right now. */
+    private fun safeUnregister() =
+        runCatching {
+            unregister()
+        }
+
+    // Best attempt to check if the network is available
+    private fun NetworkCapabilities.available(): Boolean {
+        val validated =
+            if (VERSION.SDK_INT >= VERSION_CODES.M) {
+                hasCapability(NET_CAPABILITY_VALIDATED)
+            } else {
+                true
+            }
+        return validated && hasCapability(NET_CAPABILITY_INTERNET)
+    }
+
+    companion object {
+        /**
+         * Callbacks currently registered with [ConnectivityManager] by this process.
+         * Tracked so that registrations whose delegate was garbage collected can be swept
+         * eagerly on new registrations, instead of waiting for a network event to reach them.
+         */
+        private val registeredCallbacks = CopyOnWriteArrayList<AndroidNetworkCallback>()
+
+        /** Unregisters callbacks whose delegate has been garbage collected. */
+        fun unregisterAbandonedCallbacks() {
+            registeredCallbacks
+                .filter { it.delegateRef.get() == null }
+                .forEach {
+                    it.safeUnregister()
+                }
+        }
+    }
+}

--- a/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkCallback.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkCallback.kt
@@ -50,6 +50,7 @@ internal class AndroidNetworkCallback(
             }
 
     /** Registers this callback with [ConnectivityManager] and starts tracking it. */
+    @RequiresPermission(ACCESS_NETWORK_STATE)
     fun register(networkRequest: NetworkRequest) {
         connectivityManager.registerNetworkCallback(networkRequest, this)
         registeredCallbacks.add(this)

--- a/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkListener.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkListener.kt
@@ -4,15 +4,8 @@ import android.Manifest.permission.ACCESS_NETWORK_STATE
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.ConnectivityManager
-import android.net.ConnectivityManager.NetworkCallback
-import android.net.Network
-import android.net.NetworkCapabilities
 import android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET
-import android.net.NetworkCapabilities.NET_CAPABILITY_VALIDATED
 import android.net.NetworkRequest
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
-import androidx.annotation.RequiresPermission
 import androidx.annotation.VisibleForTesting
 import com.amplitude.android.utilities.AndroidNetworkConnectivityChecker.Companion.hasNetworkPermission
 import com.amplitude.common.Logger
@@ -25,7 +18,7 @@ public class AndroidNetworkListener(
     private val logger: Logger,
     private val networkCallback: NetworkChangeCallback,
 ) {
-    private var networkCallbackForApiLevel21Plus: NetworkCallback? = null
+    private var registeredNetworkCallback: AndroidNetworkCallback? = null
 
     public interface NetworkChangeCallback {
         public fun onNetworkAvailable()
@@ -58,79 +51,30 @@ public class AndroidNetworkListener(
     @SuppressLint("MissingPermission")
     @VisibleForTesting
     internal fun setupNetworkCallback() {
+        if (registeredNetworkCallback != null) return
+
         val connectivityManager =
             context
                 .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        // Free the registration slots of callbacks whose owner was garbage collected
+        // before consuming a new one.
+        AndroidNetworkCallback.unregisterAbandonedCallbacks()
         val networkRequest =
             NetworkRequest.Builder()
                 .addCapability(NET_CAPABILITY_INTERNET)
                 .build()
 
-        networkCallbackForApiLevel21Plus =
-            object : NetworkCallback() {
-                private var networkState: NetworkState? = null
-
-                @RequiresPermission(ACCESS_NETWORK_STATE)
-                override fun onAvailable(network: Network) {
-                    // A default network is available, set the network state and callback
-                    val capabilities = connectivityManager.getNetworkCapabilities(network)
-                    networkState =
-                        NetworkState(
-                            network = network,
-                            networkCallback = networkCallback,
-                            available = capabilities?.available() ?: true,
-                            blocked = false,
-                        )
-                }
-
-                override fun onUnavailable() {
-                    // no network is found
-                    networkCallback.onNetworkUnavailable()
-                }
-
-                override fun onLost(network: Network) {
-                    networkState?.update(network, available = false)
-                }
-
-                override fun onCapabilitiesChanged(
-                    network: Network,
-                    networkCapabilities: NetworkCapabilities,
-                ) {
-                    networkState?.update(network, available = networkCapabilities.available())
-                }
-
-                override fun onBlockedStatusChanged(
-                    network: Network,
-                    blocked: Boolean,
-                ) {
-                    networkState?.update(network, blocked = blocked)
-                }
-
-                // Best attempt to check if the network is available
-                private fun NetworkCapabilities.available(): Boolean {
-                    val validated =
-                        if (VERSION.SDK_INT >= VERSION_CODES.M) {
-                            hasCapability(NET_CAPABILITY_VALIDATED)
-                        } else {
-                            true
-                        }
-                    return hasCapability(NET_CAPABILITY_INTERNET) && validated
-                }
-            }.also { callback ->
-                connectivityManager.registerNetworkCallback(
-                    networkRequest,
-                    callback,
-                )
+        registeredNetworkCallback =
+            AndroidNetworkCallback(networkCallback, connectivityManager).also { callback ->
+                callback.register(networkRequest)
             }
     }
 
     public fun stopListening() {
+        val callback = registeredNetworkCallback ?: return
+        registeredNetworkCallback = null
         try {
-            val connectivityManager =
-                context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            networkCallbackForApiLevel21Plus?.let {
-                connectivityManager.unregisterNetworkCallback(it)
-            }
+            callback.unregister()
         } catch (e: IllegalArgumentException) {
             // callback was already unregistered.
         } catch (e: IllegalStateException) {
@@ -143,54 +87,6 @@ public class AndroidNetworkListener(
             // https://github.com/amplitude/Amplitude-Kotlin/issues/220
             // https://github.com/amplitude/Amplitude-Kotlin/issues/197
             logger.warn("Error stopping network listener: ${throwable.message}")
-        }
-    }
-
-    /**
-     * NetworkState is used to track the state of a network connection.
-     * It considers the availability and blocked status of the network before notifying the callback.
-     *
-     * On initialization, it checks if the network is available and not blocked.
-     */
-    private class NetworkState(
-        private val network: Network,
-        private val networkCallback: NetworkChangeCallback,
-        private var available: Boolean,
-        private var blocked: Boolean,
-    ) {
-        init {
-            notifyNetworkCallback()
-        }
-
-        /**
-         * Notify the network callback based on the current state of the network.
-         * Ideally called only when the state changes (e.g. initialized, available or blocked toggled).
-         */
-        private fun notifyNetworkCallback() {
-            if (available && !blocked) {
-                networkCallback.onNetworkAvailable()
-            } else {
-                networkCallback.onNetworkUnavailable()
-            }
-        }
-
-        /**
-         * Update the availability/blocked state and notify the callback if necessary.
-         * Checks if we're on the same network, else just ignore.
-         */
-        fun update(
-            network: Network,
-            available: Boolean = this.available,
-            blocked: Boolean = this.blocked,
-        ) {
-            if (this.network != network) return
-            val toggled = this.available != available || this.blocked != blocked
-            this.available = available
-            this.blocked = blocked
-
-            if (toggled) {
-                notifyNetworkCallback()
-            }
         }
     }
 }

--- a/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkState.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/AndroidNetworkState.kt
@@ -1,0 +1,50 @@
+package com.amplitude.android.utilities
+
+import android.net.Network
+import java.lang.ref.WeakReference
+
+/**
+ * AndroidNetworkState is used to track the state of a network connection.
+ * It considers the availability and blocked status of the network before notifying the delegate.
+ *
+ * On initialization and whenever an update toggles the connected state, it notifies the delegate.
+ * The delegate is held through a [WeakReference] (shared with [AndroidNetworkCallback]) so this
+ * state cannot pin an abandoned Amplitude instance.
+ */
+internal class AndroidNetworkState(
+    private val network: Network,
+    private val delegateRef: WeakReference<AndroidNetworkListener.NetworkChangeCallback>,
+    private var available: Boolean,
+    private var blocked: Boolean,
+) {
+    init {
+        notifyDelegate()
+    }
+
+    /**
+     * Update the availability/blocked state and notify the delegate if the connected state
+     * toggled. Updates for other networks are ignored.
+     */
+    fun update(
+        network: Network,
+        available: Boolean = this.available,
+        blocked: Boolean = this.blocked,
+    ) {
+        if (this.network != network) return
+        val toggled = this.available != available || this.blocked != blocked
+        this.available = available
+        this.blocked = blocked
+        if (toggled) {
+            notifyDelegate()
+        }
+    }
+
+    private fun notifyDelegate() {
+        val delegate = delegateRef.get() ?: return
+        if (available && !blocked) {
+            delegate.onNetworkAvailable()
+        } else {
+            delegate.onNetworkUnavailable()
+        }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/plugins/AndroidNetworkConnectivityCheckerPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/plugins/AndroidNetworkConnectivityCheckerPluginTest.kt
@@ -50,10 +50,11 @@ class AndroidNetworkConnectivityCheckerPluginTest {
     fun `should teardown correctly`() {
         plugin.setup(amplitude)
         assertNotNull(plugin.networkListener)
-        plugin.networkListener.let { networkListener ->
-            spyk(networkListener)
-            plugin.teardown()
-            verify { networkListener.stopListening() }
-        }
+        val networkListener = spyk(plugin.networkListener)
+        plugin.networkListener = networkListener
+
+        plugin.teardown()
+
+        verify { networkListener.stopListening() }
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkCallbackTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkCallbackTest.kt
@@ -1,0 +1,153 @@
+package com.amplitude.android.utilities
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import java.lang.ref.WeakReference
+
+class AndroidNetworkCallbackTest {
+    private val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
+    private val network = mockk<Network>()
+    private val delegate = RecordingNetworkChangeCallback()
+    private val callback = AndroidNetworkCallback(delegate, connectivityManager)
+
+    @Test
+    fun `register should register with the connectivity manager`() {
+        val networkRequest = mockk<NetworkRequest>()
+
+        callback.register(networkRequest)
+
+        verify { connectivityManager.registerNetworkCallback(networkRequest, callback) }
+    }
+
+    @Test
+    fun `unregister should unregister from the connectivity manager`() {
+        callback.register(mockk())
+
+        callback.unregister()
+
+        verify { connectivityManager.unregisterNetworkCallback(callback) }
+    }
+
+    @Test
+    fun `onAvailable should notify the delegate based on capabilities`() {
+        every { connectivityManager.getNetworkCapabilities(network) } returns capabilities(internet = true)
+
+        callback.onAvailable(network)
+
+        assertEquals(listOf(true), delegate.notifications)
+    }
+
+    @Test
+    fun `onAvailable should notify unavailable when capabilities lack internet`() {
+        every { connectivityManager.getNetworkCapabilities(network) } returns capabilities(internet = false)
+
+        callback.onAvailable(network)
+
+        assertEquals(listOf(false), delegate.notifications)
+    }
+
+    @Test
+    fun `onAvailable should assume available when capabilities are unknown`() {
+        every { connectivityManager.getNetworkCapabilities(network) } returns null
+
+        callback.onAvailable(network)
+
+        assertEquals(listOf(true), delegate.notifications)
+    }
+
+    @Test
+    fun `onUnavailable should notify the delegate`() {
+        callback.onUnavailable()
+
+        assertEquals(listOf(false), delegate.notifications)
+    }
+
+    @Test
+    fun `onLost should notify the delegate for the tracked network`() {
+        every { connectivityManager.getNetworkCapabilities(network) } returns capabilities(internet = true)
+        callback.onAvailable(network)
+
+        callback.onLost(network)
+
+        assertEquals(listOf(true, false), delegate.notifications)
+    }
+
+    @Test
+    fun `events before onAvailable should be ignored`() {
+        callback.onLost(network)
+        callback.onCapabilitiesChanged(network, capabilities(internet = true))
+        callback.onBlockedStatusChanged(network, true)
+
+        assertEquals(emptyList<Boolean>(), delegate.notifications)
+    }
+
+    @Test
+    fun `network event should unregister the callback when the delegate is collected`() {
+        val (abandonedCallback, delegateRef) = registerAndAbandonCallback()
+
+        awaitCollected(delegateRef)
+        abandonedCallback.onUnavailable()
+
+        verify { connectivityManager.unregisterNetworkCallback(abandonedCallback) }
+    }
+
+    @Test
+    fun `unregisterAbandonedCallbacks should unregister only collected delegates`() {
+        val liveCallback = AndroidNetworkCallback(delegate, connectivityManager)
+        liveCallback.register(mockk())
+        val (abandonedCallback, delegateRef) = registerAndAbandonCallback()
+
+        awaitCollected(delegateRef)
+        AndroidNetworkCallback.unregisterAbandonedCallbacks()
+
+        verify { connectivityManager.unregisterNetworkCallback(abandonedCallback) }
+        verify(exactly = 0) { connectivityManager.unregisterNetworkCallback(liveCallback) }
+    }
+
+    /**
+     * Registers a callback whose delegate has no remaining strong references, simulating
+     * an abandoned Amplitude instance.
+     */
+    private fun registerAndAbandonCallback(): Pair<AndroidNetworkCallback, WeakReference<AndroidNetworkListener.NetworkChangeCallback>> {
+        val abandonedDelegate = RecordingNetworkChangeCallback()
+        val abandonedCallback = AndroidNetworkCallback(abandonedDelegate, connectivityManager)
+        abandonedCallback.register(mockk())
+        return abandonedCallback to WeakReference(abandonedDelegate)
+    }
+
+    private fun awaitCollected(ref: WeakReference<*>) {
+        repeat(100) {
+            if (ref.get() == null) return
+            System.gc()
+            Thread.sleep(10)
+        }
+        fail<Unit>("Reference was not garbage collected")
+    }
+
+    private fun capabilities(internet: Boolean): NetworkCapabilities =
+        mockk {
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) } returns internet
+            every { hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) } returns internet
+        }
+
+    private class RecordingNetworkChangeCallback : AndroidNetworkListener.NetworkChangeCallback {
+        /** One entry per notification: true for available, false for unavailable. */
+        val notifications = mutableListOf<Boolean>()
+
+        override fun onNetworkAvailable() {
+            notifications.add(true)
+        }
+
+        override fun onNetworkUnavailable() {
+            notifications.add(false)
+        }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkListenerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkListenerTest.kt
@@ -15,6 +15,8 @@ import io.mockk.verify
 import org.junit.Before
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import java.lang.ref.WeakReference
 import kotlin.test.Test
 
 class AndroidNetworkListenerTest {
@@ -117,4 +119,211 @@ class AndroidNetworkListenerTest {
         networkCallback.onUnavailable()
         assertFalse(networkChangeCallback.available)
     }
+
+    @Test
+    fun `stop listening should unregister the network callback`() {
+        val networkListener =
+            AndroidNetworkListener(
+                context = fakeContext,
+                logger = fakeLogger,
+                networkCallback = noopNetworkChangeCallback(),
+            )
+
+        networkListener.setupNetworkCallback()
+        val networkCallbackSlot = slot<NetworkCallback>()
+        verify {
+            fakeConnectivityManager.registerNetworkCallback(
+                any<NetworkRequest>(),
+                capture(networkCallbackSlot),
+            )
+        }
+
+        networkListener.stopListening()
+
+        verify {
+            fakeConnectivityManager.unregisterNetworkCallback(networkCallbackSlot.captured)
+        }
+    }
+
+    @Test
+    fun `stop listening twice should unregister only once`() {
+        val networkListener =
+            AndroidNetworkListener(
+                context = fakeContext,
+                logger = fakeLogger,
+                networkCallback = noopNetworkChangeCallback(),
+            )
+        networkListener.setupNetworkCallback()
+
+        networkListener.stopListening()
+        networkListener.stopListening()
+
+        verify(exactly = 1) {
+            fakeConnectivityManager.unregisterNetworkCallback(any<NetworkCallback>())
+        }
+    }
+
+    @Test
+    fun `setup after stop should register again`() {
+        val networkListener =
+            AndroidNetworkListener(
+                context = fakeContext,
+                logger = fakeLogger,
+                networkCallback = noopNetworkChangeCallback(),
+            )
+
+        networkListener.setupNetworkCallback()
+        networkListener.stopListening()
+        networkListener.setupNetworkCallback()
+
+        verify(exactly = 2) {
+            fakeConnectivityManager.registerNetworkCallback(
+                any<NetworkRequest>(),
+                any<NetworkCallback>(),
+            )
+        }
+    }
+
+    @Test
+    fun `setup network callback twice should register only once`() {
+        val networkListener =
+            AndroidNetworkListener(
+                context = fakeContext,
+                logger = fakeLogger,
+                networkCallback = noopNetworkChangeCallback(),
+            )
+
+        networkListener.setupNetworkCallback()
+        networkListener.setupNetworkCallback()
+
+        verify(exactly = 1) {
+            fakeConnectivityManager.registerNetworkCallback(
+                any<NetworkRequest>(),
+                any<NetworkCallback>(),
+            )
+        }
+    }
+
+    @Test
+    fun `registered network callback should not pin a garbage collected listener`() {
+        val (registeredCallback, delegateRef) = registerAndAbandonListener()
+
+        awaitCollected(delegateRef)
+
+        // The first event after collection should release the system registration
+        // without notifying anyone.
+        registeredCallback.onAvailable(mockk(relaxed = true))
+
+        verify {
+            fakeConnectivityManager.unregisterNetworkCallback(registeredCallback)
+        }
+    }
+
+    @Test
+    fun `starting a new listener should unregister abandoned network callbacks`() {
+        val (abandonedCallback, delegateRef) = registerAndAbandonListener()
+
+        awaitCollected(delegateRef)
+
+        val networkListener =
+            AndroidNetworkListener(
+                context = fakeContext,
+                logger = fakeLogger,
+                networkCallback = noopNetworkChangeCallback(),
+            )
+        networkListener.setupNetworkCallback()
+
+        verify {
+            fakeConnectivityManager.unregisterNetworkCallback(abandonedCallback)
+        }
+    }
+
+    @Test
+    fun `starting a new listener should not unregister callbacks of live listeners`() {
+        val liveNetworkChangeCallback = noopNetworkChangeCallback()
+        val liveListener =
+            AndroidNetworkListener(
+                context = fakeContext,
+                logger = fakeLogger,
+                networkCallback = liveNetworkChangeCallback,
+            )
+        liveListener.setupNetworkCallback()
+        val liveCallback = lastRegisteredNetworkCallback()
+
+        val (abandonedCallback, delegateRef) = registerAndAbandonListener()
+        awaitCollected(delegateRef)
+
+        val newListener =
+            AndroidNetworkListener(
+                context = fakeContext,
+                logger = fakeLogger,
+                networkCallback = noopNetworkChangeCallback(),
+            )
+        newListener.setupNetworkCallback()
+
+        // The sweep frees only the abandoned registration, sparing the live one.
+        verify {
+            fakeConnectivityManager.unregisterNetworkCallback(abandonedCallback)
+        }
+        verify(exactly = 0) {
+            fakeConnectivityManager.unregisterNetworkCallback(liveCallback)
+        }
+        liveListener.stopListening()
+        verify(exactly = 1) {
+            fakeConnectivityManager.unregisterNetworkCallback(liveCallback)
+        }
+    }
+
+    /**
+     * Registers a listener and drops every strong reference to it and its
+     * [AndroidNetworkListener.NetworkChangeCallback], simulating an app abandoning an
+     * Amplitude instance without calling [AndroidNetworkListener.stopListening].
+     */
+    private fun registerAndAbandonListener(): Pair<NetworkCallback, WeakReference<AndroidNetworkListener.NetworkChangeCallback>> {
+        val networkChangeCallback =
+            object : AndroidNetworkListener.NetworkChangeCallback {
+                override fun onNetworkAvailable() {
+                    fail<Unit>("Collected delegate should not be notified")
+                }
+
+                override fun onNetworkUnavailable() {
+                    fail<Unit>("Collected delegate should not be notified")
+                }
+            }
+        val networkListener =
+            AndroidNetworkListener(
+                context = fakeContext,
+                logger = fakeLogger,
+                networkCallback = networkChangeCallback,
+            )
+        networkListener.setupNetworkCallback()
+        return lastRegisteredNetworkCallback() to WeakReference(networkChangeCallback)
+    }
+
+    private fun lastRegisteredNetworkCallback(): NetworkCallback {
+        val capturedCallbacks = mutableListOf<NetworkCallback>()
+        verify {
+            fakeConnectivityManager.registerNetworkCallback(
+                any<NetworkRequest>(),
+                capture(capturedCallbacks),
+            )
+        }
+        return capturedCallbacks.last()
+    }
+
+    private fun awaitCollected(ref: WeakReference<*>) {
+        repeat(100) {
+            if (ref.get() == null) return
+            System.gc()
+            Thread.sleep(10)
+        }
+        fail<Unit>("Reference was not garbage collected")
+    }
+
+    private fun noopNetworkChangeCallback() =
+        object : AndroidNetworkListener.NetworkChangeCallback {
+            override fun onNetworkAvailable() {}
+
+            override fun onNetworkUnavailable() {}
+        }
 }

--- a/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkStateTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/AndroidNetworkStateTest.kt
@@ -1,0 +1,97 @@
+package com.amplitude.android.utilities
+
+import android.net.Network
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.lang.ref.WeakReference
+
+class AndroidNetworkStateTest {
+    private val network = mockk<Network>()
+    private val otherNetwork = mockk<Network>()
+    private val delegate = RecordingNetworkChangeCallback()
+    private val delegateRef =
+        WeakReference<AndroidNetworkListener.NetworkChangeCallback>(delegate)
+
+    @Test
+    fun `creation should notify available when available and not blocked`() {
+        AndroidNetworkState(network, delegateRef, available = true, blocked = false)
+
+        assertEquals(listOf(true), delegate.notifications)
+    }
+
+    @Test
+    fun `creation should notify unavailable when not available`() {
+        AndroidNetworkState(network, delegateRef, available = false, blocked = false)
+
+        assertEquals(listOf(false), delegate.notifications)
+    }
+
+    @Test
+    fun `creation should notify unavailable when blocked`() {
+        AndroidNetworkState(network, delegateRef, available = true, blocked = true)
+
+        assertEquals(listOf(false), delegate.notifications)
+    }
+
+    @Test
+    fun `update should notify when availability toggles`() {
+        val state = AndroidNetworkState(network, delegateRef, available = true, blocked = false)
+
+        state.update(network, available = false)
+        state.update(network, available = true)
+
+        assertEquals(listOf(true, false, true), delegate.notifications)
+    }
+
+    @Test
+    fun `update should notify when blocked toggles`() {
+        val state = AndroidNetworkState(network, delegateRef, available = true, blocked = false)
+
+        state.update(network, blocked = true)
+        state.update(network, blocked = false)
+
+        assertEquals(listOf(true, false, true), delegate.notifications)
+    }
+
+    @Test
+    fun `update should not notify when nothing toggles`() {
+        val state = AndroidNetworkState(network, delegateRef, available = true, blocked = false)
+
+        state.update(network, available = true, blocked = false)
+
+        assertEquals(listOf(true), delegate.notifications)
+    }
+
+    @Test
+    fun `update should ignore other networks`() {
+        val state = AndroidNetworkState(network, delegateRef, available = true, blocked = false)
+
+        state.update(otherNetwork, available = false)
+
+        assertEquals(listOf(true), delegate.notifications)
+    }
+
+    @Test
+    fun `update should not notify a collected delegate`() {
+        val state = AndroidNetworkState(network, delegateRef, available = true, blocked = false)
+
+        delegateRef.clear()
+        state.update(network, available = false)
+
+        assertEquals(listOf(true), delegate.notifications)
+    }
+
+    private class RecordingNetworkChangeCallback : AndroidNetworkListener.NetworkChangeCallback {
+        /** One entry per notification: true for available, false for unavailable. */
+        val notifications = mutableListOf<Boolean>()
+
+        override fun onNetworkAvailable() {
+            notifications.add(true)
+        }
+
+        override fun onNetworkUnavailable() {
+            notifications.add(false)
+        }
+    }
+}


### PR DESCRIPTION
### Describe what this PR is addressing

Fixes #236. The `ConnectivityManager.NetworkCallback` registered by `AndroidNetworkListener` had two problems:

1. **Memory leak** — the callback strongly referenced the `NetworkChangeCallback`, which holds the entire `Amplitude` instance. Since `ConnectivityManager` keeps registered callbacks strongly reachable until unregistered, an abandoned instance could never be garbage collected (the one system registration missed by #425).
2. **Callback quota exhaustion** — `unregisterNetworkCallback()` was never called in practice: plugin `teardown()` only runs on explicit `remove(plugin)`, which apps don't call. Each abandoned instance permanently consumed one of the app's 100 network-callback slots, eventually causing `TooManyRequestsException` for the host app and other SDKs.

Linear: [SDKA-31](https://linear.app/amplitude/issue/SDKA-31/kotlin-sdk-connectivitymanager-network-callback-leaks-amplitude)

### Describe the solution

* Extracted the anonymous callback into `AndroidNetworkCallback`, which holds the delegate through a `WeakReference` — the system side can no longer pin an Amplitude instance.
* A callback whose delegate has been collected frees its registration slot two ways: it self-unregisters on the next network event it receives, and every new `startListening()` sweeps a registry of live registrations (covers the "new instance per `track()`" misuse from the issue without waiting for a network event).
* `stopListening()` remains the deterministic path and is now idempotent; `startListening()` guards double registration.
* `AndroidNetworkState` (renamed from the nested `NetworkState`) shares the same `WeakReference` and notifies implicitly on creation and on toggles; each class now lives in its own file.
* Kept the catch-all in `startListening()` rather than rethrowing `TooManyRequestsException`: crashing host apps from an analytics SDK is worse than degraded offline detection, and with this fix the SDK no longer fills the quota.

No public API changes (`apiCheck` passes; new classes are `internal`).

### Steps to verify the change

* `./gradlew :android:test :android:apiCheck :android:ktlintCheck` — all green.
* New unit tests: `AndroidNetworkCallbackTest` and `AndroidNetworkStateTest` cover the bridge and the state machine; `AndroidNetworkListenerTest` adds GC-based end-to-end tests proving an abandoned listener's delegate is collectable and its registration is released, plus sweep selectivity (live callbacks are spared), stop idempotency, and re-setup after stop.
* Key regressions were mutation-tested: dropping the sweep's collected-delegate guard or the `stopListening()` null-out fails the new tests.

### Useful links and documentation (optional)

* https://github.com/amplitude/Amplitude-Kotlin/issues/236
* [`ConnectivityManager.registerNetworkCallback` docs](https://developer.android.com/reference/android/net/ConnectivityManager#registerNetworkCallback(android.net.NetworkRequest,%20android.net.ConnectivityManager.NetworkCallback)) — 100-callback limit
* Prior art: #425 (same weak-reference pattern for other system-held references)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<details>
<summary>AI Prompt</summary>

From GitHub issue #236, two issues to solve while keeping the architecture of AndroidNetworkListener clean: (1) a memory leak in AndroidNetworkListener.setupNetworkCallback() — the callback passed to registerNetworkCallback leaks the entire Amplitude instance; (2) ConnectivityManager.unregisterNetworkCallback() is never called, so if the Amplitude instance is released and recreated, the ConnectivityManager approaches its quota of 100 simultaneous callbacks.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches offline detection and ConnectivityManager registration lifecycle; behavior is intended to match prior logic but incorrect cleanup could miss network events or unregister live callbacks.
> 
> **Overview**
> Fixes **memory leaks** and **`ConnectivityManager`’s 100-callback limit** when apps abandon `Amplitude` without tearing down the network listener.
> 
> Network handling is split into **`AndroidNetworkCallback`** and **`AndroidNetworkState`**, both holding the app delegate via **`WeakReference`** so a registered system callback no longer pins the `Amplitude` instance. When the delegate is collected, the callback **unregisters itself** on the next network event; **`unregisterAbandonedCallbacks()`** runs on each new **`setupNetworkCallback()`** so slots are reclaimed without waiting for connectivity changes.
> 
> **`AndroidNetworkListener`** now delegates registration to **`AndroidNetworkCallback`**, skips duplicate setup, and makes **`stopListening()`** idempotent by clearing the registered callback before unregistering. Behavior for live listeners is unchanged; new unit tests cover GC abandonment, sweep selectivity, and stop/setup lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ade49b9cff5b0ea9f8a70ca4597c2113a4630705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->