### PR TITLE
ci: add Dependabot config with grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,95 @@
+# Dependabot configuration.
+#
+# Grouping is scoped by blast radius: anything that only affects CI, the release
+# automation, or the test suite is collapsed into one PR, while anything a
+# consumer resolves from the published POM keeps its own reviewable PR.
+version: 2
+updates:
+  # ---------------------------------------------------------------------------
+  # JavaScript — the semantic-release toolchain behind
+  # `.github/workflows/release.yml`. None of it ships in the Maven artifacts.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      # The semantic-release core and its plugins have interlocking peer ranges
+      # and must move together, so everything here belongs in one PR — majors
+      # included.
+      release-tooling:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      release-tooling-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions — CI only. Actions are SHA-pinned; Dependabot rewrites both
+  # the SHA and the trailing version comment.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "ci(deps)"
+    labels:
+      - dependencies
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # Gradle — reads `gradle/libs.versions.toml`.
+  #
+  # Only test tooling is grouped. Consumer-visible dependencies (coroutines,
+  # core-ktx, activity-ktx, curtains, analytics-connector, okhttp, org.json) land
+  # in the published POM or can move the API dump, so each keeps its own PR.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+    ignore:
+      # `kotlinCompilerExtension` is hand-pinned to match `kotlin`, and Kotlin 2.x
+      # folds the Compose compiler into the Kotlin plugin — a bot bump cannot
+      # land on its own. Bump Kotlin deliberately instead.
+      #
+      # These are deliberately not written as `org.jetbrains.kotlin*`, which
+      # would also swallow `org.jetbrains.kotlinx` coroutines updates.
+      - dependency-name: "org.jetbrains.kotlin:*"
+      - dependency-name: "org.jetbrains.kotlin.android:*"
+      - dependency-name: "org.jetbrains.kotlin.jvm:*"
+    groups:
+      test-tooling:
+        applies-to: version-updates
+        patterns:
+          - "org.junit:*" # junit-bom
+          - "org.junit.jupiter:*"
+          - "org.junit.vintage:*"
+          - "junit:junit"
+          - "io.mockk:*"
+          - "org.robolectric:*"
+          - "androidx.test*" # androidx.test, .ext, .espresso
+          - "com.squareup.okhttp3:mockwebserver" # not okhttp itself — that ships

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,11 +76,15 @@ updates:
       # folds the Compose compiler into the Kotlin plugin — a bot bump cannot
       # land on its own. Bump Kotlin deliberately instead.
       #
-      # These are deliberately not written as `org.jetbrains.kotlin*`, which
-      # would also swallow `org.jetbrains.kotlinx` coroutines updates.
+      # Libraries are named `group:artifact`, but Gradle plugins are named by
+      # bare plugin id (dependabot-core names a plugin dependency `name` alone,
+      # not `group:name`), so the plugin entries carry no colon and no wildcard.
+      #
+      # Deliberately not `org.jetbrains.kotlin*`, which would also swallow
+      # `org.jetbrains.kotlinx` coroutines updates.
       - dependency-name: "org.jetbrains.kotlin:*"
-      - dependency-name: "org.jetbrains.kotlin.android:*"
-      - dependency-name: "org.jetbrains.kotlin.jvm:*"
+      - dependency-name: "org.jetbrains.kotlin.android"
+      - dependency-name: "org.jetbrains.kotlin.jvm"
     groups:
       test-tooling:
         applies-to: version-updates


### PR DESCRIPTION
### Describe what this PR is addressing

There is no `dependabot.yml` in this repo, so only GitHub's automatic security updates run — and they arrive one PR per dependency. Six are open right now (#369, #378, #379, #380, #384, #385), every one of them bumping a dependency of the semantic-release toolchain behind `release.yml`. None of that JavaScript ships in the published Maven artifacts, so it is release-tooling hygiene competing for review attention with SDK changes.

Separately, `#369` shows why one-at-a-time PRs don't work for this toolchain: it bumps `semantic-release` 17 → 25 but leaves `@semantic-release/changelog` at 5.0.1, whose peer range caps at `semantic-release <18`. The pieces only move together.

### Describe the solution

Groups updates by blast radius — anything that only touches CI, release automation, or tests collapses into one PR; anything a consumer resolves from the published POM keeps its own reviewable PR.

- **npm** — one group, majors included, because the interlocking peer ranges mean partial upgrades don't install.
- **github-actions** — one group. CI-only, SHA-pinned; Dependabot rewrites both the SHA and the version comment.
- **gradle** — new ecosystem for this repo. Dependabot reads `gradle/libs.versions.toml` directly (no Gradle execution). Only `test-tooling` is grouped. Coroutines, `core-ktx`, `activity-ktx`, `curtains`, `analytics-connector`, `okhttp`, and `org.json` stay ungrouped so each bump can be reviewed against `apiCheck` and consumer resolution on its own.

Two decisions worth calling out:

- **Kotlin is ignored.** `kotlinCompilerExtension` is hand-pinned to match `kotlin`, and Kotlin 2.x folds the Compose compiler into the Kotlin plugin, so a bot-authored Kotlin bump cannot build on its own. The patterns are spelled out per-coordinate instead of `org.jetbrains.kotlin*`, which would also silently swallow `org.jetbrains.kotlinx` coroutines updates.
- **No `test-tooling-security` group.** It would be dead config: the dependency graph currently contains zero Gradle packages (548 npm, 6 actions, 0 Maven), because GitHub does not statically parse Gradle files — that data only arrives via the Dependency Submission API. Until that is enabled, Gradle security updates cannot fire at all. Tracked as follow-up, not fixed here.

Expect a first-run burst on the gradle ecosystem: everything outside `test-tooling` gets an individual PR, throttled by `open-pull-requests-limit: 5`. Adding `build-plugins` and `sample-app` groups later would settle it.

### Steps to verify the change

This is config with no build surface, so verification is behavioral rather than a test run:

1. Config parses as valid YAML and matches the documented schema (`version: 2`, one entry per ecosystem, one `applies-to` per group).
2. Merging to `main` triggers a Dependabot run automatically ("Dependabot also runs an update on subsequent changes to the configuration file") — no manual trigger needed. Watch Insights → Dependency graph → Dependabot for the run.
3. Expect a single `release-tooling` npm PR that bumps `semantic-release`, `@semantic-release/changelog` (to 7.x, clearing the peer conflict), `git`, `exec`, and the replace plugin together. Verify the `package.json` diff contains all of them before merging.
4. Once that lands, close #369, #378, #379, #380, #384, #385 as superseded — they are ~4 months old, past the 30-day mark where Dependabot stops rebasing and superseding, so they will not self-close.
5. Then run **Release** with `dryRun: true`, which is the only thing that exercises `npm ci` plus semantic-release's plugin loading against the real `release.config.js`.

### Useful links and documentation (optional)

- [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)
- [Optimizing PR creation for version updates](https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates)
- [Dependabot version updates keep Gradle version catalogs up to date](https://github.blog/changelog/2023-03-13-dependabot-version-updates-keeps-gradle-version-catalogs-up-to-date/)
- [Gradle support for Dependabot security updates](https://github.blog/changelog/2023-08-24-gradle-support-for-dependabot-security-updates/) — why the Submission API follow-up matters

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<details>
<summary>AI Prompt</summary>

there are a few dependabot PRs open for javascript dependencies. Can you check if/why these dependencies are needed?

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds CI/supply-chain automation config only; no runtime SDK, auth, or build logic changes.
> 
> **Overview**
> Introduces **`.github/dependabot.yml`** so version updates are automated with grouping by blast radius instead of one PR per dependency.
> 
> **npm** (semantic-release toolchain for release automation) and **github-actions** each get a single grouped PR for version and security updates, with monthly schedule and tight open-PR limits. **gradle** is added as a new ecosystem reading `gradle/libs.versions.toml`: only **test-tooling** (JUnit, MockK, Robolectric, AndroidX test, mockwebserver) is grouped; published/consumer-facing coordinates stay one PR each. **Kotlin** plugin and `org.jetbrains.kotlin:*` library bumps are **ignored** so bot runs cannot break the hand-pinned Compose compiler / Kotlin 2.x story or swallow coroutines updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f18c2b0bbb9ed0a4138d107732ec2dc6a94f9e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->