### PR TITLE
feat(core): new upload retry backoff schedule (SDKA-36)

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/Configuration.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/Configuration.kt
@@ -28,6 +28,7 @@ public open class Configuration
         public open var minIdLength: Int? = null,
         public open var partnerId: String? = null,
         public open var callback: EventCallBack? = null,
+        @Deprecated("Upload retries are no longer capped. Property will be removed.")
         public open var flushMaxRetries: Int = FLUSH_MAX_RETRIES,
         public open var useBatch: Boolean = false,
         public open var serverZone: ServerZone = ServerZone.US,

--- a/analytics-core/src/main/java/com/amplitude/core/ConfigurationBuilder.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/ConfigurationBuilder.kt
@@ -30,6 +30,7 @@ public class ConfigurationBuilder(
     override var storageProvider: StorageProvider = InMemoryStorageProvider()
     override var loggerProvider: LoggerProvider = ConsoleLoggerProvider()
 
+    @Suppress("DEPRECATION")
     public fun build(): Configuration =
         Configuration(
             apiKey = apiKey,

--- a/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
@@ -185,7 +185,7 @@ public class EventPipeline(
         scope.launch(amplitude.storageIODispatcher) {
             if (isActive && running && !scheduled) {
                 scheduled = true
-                delay(amplitude.configuration.flushIntervalMillis.toLong())
+                delay(amplitude.configuration.flushIntervalMillis.milliseconds)
                 flush()
                 scheduled = false
             }

--- a/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
@@ -1,12 +1,15 @@
 package com.amplitude.core.platform
 
 import com.amplitude.core.Amplitude
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.Storage
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.utilities.ExponentialBackoffRetryHandler
+import com.amplitude.core.utilities.http.BadRequestResponse
 import com.amplitude.core.utilities.http.HttpClient
 import com.amplitude.core.utilities.http.HttpClientInterface
 import com.amplitude.core.utilities.http.ResponseHandler
+import com.amplitude.core.utilities.http.TooManyRequestsResponse
 import com.amplitude.core.utilities.logWithStackTrace
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
@@ -19,17 +22,16 @@ import kotlinx.coroutines.withContext
 import java.io.FileNotFoundException
 import java.lang.ref.WeakReference
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
 
+@OptIn(RestrictedAmplitudeFeature::class)
 public class EventPipeline(
     private val amplitude: Amplitude,
     private val eventCount: AtomicInteger = AtomicInteger(0),
     private val httpClient: HttpClientInterface =
         amplitude.configuration.httpClient
             ?: HttpClient(amplitude.configuration, amplitude.logger),
-    private val retryUploadHandler: ExponentialBackoffRetryHandler =
-        ExponentialBackoffRetryHandler(
-            maxRetryAttempt = amplitude.configuration.flushMaxRetries,
-        ),
+    private val retryUploadHandler: ExponentialBackoffRetryHandler = ExponentialBackoffRetryHandler(),
     private val storage: Storage = amplitude.storage,
     private val scope: CoroutineScope = amplitude.amplitudeScope,
     private val writeChannel: Channel<WriteQueueMessage> = Channel(UNLIMITED),
@@ -51,7 +53,11 @@ public class EventPipeline(
 
     public companion object {
         private const val UPLOAD_SIG = "#!upload"
-        private const val MAX_RETRY_ATTEMPT_SIG = "#!maxRetryAttemptReached"
+
+        /**
+         * The server asked us to slow down, so we wait this long before retrying.
+         */
+        private const val TOO_MANY_REQUESTS_DELAY_IN_MS = 30_000L
     }
 
     init {
@@ -115,7 +121,7 @@ public class EventPipeline(
 
     private fun upload() =
         scope.launch(amplitude.networkIODispatcher) {
-            uploadChannel.consumeEach { signal ->
+            uploadChannel.consumeEach { _ ->
                 withContext(amplitude.storageIODispatcher) {
                     try {
                         storage.rollover()
@@ -124,16 +130,6 @@ public class EventPipeline(
                             amplitude.logger.warn("Event storage file not found: $it")
                         }
                     }
-                }
-
-                if (signal == MAX_RETRY_ATTEMPT_SIG) {
-                    amplitude.logger.debug(
-                        "Max retries ${retryUploadHandler.maxRetryAttempt} reached, temporarily stop consuming upload signals.",
-                    )
-                    // Use the max delay when retry attempt is reached
-                    delay(retryUploadHandler.maxDelayInMs)
-                    retryUploadHandler.reset()
-                    amplitude.logger.debug("Enable consuming of upload signals again.")
                 }
 
                 val eventFiles = storage.readEventsContent()
@@ -146,12 +142,25 @@ public class EventPipeline(
                         val response = httpClient.upload(eventsString, diagnostics)
                         val shouldRetryUploadOnFailure = responseHandler.handle(response, eventFile, eventsString)
 
+                        // an invalid API key is terminal, retrying can never recover from it
+                        if (response is BadRequestResponse && response.isInvalidApiKeyResponse()) {
+                            amplitude.logger.error("Invalid API key. Don't retry.")
+                            break
+                        }
+
                         // if we encounter a retryable error, we retry with delay and
                         // restart the loop to get the newest event files
                         if (shouldRetryUploadOnFailure == true) {
+                            if (response is TooManyRequestsResponse) {
+                                delay(TOO_MANY_REQUESTS_DELAY_IN_MS.milliseconds)
+                                uploadChannel.trySend(UPLOAD_SIG)
+                                break
+                            }
+
                             retryUploadHandler.attemptRetry { canRetry ->
-                                val retrySignal = if (canRetry) UPLOAD_SIG else MAX_RETRY_ATTEMPT_SIG
-                                uploadChannel.trySend(retrySignal)
+                                if (canRetry) {
+                                    uploadChannel.trySend(UPLOAD_SIG)
+                                }
                             }
                             break
                         }

--- a/analytics-core/src/main/java/com/amplitude/core/utilities/ExponentialBackoffRetryHandler.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/ExponentialBackoffRetryHandler.kt
@@ -1,67 +1,84 @@
 package com.amplitude.core.utilities
 
+import com.amplitude.core.RestrictedAmplitudeFeature
 import kotlinx.coroutines.delay
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.math.pow
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * A utility class to handle exponential backoff retry logic.
+ * A utility class to handle retry backoff logic.
+ *
+ * Delays follow a fixed schedule of 1s, 8s, 32s, 128s and then plateau at 300s, which is repeated
+ * for as long as the retries keep failing. Every delay is jittered by +/- half of itself so retries
+ * from different clients spread out.
  *
  * Usage:
- * - call [attemptRetry] to attempt retry with exponential backoff delay
- * - always call [reset] at the end of your session to reset the retry attempt counter.
+ * - call [attemptRetry] to attempt retry with a backoff delay
+ * - call [reset] on success, so the next failure starts the schedule over.
  */
-public class ExponentialBackoffRetryHandler(
-    public val maxRetryAttempt: Int = MAX_RETRY_ATTEMPT,
-    private val baseDelayInMs: Int = 1_000,
-    private val factor: Double = 2.0,
-) {
-    /**
-     * The current exponential backoff delay in milliseconds. Formula is [baseDelayInMs] * ([factor]^[attempt])
-     *
-     * e.g. for the default values, it will be: 1, 2, 4, 8, 16 seconds
-     */
-    private val exponentialBackOffDelayInMs
-        get() = (baseDelayInMs * factor.pow(attempt.get())).toLong()
+@RestrictedAmplitudeFeature
+public class ExponentialBackoffRetryHandler() {
+    @Deprecated(
+        "The backoff schedule is fixed now, baseDelayInMs and factor are ignored.",
+        ReplaceWith("ExponentialBackoffRetryHandler()"),
+    )
+    @RestrictedAmplitudeFeature
+    public constructor(
+        maxRetryAttempt: Int = 5,
+        baseDelayInMs: Int,
+        factor: Double,
+    ) : this()
+
+    @Deprecated("The backoff schedule no longer has a max retry cap. This is ignored and will be removed.")
+    public val maxRetryAttempt: Int = 5
 
     /**
      * After we've reached [maxRetryAttempt], we will stop retrying for a longer period and use this
-     * value. We apply a ceiling of 60 seconds [MAX_DELAY_IN_MILLIS] to the delay to avoid waiting too long.
+     * value.
      */
+    @Deprecated("Unused. Will be removed.")
     public val maxDelayInMs: Long
-        get() =
-            MAX_DELAY_IN_MILLIS.coerceAtMost(
-                baseDelayInMs * factor.pow(maxRetryAttempt + 1).toInt(),
-            ).toLong()
+        get() = DELAYS_IN_MS.last()
 
     internal var attempt = AtomicInteger(0)
 
-    private fun canRetry() = attempt.get() < maxRetryAttempt
-
     /**
-     * Attempt retry with exponential backoff delay. see [exponentialBackOffDelayInMs]
+     * Attempt retry with the backoff delay of the current attempt. see [nextDelay]
      * @param block a lambda to execute the retry logic. The lambda will receive a boolean parameter to indicate if the retry logic should be executed.
-     * If boolean parameter is false, [maxRetryAttempt] was reached and you should stop retrying and handle the failure.
+     * Retries are no longer capped, so the parameter is always true.
      */
     public suspend fun attemptRetry(block: (Boolean) -> Unit) {
-        if (!canRetry()) {
-            block(false)
-            return
-        }
-        delay(exponentialBackOffDelayInMs)
+        delay(nextDelay())
         block(true)
         attempt.incrementAndGet()
     }
 
     /**
-     * Reset the retry attempt counter.
+     * Reset the retry attempt counter, so the next retry starts the backoff schedule over.
      */
     public fun reset() {
         attempt.set(0)
     }
 
+    /**
+     * The jittered delay of the current attempt.
+     */
+    internal fun nextDelay(): Duration {
+        val delayInMs = DELAYS_IN_MS[attempt.get().coerceAtMost(DELAYS_IN_MS.lastIndex)]
+        return jitter(delayInMs).milliseconds
+    }
+
+    /**
+     * Spread [delayInMs] over +/- half of itself, e.g. 8s becomes a delay within 4s and 12s.
+     */
+    private fun jitter(delayInMs: Long): Long = delayInMs / 2 + Random.nextLong(delayInMs + 1)
+
     public companion object {
-        private const val MAX_RETRY_ATTEMPT = 5
-        private const val MAX_DELAY_IN_MILLIS = 60_000
+        /**
+         * The backoff delay of each attempt, the last one is reused for every attempt after it.
+         */
+        private val DELAYS_IN_MS = listOf(1_000L, 8_000L, 32_000L, 128_000L, 300_000L)
     }
 }

--- a/analytics-core/src/main/java/com/amplitude/core/utilities/InMemoryResponseHandler.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/InMemoryResponseHandler.kt
@@ -149,6 +149,7 @@ internal class InMemoryResponseHandler
             }
         }
 
+        @Suppress("DEPRECATION")
         override fun handleFailedResponse(
             failedResponse: FailedResponse,
             events: Any,

--- a/analytics-core/src/test/kotlin/com/amplitude/core/platform/EventPipelineTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/platform/EventPipelineTest.kt
@@ -2,6 +2,7 @@ package com.amplitude.core.platform
 
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Configuration
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.State
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.utilities.ConsoleLoggerProvider
@@ -20,6 +21,7 @@ import com.amplitude.core.utilities.http.PayloadTooLargeResponse
 import com.amplitude.core.utilities.http.ResponseHandler
 import com.amplitude.core.utilities.http.SuccessResponse
 import com.amplitude.core.utilities.http.TimeoutResponse
+import com.amplitude.core.utilities.http.TooManyRequestsResponse
 import com.amplitude.core.utils.FakeAmplitude
 import com.amplitude.core.utils.StubPlugin
 import com.amplitude.id.IMIdentityStorageProvider
@@ -32,17 +34,21 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 @ExperimentalCoroutinesApi
+@OptIn(RestrictedAmplitudeFeature::class)
 class EventPipelineTest {
     private lateinit var fakeResponse: AnalyticsResponse
+    private val flushIntervalMillis = 1
     private val config =
         Configuration(
             apiKey = "API_KEY",
-            flushIntervalMillis = 1,
+            flushIntervalMillis = flushIntervalMillis,
             storageProvider = InMemoryStorageProvider(),
             loggerProvider = ConsoleLoggerProvider(),
             identifyInterceptStorageProvider = InMemoryStorageProvider(),
@@ -227,15 +233,58 @@ class EventPipelineTest {
         }
 
     @Test
-    fun `should send MAX_RETRY_ATTEMPT_SIG after max retry attempts`() =
+    fun `should wait 30 seconds before retrying too many requests`() =
         runTest(testDispatcher) {
             amplitude.isBuilt.await()
-            val retryUploadHandler =
-                spyk(
-                    ExponentialBackoffRetryHandler(
-                        maxRetryAttempt = 0,
-                    ),
+            val retryUploadHandler = spyk(ExponentialBackoffRetryHandler())
+            val eventPipeline =
+                EventPipeline(
+                    amplitude,
+                    retryUploadHandler = retryUploadHandler,
+                    overrideResponseHandler = fakeResponseHandler,
                 )
+            val event = BaseEvent().apply { eventType = "test_event" }
+
+            fakeResponse = TooManyRequestsResponse(JSONObject())
+            eventPipeline.start()
+            val startTime = currentTime
+            eventPipeline.put(event)
+            advanceUntilIdle()
+
+            // a 429 waits a fixed 30s, it does not go through the backoff schedule
+            assertEquals(30_000L, currentTime - startTime - flushIntervalMillis)
+            coVerify(exactly = 0) { retryUploadHandler.attemptRetry(any<(Boolean) -> Unit>()) }
+        }
+
+    @Test
+    fun `should NOT retry on an invalid API key`() =
+        runTest(testDispatcher) {
+            amplitude.isBuilt.await()
+            val retryUploadHandler = spyk(ExponentialBackoffRetryHandler())
+            val eventPipeline =
+                EventPipeline(
+                    amplitude,
+                    retryUploadHandler = retryUploadHandler,
+                    overrideResponseHandler = fakeResponseHandler,
+                )
+            val event = BaseEvent().apply { eventType = "test_event" }
+
+            fakeResponse = BadRequestResponse(JSONObject().put("error", "Invalid API key: API_KEY"))
+            eventPipeline.start()
+            eventPipeline.put(event)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { retryUploadHandler.attemptRetry(any<(Boolean) -> Unit>()) }
+            verify(exactly = 0) { retryUploadHandler.reset() }
+        }
+
+    @Test
+    fun `should keep retrying past the flush max retries`() =
+        runTest(testDispatcher) {
+            amplitude.isBuilt.await()
+            val retryUploadHandler = spyk(ExponentialBackoffRetryHandler())
+            // way past configuration.flushMaxRetries, upload retries are not capped
+            retryUploadHandler.attempt.set(50)
             val eventPipeline =
                 EventPipeline(
                     amplitude,
@@ -250,10 +299,8 @@ class EventPipelineTest {
             advanceUntilIdle()
 
             coVerify { retryUploadHandler.attemptRetry(any<(Boolean) -> Unit>()) }
-            // this will be called on the MAX_RETRY_ATTEMPT_SIG block on upload(),
-            // this is because the InMemoryStorage will clear the buffer and the second call to
-            // readEventsContent() will return an empty list and will stop the processing
-            verify(exactly = 1) { retryUploadHandler.reset() }
+            assertEquals(51, retryUploadHandler.attempt.get())
+            verify(exactly = 0) { retryUploadHandler.reset() }
         }
 
     @Test

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/ExponentialBackoffRetryHandlerTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/ExponentialBackoffRetryHandlerTest.kt
@@ -1,108 +1,89 @@
 package com.amplitude.core.utilities
 
+import com.amplitude.core.RestrictedAmplitudeFeature
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.math.pow
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, RestrictedAmplitudeFeature::class)
 class ExponentialBackoffRetryHandlerTest {
-    @Test
-    fun `attemptRetry returns properly until maxRetryAttempt is reached`() =
-        runBlocking {
-            val handler =
-                ExponentialBackoffRetryHandler(
-                    maxRetryAttempt = 2,
-                    baseDelayInMs = 10,
-                )
-            repeat(3) { count ->
-                handler.attemptRetry { canRetry ->
-                    if (count < 2) {
-                        assertTrue(canRetry)
-                    } else {
-                        assertFalse(canRetry)
-                    }
+    @Nested
+    inner class BackoffSchedule {
+        @Test
+        fun `attemptRetry delays 1s, 8s, 32s, 128s then repeats 300s indefinitely`() =
+            runTest {
+                val handler = ExponentialBackoffRetryHandler()
+
+                val expectedDelays =
+                    listOf(1_000L, 8_000L, 32_000L, 128_000L) + List(10) { 300_000L }
+                expectedDelays.forEachIndexed { attempt, expected ->
+                    var canRetry = false
+                    val elapsed = measureDelay { handler.attemptRetry { canRetry = it } }
+
+                    assertTrue(canRetry, "expected to keep retrying on attempt $attempt")
+                    assertWithinJitter(expected, elapsed, "attempt $attempt")
                 }
             }
-        }
 
-    @Test
-    fun `retryWithDelay increments attempts within max range`() =
-        runTest {
-            val handler = ExponentialBackoffRetryHandler(maxRetryAttempt = 2)
+        @Test
+        fun `attemptRetry increments the attempt count`() =
+            runTest {
+                val handler = ExponentialBackoffRetryHandler()
 
-            handler.attemptRetry {}
-            assertEquals(1, handler.attempt.get())
-            handler.attemptRetry {}
-            assertEquals(2, handler.attempt.get())
-            handler.attemptRetry {}
-            assertEquals(2, handler.attempt.get()) // max attempt reached
-        }
+                handler.attemptRetry {}
+                assertEquals(1, handler.attempt.get())
+                handler.attemptRetry {}
+                assertEquals(2, handler.attempt.get())
+            }
 
-    @Test
-    fun `reset sets attempts to zero`() =
-        runBlocking {
-            val handler = ExponentialBackoffRetryHandler(maxRetryAttempt = 3, baseDelayInMs = 10)
-            repeat(4) { count ->
-                handler.attemptRetry { canRetry ->
-                    if (count < 3) {
-                        assertTrue(canRetry)
-                    } else {
-                        assertFalse(canRetry)
+        @Test
+        fun `reset starts the schedule over`() =
+            runTest {
+                val handler = ExponentialBackoffRetryHandler()
+                handler.attempt.set(4)
+
+                handler.reset()
+
+                assertEquals(0, handler.attempt.get())
+                assertWithinJitter(1_000L, measureDelay { handler.attemptRetry {} }, "delay after reset")
+            }
+
+        @Test
+        fun `jitter spreads a delay over plus or minus half of itself`() =
+            runTest {
+                val delays =
+                    (1..100).map {
+                        measureDelay { ExponentialBackoffRetryHandler().attemptRetry {} }
                     }
-                }
+
+                delays.forEach { assertWithinJitter(1_000L, it, "jittered delay") }
+                assertTrue(delays.distinct().size > 1, "expected jittered delays to vary, got $delays")
             }
-            handler.reset()
-            assertEquals(0, handler.attempt.get())
-            handler.attemptRetry { canRetry ->
-                assertTrue(canRetry)
-            }
-        }
+    }
 
-    @Test
-    fun `attemptRetry respects exponential backoff`() =
-        runBlocking {
-            val baseDelayInMs = 10
-            val attemptNumber = 4
-            val handler =
-                ExponentialBackoffRetryHandler(
-                    baseDelayInMs = baseDelayInMs,
-                )
-            handler.attempt.set(attemptNumber)
+    /**
+     * The virtual time a [block] of suspending calls spends delaying.
+     */
+    private suspend fun TestScope.measureDelay(block: suspend () -> Unit): Long {
+        val startTime = currentTime
+        block()
+        return currentTime - startTime
+    }
 
-            val startTime = System.currentTimeMillis()
-            handler.attemptRetry { canRetry ->
-                assertTrue(canRetry)
-                val endTime = System.currentTimeMillis()
-                val elapsedTime = endTime - startTime
-
-                val expected = baseDelayInMs * 2.0.pow(attemptNumber)
-                assertTrue(elapsedTime >= expected)
-            }
-        }
-
-    @Test
-    fun `maxDelay respects ceiling value and current attempt count`() {
-        val maxRetryAttempt = 10
-        var handler =
-            ExponentialBackoffRetryHandler(
-                maxRetryAttempt = maxRetryAttempt,
-            )
-
-        // should be set to ceiling of 60 seconds
-        handler.attempt.set(10)
-        assertEquals(handler.maxDelayInMs, 60_000)
-
-        // should be set to 2^5: 2^(maxRetryAttempt + 1)
-        handler =
-            ExponentialBackoffRetryHandler(
-                maxRetryAttempt = 4,
-            )
-        handler.attempt.set(4)
-        assertEquals(handler.maxDelayInMs, 32_000)
+    private fun assertWithinJitter(
+        expectedDelayInMs: Long,
+        actualDelayInMs: Long,
+        message: String,
+    ) {
+        val jitter = expectedDelayInMs / 2
+        assertTrue(
+            actualDelayInMs in (expectedDelayInMs - jitter)..(expectedDelayInMs + jitter),
+            "$message: expected $actualDelayInMs to be within +/- $jitter of $expectedDelayInMs",
+        )
     }
 }

--- a/android/src/main/java/com/amplitude/android/Configuration.kt
+++ b/android/src/main/java/com/amplitude/android/Configuration.kt
@@ -30,6 +30,7 @@ public open class Configuration(
     override var minIdLength: Int? = null,
     override var partnerId: String? = null,
     override var callback: EventCallBack? = null,
+    @Deprecated("Upload retries are no longer capped. Property will be removed.")
     override var flushMaxRetries: Int = FLUSH_MAX_RETRIES,
     override var useBatch: Boolean = false,
     override var serverZone: ServerZone = ServerZone.US,

--- a/android/src/main/java/com/amplitude/android/ConfigurationBuilder.kt
+++ b/android/src/main/java/com/amplitude/android/ConfigurationBuilder.kt
@@ -32,6 +32,7 @@ public class ConfigurationBuilder(
         context = context,
         autocapture = setOf(AutocaptureOption.SESSIONS),
     ) {
+    @Suppress("DEPRECATION")
     public fun build(): Configuration =
         Configuration(
             apiKey = apiKey,


### PR DESCRIPTION
### Describe what this PR is addressing

Upload retries used a `1s → 2s → 4s → 8s → 16s` exponential formula, then paused for a 60s cooldown once `flushMaxRetries` was hit and restarted the ladder. Every client retried on the same unjittered cadence, and a 429 was treated like any other retryable failure, so throttled clients came back well before the server wanted them to.

The [Client SDK Retry Logic](https://linear.app/amplitude/document/client-sdk-retry-logic-69d8c83f50b2) doc defines one retry policy across the Swift, Kotlin, and TypeScript SDKs. This aligns Kotlin with it.

Ref: SDKA-36

### Describe the solution

`ExponentialBackoffRetryHandler` now walks a fixed schedule — 1s, 8s, 32s, 128s — and then repeats 300s for as long as uploads keep failing. Each delay is jittered by ± half of itself, so clients spread out instead of retrying in lockstep; the effective windows are 0.5–1.5s, 4–12s, 16–48s, 64–192s, then 150–450s. A successful upload calls `reset()` and the schedule starts over.

Three deliberate decisions worth reviewing:

* **Retries are no longer capped.** The old max-attempt cooldown restarted the ladder back at the shortest delay, which contradicts "300s repeats until success." Removing the cap means `configuration.flushMaxRetries` no longer governs upload retries — it still applies to per-event attempts in `InMemoryResponseHandler`. That is a behavior change for anyone who set it expecting a ceiling. Events are not dropped by this path, so nothing is lost; uploads just keep trying.
* **A 429 waits a fixed 30s** and bypasses the backoff schedule entirely, per the doc's "429 (wait 30 sec)". Note this delay is not jittered and does not escalate, so sustained throttling produces a flat 30s cadence across clients. Respecting `Retry-After` is not possible yet — `HttpClientInterface.upload()` returns no headers.
* **An invalid API key is terminal.** The response handler still drops the batch and fires the 400 callbacks; the pipeline now stops walking the remaining event files instead of re-issuing a request per file that is guaranteed to fail the same way.

`ExponentialBackoffRetryHandler` is annotated `@RestrictedAmplitudeFeature`, so external construction now requires opt-in. The public API dump is unchanged — `apiCheck` passes with no `.api` edits. The old `(Int, Int, Double)` constructor and `maxRetryAttempt` are retained but deprecated and ignored.

### Steps to verify the change

* `./gradlew :analytics-core:test :android:test apiCheck ktlintCheck` — green.
* `ExponentialBackoffRetryHandlerTest` asserts the ladder in order, that it plateaus at 300s across 10 further attempts, that every delay lands within ± half of its nominal value and that the values actually vary, and that `reset()` returns to the 1s step. Delays are measured in `runTest` virtual time, so the suite does not sleep.
* `EventPipelineTest` covers the 429 path waiting exactly 30s without touching the retry handler, an invalid API key not retrying, and retries continuing past `flushMaxRetries` (attempt 50 → 51).

### Useful links and documentation (optional)

* [Client SDK Retry Logic](https://linear.app/amplitude/document/client-sdk-retry-logic-69d8c83f50b2)
* [SDKA-36](https://linear.app/amplitude/issue/SDKA-36/align-upload-retry-backoff-with-the-client-sdk-retry-logic-doc)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

Not marked as breaking, so semantic-release cuts a minor. Arguable both ways: `flushMaxRetries` becomes inert for uploads, and the deprecated constructor lost its parameter defaults (a source break, though binary compatibility holds). Say the word and I will add a `BREAKING CHANGE:` footer for a major.

<details>
<summary>AI Prompt</summary>

Update retry logic in ExponentialBackoffRetryHandler, etc.

New logic:

Retry exponentially with delays 8s, 32s, 128s, 256s, 300s, 300s, 300s. For each stage add a jitter of +/- half the delay.

so, 4-12s, 16-48s, 64-192s, 128s-384s, 150s-450s, 150s-450s, ...

do not retry on bad API key errors, this is terminal.

for 429 errors, wait a minimum of 30 seconds before retrying.

(The schedule was subsequently changed to 1s, 8s, 32s, 128s, 300s to match the design doc, and the 429 delay became a fixed 30s rather than a minimum.)

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core upload retry timing and removes the upload retry ceiling (`flushMaxRetries` no longer applies here), which can alter offline recovery behavior and server load patterns for existing apps.
> 
> **Overview**
> Aligns Kotlin **event upload retries** with the shared Client SDK retry policy: fixed backoff steps with jitter, special handling for **429** and **invalid API key**, and **no cap** on upload retries.
> 
> **`ExponentialBackoffRetryHandler`** no longer uses exponential `2^n` delays or `flushMaxRetries`. Retries follow **1s → 8s → 32s → 128s**, then **300s** indefinitely, each step jittered by ±50%. `attemptRetry` always signals retry (`canRetry` is always true). The old parameterized constructor and `maxRetryAttempt` / `maxDelayInMs` are deprecated. The class is **`@RestrictedAmplitudeFeature`**.
> 
> **`EventPipeline`** wires the new handler (default constructor only), drops the **max-retry cooldown** (`MAX_RETRY_ATTEMPT_SIG` / 60s pause), treats **invalid API key** `BadRequestResponse` as **terminal** (stop processing remaining files, no retry), and on **429** waits a **fixed 30s** before re-queueing upload—**without** going through the backoff handler.
> 
> Tests cover the new schedule, jitter, 429 timing, invalid API key, and retries continuing past former `flushMaxRetries` limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 260e9ddd0f91ad9f1ec20cbd1bffb488ed8e42fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->