### PR TITLE
docs: require KDoc for public APIs in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ Analytics SDK for Android. Two modules: **`analytics-core`** (pure Kotlin/JVM) a
 - `ktlintFormat` before every commit.
 - Open classes for public types. Data classes only for internal DTOs. Sealed classes for fixed types.
 - Companion objects for constants and factory methods. No `@JvmStatic` or `@JvmField`.
+- KDoc for all public APIs.
+  - Consider including an example usage code block when it makes the element easier to use correctly.
+  - Elements annotated `@Deprecated` or `@RestrictedAmplitudeFeature` are exempt from new documentation requirements.
 
 ### Public API Stability
 


### PR DESCRIPTION
### Describe what this PR is addressing
Agent guidelines (AGENTS.md) had no rule about documenting the public API surface, so agent-authored changes could add undocumented public elements to this published SDK.

### Describe the solution
Adds a KDoc rule to the Code Quality section: KDoc for all public APIs, with example usage code blocks when they help, and an exemption from new documentation requirements for elements annotated `@Deprecated` or `@RestrictedAmplitudeFeature`.

### Steps to verify the change
Docs-only change to AGENTS.md — review the wording.

### Useful links and documentation (optional)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor guidelines; no code, CI, or public API behavior is affected.
> 
> **Overview**
> **Agent/contributor guidelines** now require **KDoc on all public APIs**, aligned with the published SDK surface described elsewhere in `AGENTS.md`.
> 
> The new **Code Quality** bullets say to add example usage in KDoc when it helps callers, and that **`@Deprecated`** and **`@RestrictedAmplitudeFeature`** elements are exempt from *new* documentation requirements. No runtime, build, or API dump changes—documentation-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c886b56dd4b8a6190db6730e5284e983b66e4afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->