### PR TITLE
chore(deps): remove unused activity-ktx from analytics-android

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,7 +59,7 @@ updates:
   # Gradle — reads `gradle/libs.versions.toml`.
   #
   # Only test tooling is grouped. Consumer-visible dependencies (coroutines,
-  # core-ktx, activity-ktx, curtains, analytics-connector, okhttp, org.json) land
+  # core-ktx, curtains, analytics-connector, okhttp, org.json) land
   # in the published POM or can move the API dump, so each keeps its own PR.
   #
   # `mockwebserver` is deliberately outside the test-tooling group: it shares the

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -81,7 +81,6 @@ dependencies {
     implementation(libs.coroutines.android)
     implementation(libs.analytics.connector)
     implementation(libs.core.ktx)
-    implementation(libs.activity.ktx)
     implementation(libs.curtains)
     compileOnly(libs.okhttp)
     compileOnly(libs.fragment.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 activityCompose = "1.10.1"
 bcv = "0.18.1"
-activityKtx = "1.10.0"
 analyticsConnector = "1.0.0"
 androidGradlePlugin = "9.3.1"
 androidJunit5 = "1.12.2.0"
@@ -37,7 +36,6 @@ testRunner = "1.7.0"
 
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtx" }
 analytics-connector = { module = "com.amplitude:analytics-connector", version.ref = "analyticsConnector" }
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" } # Added
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉
Please fill out the following sections to help us quickly review your pull request.
--->

### Describe what this PR is addressing
`analytics-android` declared `androidx.activity:activity-ktx` but never used it — lifecycle tracking uses `Application.ActivityLifecycleCallbacks`. The unused dep still pulled Activity/AndroidX onto every consumer's runtime classpath.

Fixes [SDKA-51](https://linear.app/amplitude/issue/SDKA-51/remove-unused-activity-ktx-dependency-from-analytics-android).

### Describe the solution
* Removed `implementation(libs.activity.ktx)` from `:android`
* Dropped unused `activityKtx` / `activity-ktx` version catalog entries (`activity-compose` kept for samples)
* Updated Dependabot comment to match

No public API / `.api` impact — dependency-only change.

### Steps to verify the change
* `./gradlew :android:dependencies --configuration releaseRuntimeClasspath` — no `androidx.activity`
* `./gradlew :android:test`

### Useful links and documentation (optional)
* https://linear.app/amplitude/issue/SDKA-51/remove-unused-activity-ktx-dependency-from-analytics-android

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c33328b549e1e610855431efbce614f4ab137038. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->