### PR TITLE
fix: preserve coroutine cancellation in catch sites

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
@@ -7,6 +7,7 @@ import com.amplitude.core.ServerZone
 import com.amplitude.core.remoteconfig.RemoteConfigClient
 import com.amplitude.core.utilities.Sample
 import com.amplitude.core.utilities.http.HttpClient
+import com.amplitude.core.utilities.runCatchingCancellable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -456,7 +457,7 @@ internal class DiagnosticsClientImpl(
     ) {
         val payload = snapshot.toPayload()
 
-        try {
+        runCatchingCancellable {
             val jsonString = payload.toJsonString()
             val request =
                 HttpClient.Request(
@@ -479,11 +480,11 @@ internal class DiagnosticsClientImpl(
                 } else {
                     logger.error("DiagnosticsClient: Failed to upload diagnostics: ${response.statusCode}")
                 }
-                return
+                return@runCatchingCancellable
             }
 
             logger.debug("DiagnosticsClient: Uploaded diagnostics : $jsonString")
-        } catch (e: Exception) {
+        }.onFailure { e ->
             logger.error("DiagnosticsClient: Failed to upload diagnostics: ${e.message}")
         }
     }

--- a/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsStorage.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsStorage.kt
@@ -2,8 +2,8 @@ package com.amplitude.core.diagnostics
 
 import com.amplitude.common.Logger
 import com.amplitude.core.utilities.Hash
+import com.amplitude.core.utilities.runCatchingCancellable
 import com.amplitude.core.utilities.toHexString
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -65,7 +65,7 @@ internal class DiagnosticsStorage(
                 val result = channel.receiveCatching()
                 if (result.isClosed) break
                 result.getOrNull()?.let { operation ->
-                    try {
+                    runCatchingCancellable {
                         when (operation) {
                             is Operation.SaveSnapshot -> {
                                 val directory = activeStorageDirectory()
@@ -76,9 +76,7 @@ internal class DiagnosticsStorage(
                                 removeActiveFiles()
                             }
                         }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
+                    }.onFailure { e ->
                         logger.error("DiagnosticsStorage: Error processing operation: ${e.message}")
                     }
                 }

--- a/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
@@ -124,11 +124,15 @@ public class EventPipeline(
         scope.launch(amplitude.networkIODispatcher) {
             uploadChannel.consumeEach { _ ->
                 withContext(amplitude.storageIODispatcher) {
-                    try {
+                    runCatchingCancellable {
                         storage.rollover()
-                    } catch (e: FileNotFoundException) {
-                        e.message?.let {
-                            amplitude.logger.warn("Event storage file not found: $it")
+                    }.onFailure { e ->
+                        if (e is FileNotFoundException) {
+                            e.message?.let {
+                                amplitude.logger.warn("Event storage file not found: $it")
+                            }
+                        } else {
+                            throw e
                         }
                     }
                 }

--- a/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/EventPipeline.kt
@@ -11,6 +11,7 @@ import com.amplitude.core.utilities.http.HttpClientInterface
 import com.amplitude.core.utilities.http.ResponseHandler
 import com.amplitude.core.utilities.http.TooManyRequestsResponse
 import com.amplitude.core.utilities.logWithStackTrace
+import com.amplitude.core.utilities.runCatchingCancellable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
@@ -94,9 +95,9 @@ public class EventPipeline(
                 // write to storage
                 val triggerFlush = (message.type == WriteQueueMessageType.FLUSH)
                 if (!triggerFlush && message.event != null) {
-                    try {
+                    runCatchingCancellable {
                         storage.writeEvent(message.event)
-                    } catch (e: Exception) {
+                    }.onFailure { e ->
                         e.logWithStackTrace(
                             amplitude.logger,
                             "Error when writing event to pipeline",
@@ -134,44 +135,52 @@ public class EventPipeline(
 
                 val eventFiles = storage.readEventsContent()
                 for (eventFile in eventFiles) {
-                    try {
-                        val eventsString = storage.getEventsString(eventFile)
-                        if (eventsString.isEmpty()) continue
+                    val shouldStop =
+                        runCatchingCancellable {
+                            val eventsString = storage.getEventsString(eventFile)
+                            if (eventsString.isEmpty()) return@runCatchingCancellable false
 
-                        val diagnostics = amplitude.diagnostics.extractDiagnostics()
-                        val response = httpClient.upload(eventsString, diagnostics)
-                        val shouldRetryUploadOnFailure = responseHandler.handle(response, eventFile, eventsString)
+                            val diagnostics = amplitude.diagnostics.extractDiagnostics()
+                            val response = httpClient.upload(eventsString, diagnostics)
+                            val shouldRetryUploadOnFailure =
+                                responseHandler.handle(response, eventFile, eventsString)
 
-                        // an invalid API key is terminal, retrying can never recover from it
-                        if (response is BadRequestResponse && response.isInvalidApiKeyResponse()) {
-                            amplitude.logger.error("Invalid API key. Don't retry.")
-                            break
-                        }
-
-                        // if we encounter a retryable error, we retry with delay and
-                        // restart the loop to get the newest event files
-                        if (shouldRetryUploadOnFailure == true) {
-                            if (response is TooManyRequestsResponse) {
-                                delay(TOO_MANY_REQUESTS_DELAY_IN_MS.milliseconds)
-                                uploadChannel.trySend(UPLOAD_SIG)
-                                break
+                            // an invalid API key is terminal, retrying can never recover from it
+                            if (response is BadRequestResponse && response.isInvalidApiKeyResponse()) {
+                                amplitude.logger.error("Invalid API key. Don't retry.")
+                                return@runCatchingCancellable true
                             }
 
-                            retryUploadHandler.attemptRetry { canRetry ->
-                                if (canRetry) {
+                            // if we encounter a retryable error, we retry with delay and
+                            // restart the loop to get the newest event files
+                            if (shouldRetryUploadOnFailure == true) {
+                                if (response is TooManyRequestsResponse) {
+                                    delay(TOO_MANY_REQUESTS_DELAY_IN_MS.milliseconds)
                                     uploadChannel.trySend(UPLOAD_SIG)
+                                    return@runCatchingCancellable true
                                 }
+
+                                retryUploadHandler.attemptRetry { canRetry ->
+                                    if (canRetry) {
+                                        uploadChannel.trySend(UPLOAD_SIG)
+                                    }
+                                }
+                                return@runCatchingCancellable true
                             }
-                            break
+                            retryUploadHandler.reset() // always reset when we've successfully uploaded
+                            false
+                        }.getOrElse { e ->
+                            when (e) {
+                                is FileNotFoundException ->
+                                    e.message?.let {
+                                        amplitude.logger.warn("Event storage file not found: $it")
+                                    }
+                                else ->
+                                    e.logWithStackTrace(amplitude.logger, "Error when uploading event")
+                            }
+                            false
                         }
-                        retryUploadHandler.reset() // always reset when we've successfully uploaded
-                    } catch (e: FileNotFoundException) {
-                        e.message?.let {
-                            amplitude.logger.warn("Event storage file not found: $it")
-                        }
-                    } catch (e: Exception) {
-                        e.logWithStackTrace(amplitude.logger, "Error when uploading event")
-                    }
+                    if (shouldStop) break
                 }
             }
         }

--- a/analytics-core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptFileStorageHandler.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptFileStorageHandler.kt
@@ -6,6 +6,7 @@ import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.events.IdentifyOperation
 import com.amplitude.core.platform.intercept.IdentifyInterceptorUtil.filterNonNullValues
 import com.amplitude.core.utilities.EventsFileStorage
+import com.amplitude.core.utilities.runCatchingCancellable
 import com.amplitude.core.utilities.toEvents
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -17,13 +18,14 @@ public class IdentifyInterceptFileStorageHandler(
     private val amplitude: Amplitude,
 ) : IdentifyInterceptStorageHandler {
     override suspend fun getTransferIdentifyEvent(): BaseEvent? {
-        try {
+        runCatchingCancellable {
             storage.rollover()
-        } catch (e: FileNotFoundException) {
-            e.message?.let {
-                logger.warn("Event storage file not found: $it")
+        }.onFailure { e ->
+            if (e is FileNotFoundException) {
+                e.message?.let { logger.warn("Event storage file not found: $it") }
+                return null
             }
-            return null
+            throw e
         }
         val eventsData = storage.readEventsContent()
         if (eventsData.isEmpty()) {
@@ -32,29 +34,30 @@ public class IdentifyInterceptFileStorageHandler(
         var event: BaseEvent? = null
         var identifyEventUserProperties: MutableMap<String, Any?>? = null
         for (eventPath in eventsData) {
-            try {
+            runCatchingCancellable {
                 val eventsString = storage.getEventsString(eventPath)
                 if (eventsString.isEmpty()) {
                     removeFile(eventPath as String)
-                    continue
+                    return@runCatchingCancellable
                 }
                 val eventsList = JSONArray(eventsString).toEvents()
                 if (eventsList.isEmpty()) {
                     removeFile(eventPath as String)
-                    continue
+                    return@runCatchingCancellable
                 }
                 var events = eventsList
                 if (event == null) {
-                    event = eventsList[0]
+                    val firstEvent = eventsList[0]
+                    event = firstEvent
                     identifyEventUserProperties =
-                        filterNonNullValues(event.userProperties?.get(IdentifyOperation.SET.operationType) as MutableMap<String, Any?>)
+                        filterNonNullValues(firstEvent.userProperties?.get(IdentifyOperation.SET.operationType) as MutableMap<String, Any?>)
                     events = eventsList.subList(1, eventsList.size)
                 }
                 val userProperties = IdentifyInterceptorUtil.mergeIdentifyList(events)
                 identifyEventUserProperties?.putAll(userProperties)
                 removeFile(eventPath as String)
-            } catch (e: Exception) {
-                logger.warn("Identify Merge error: " + e.message)
+            }.onFailure { e ->
+                logger.warn("Identify Merge error: ${e.message}")
                 removeFile(eventPath as String)
             }
         }
@@ -66,13 +69,14 @@ public class IdentifyInterceptFileStorageHandler(
     }
 
     override suspend fun clearIdentifyIntercepts() {
-        try {
+        runCatchingCancellable {
             storage.rollover()
-        } catch (e: FileNotFoundException) {
-            e.message?.let {
-                logger.warn("Event storage file not found: $it")
+        }.onFailure { e ->
+            if (e is FileNotFoundException) {
+                e.message?.let { logger.warn("Event storage file not found: $it") }
+                return
             }
-            return
+            throw e
         }
         val eventsData = storage.readEventsContent()
         if (eventsData.isEmpty()) {

--- a/analytics-core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptor.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/intercept/IdentifyInterceptor.kt
@@ -9,6 +9,7 @@ import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.events.IdentifyOperation
 import com.amplitude.core.platform.plugins.AmplitudeDestination
 import com.amplitude.core.utilities.logWithStackTrace
+import com.amplitude.core.utilities.runCatchingCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
@@ -110,9 +111,9 @@ public class IdentifyInterceptor(
         }
 
     private suspend fun saveIdentifyProperties(event: BaseEvent) {
-        try {
+        runCatchingCancellable {
             storage.writeEvent(event)
-        } catch (e: Exception) {
+        }.onFailure { e ->
             e.logWithStackTrace(logger, "Error when intercepting identifies")
         }
     }

--- a/analytics-core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/remoteconfig/RemoteConfigClient.kt
@@ -14,6 +14,7 @@ import com.amplitude.core.remoteconfig.RemoteConfigClient.Key
 import com.amplitude.core.remoteconfig.RemoteConfigClient.Source.CACHE
 import com.amplitude.core.remoteconfig.RemoteConfigClient.Source.REMOTE
 import com.amplitude.core.utilities.http.HttpClient
+import com.amplitude.core.utilities.runCatchingCancellable
 import com.amplitude.core.utilities.toJSONObject
 import com.amplitude.core.utilities.toMapObj
 import kotlinx.coroutines.CoroutineDispatcher
@@ -487,22 +488,22 @@ internal class RemoteConfigClientImpl(
 
     private suspend fun performFetch(fetchId: Long): FetchOutcome {
         val blob =
-            try {
-                fetchRemoteConfig() ?: return FetchOutcome.Failure
-            } catch (e: Exception) {
+            runCatchingCancellable {
+                fetchRemoteConfig()
+            }.getOrElse { e ->
                 logger.error("Error fetching remote configs: ${e.message}")
                 return FetchOutcome.Failure
-            }
+            } ?: return FetchOutcome.Failure
         val timestamp = System.currentTimeMillis()
         // Persisting the blob is best-effort: a storage write failure must not discard
         // a valid in-memory remote config (mirrors iOS `try? storage.setConfig`).
-        try {
+        runCatchingCancellable {
             withContext(storageIODispatcher) {
                 storage.write(REMOTE_CONFIG, blob.toJSONObject().toString())
                 storage.write(REMOTE_CONFIG_TIMESTAMP, timestamp.toString())
                 logger.debug("Successfully stored remote configs to storage")
             }
-        } catch (e: Exception) {
+        }.onFailure { e ->
             logger.error("Failed to persist remote configs (delivering anyway): ${e.message}")
         }
         return FetchOutcome.Success(blob, timestamp, fetchId)
@@ -513,12 +514,12 @@ internal class RemoteConfigClientImpl(
     }
 
     private suspend fun shouldRateLimit(): Boolean {
-        return try {
+        return runCatchingCancellable {
             val lastTsStr = withContext(storageIODispatcher) { storage.read(REMOTE_CONFIG_TIMESTAMP) }
             val lastTs = lastTsStr?.toLongOrNull() ?: 0L
-            if (lastTs <= 0L) return false
+            if (lastTs <= 0L) return@runCatchingCancellable false
             (System.currentTimeMillis() - lastTs) < MIN_FETCH_INTERVAL_MS
-        } catch (e: Exception) {
+        }.getOrElse { e ->
             // Don't let a storage read failure leak out of the refresh coroutine or
             // wedge the rate limiter — fall through and let the fetch proceed.
             logger.error("Failed to read rate-limit timestamp: ${e.message}")
@@ -534,8 +535,8 @@ internal class RemoteConfigClientImpl(
      * [storageIODispatcher] (e.g. inside `withContext(storageIODispatcher)`).
      */
     private fun getStoredConfigData(dotPath: String): ConfigData? {
-        return try {
-            val blob = getStoredConfigBlob() ?: return null
+        return runCatchingCancellable {
+            val blob = getStoredConfigBlob() ?: return@runCatchingCancellable null
 
             val resolved = resolveDotPath(blob, dotPath)
             val timestampStr = storage.read(REMOTE_CONFIG_TIMESTAMP)
@@ -543,7 +544,7 @@ internal class RemoteConfigClientImpl(
 
             logger.debug("Retrieved stored config for $dotPath with ${resolved?.size ?: 0} properties")
             ConfigData(resolved, timestamp)
-        } catch (e: Exception) {
+        }.getOrElse { e ->
             logger.error("Failed to retrieve stored config data for $dotPath: ${e.message}")
             null
         }

--- a/analytics-core/src/main/java/com/amplitude/core/utilities/EventsFileManager.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/EventsFileManager.kt
@@ -389,18 +389,22 @@ public class EventsFileManager(
                     if (!content.endsWith(DELIMITER)) {
                         // handle earlier versions
                         val normalizedContent = "[${content.trimStart('[', ',').trimEnd(']', ',')}]"
-                        try {
+                        runCatchingCancellable {
                             val jsonArray = JSONArray(normalizedContent)
                             val list = jsonArray.toJSONObjectList()
                             writeEventsToSplitFile(list, it, false)
                             if (it.extension == "tmp") {
                                 finish(it)
                             }
-                        } catch (e: JSONException) {
-                            logger.error(
-                                "Failed to parse events: $normalizedContent, dropping file: ${it.path}, error: $e",
-                            )
-                            this.remove(it.path)
+                        }.onFailure { e ->
+                            if (e is JSONException) {
+                                logger.error(
+                                    "Failed to parse events: $normalizedContent, dropping file: ${it.path}, error: $e",
+                                )
+                                this.remove(it.path)
+                            } else {
+                                throw e
+                            }
                         }
                     }
                 }

--- a/analytics-core/src/main/java/com/amplitude/core/utilities/KotlinUtils.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/KotlinUtils.kt
@@ -1,0 +1,26 @@
+package com.amplitude.core.utilities
+
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Like [runCatching], but rethrows [CancellationException] so coroutine cancellation is not
+ * swallowed into a failed [Result].
+ *
+ * [finally] always runs, including when [CancellationException] is rethrown.
+ * Pass it by name so the trailing lambda remains [block]:
+ * `runCatchingCancellable(finally = { cleanup() }) { work() }`.
+ */
+internal inline fun <T, R> T.runCatchingCancellable(
+    finally: () -> Unit = {},
+    block: T.() -> R,
+): Result<R> {
+    return try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.failure(e)
+    } finally {
+        finally()
+    }
+}

--- a/analytics-core/src/main/java/com/amplitude/core/utilities/LoggerExtensions.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/LoggerExtensions.kt
@@ -2,7 +2,7 @@ package com.amplitude.core.utilities
 
 import com.amplitude.common.Logger
 
-internal fun Exception.logWithStackTrace(
+internal fun Throwable.logWithStackTrace(
     logger: Logger,
     message: String,
 ) {

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/KotlinUtilsTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/KotlinUtilsTest.kt
@@ -1,0 +1,64 @@
+package com.amplitude.core.utilities
+
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KotlinUtilsTest {
+    @Test
+    fun `runCatchingCancellable returns success when block completes`() {
+        val result = runCatchingCancellable { "ok" }
+
+        assertTrue(result.isSuccess)
+        assertEquals("ok", result.getOrNull())
+    }
+
+    @Test
+    fun `runCatchingCancellable returns failure for non-cancellation exceptions`() {
+        val result = runCatchingCancellable { error("boom") }
+
+        assertTrue(result.isFailure)
+        assertEquals("boom", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `runCatchingCancellable rethrows CancellationException`() {
+        assertThrows(CancellationException::class.java) {
+            runCatchingCancellable { throw CancellationException("cancelled") }
+        }
+    }
+
+    @Test
+    fun `runCatchingCancellable runs finally on success`() {
+        var ran = false
+
+        runCatchingCancellable(finally = { ran = true }) { "ok" }
+
+        assertTrue(ran)
+    }
+
+    @Test
+    fun `runCatchingCancellable runs finally on failure`() {
+        var ran = false
+
+        runCatchingCancellable(finally = { ran = true }) { error("boom") }
+
+        assertTrue(ran)
+    }
+
+    @Test
+    fun `runCatchingCancellable runs finally when CancellationException is rethrown`() {
+        var ran = false
+
+        assertThrows(CancellationException::class.java) {
+            runCatchingCancellable(finally = { ran = true }) {
+                throw CancellationException("cancelled")
+            }
+        }
+        assertTrue(ran)
+    }
+}

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -11,6 +11,7 @@ import com.amplitude.android.plugins.AndroidLifecyclePlugin
 import com.amplitude.android.plugins.AndroidNetworkConnectivityCheckerPlugin
 import com.amplitude.android.storage.AndroidStorageContextV3
 import com.amplitude.android.utilities.ActivityLifecycleObserver
+import com.amplitude.android.utilities.runCatchingCancellable
 import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.State
 import com.amplitude.core.diagnostics.DiagnosticsContextProvider
@@ -213,7 +214,7 @@ public open class Amplitude internal constructor(
             isBuilt.join()
             (timeline as Timeline).awaitDrained()
             plugins(UniversalPlugin::class.java).forEach { plugin ->
-                runCatching { remove(plugin) }
+                runCatchingCancellable { remove(plugin) }
                     .onFailure { logger.warn("Failed to remove ${plugin.name ?: plugin::class.java.simpleName}: $it") }
             }
         }

--- a/android/src/main/java/com/amplitude/android/migration/AndroidStorageMigration.kt
+++ b/android/src/main/java/com/amplitude/android/migration/AndroidStorageMigration.kt
@@ -67,7 +67,7 @@ public class AndroidStorageMigration(
                 runCatchingCancellable {
                     logger.debug("Migrating $key with value $sourceValue")
                     destination.write(key, sourceValue)
-                }.getOrElse { e ->
+                }.onFailure { e ->
                     logger.error("can't write destination $key: ${e.message}")
                     return@runCatchingCancellable
                 }

--- a/android/src/main/java/com/amplitude/android/migration/AndroidStorageMigration.kt
+++ b/android/src/main/java/com/amplitude/android/migration/AndroidStorageMigration.kt
@@ -1,6 +1,7 @@
 package com.amplitude.android.migration
 
 import com.amplitude.android.storage.AndroidStorageV2
+import com.amplitude.android.utilities.runCatchingCancellable
 import com.amplitude.common.Logger
 import com.amplitude.core.Storage
 import com.amplitude.core.utilities.toEvents
@@ -17,12 +18,12 @@ public class AndroidStorageMigration(
     }
 
     private suspend fun moveEventsToDestination() {
-        try {
+        runCatchingCancellable {
             source.rollover()
             val sourceEventFiles = source.readEventsContent() as List<String>
             if (sourceEventFiles.isEmpty()) {
                 source.cleanupMetadata()
-                return
+                return@runCatchingCancellable
             }
 
             for (sourceEventFilePath in sourceEventFiles) {
@@ -30,10 +31,10 @@ public class AndroidStorageMigration(
                 var count = 0
                 val baseEvents = JSONArray(events).toEvents()
                 for (event in baseEvents) {
-                    try {
+                    runCatchingCancellable {
                         count++
                         destination.writeEvent(event)
-                    } catch (e: Exception) {
+                    }.onFailure { e ->
                         logger.error("can't move event ($event) from file $sourceEventFilePath: ${e.message}")
                     }
                 }
@@ -42,7 +43,7 @@ public class AndroidStorageMigration(
             }
             source.cleanupMetadata()
             destination.rollover()
-        } catch (e: Exception) {
+        }.onFailure { e ->
             logger.error("can't move event files: ${e.message}")
         }
     }
@@ -59,20 +60,20 @@ public class AndroidStorageMigration(
     }
 
     private suspend fun moveSimpleValue(key: Storage.Constants) {
-        try {
-            val sourceValue = source.read(key) ?: return
+        runCatchingCancellable {
+            val sourceValue = source.read(key) ?: return@runCatchingCancellable
             val destinationValue = destination.read(key)
             if (destinationValue == null) {
-                try {
+                runCatchingCancellable {
                     logger.debug("Migrating $key with value $sourceValue")
                     destination.write(key, sourceValue)
-                } catch (e: Exception) {
+                }.getOrElse { e ->
                     logger.error("can't write destination $key: ${e.message}")
-                    return
+                    return@runCatchingCancellable
                 }
             }
             source.remove(key)
-        } catch (e: Exception) {
+        }.onFailure { e ->
             logger.error("can't move $key: ${e.message}")
         }
     }

--- a/android/src/main/java/com/amplitude/android/migration/MigrationManager.kt
+++ b/android/src/main/java/com/amplitude/android/migration/MigrationManager.kt
@@ -8,6 +8,7 @@ import com.amplitude.android.storage.AndroidStorageContextV1
 import com.amplitude.android.storage.AndroidStorageContextV2
 import com.amplitude.android.storage.LegacySdkStorageContext
 import com.amplitude.android.storage.StorageVersion
+import com.amplitude.android.utilities.runCatchingCancellable
 import com.amplitude.common.Logger
 
 internal class MigrationManager(private val amplitude: Amplitude) {
@@ -35,7 +36,7 @@ internal class MigrationManager(private val amplitude: Amplitude) {
     }
 
     internal suspend fun safePerformMigration() {
-        try {
+        runCatchingCancellable {
             val config = amplitude.configuration as Configuration
             if (config.migrateLegacyData) {
                 val legacySdkStorageContext = LegacySdkStorageContext(amplitude)
@@ -49,7 +50,7 @@ internal class MigrationManager(private val amplitude: Amplitude) {
             storageContextV2.migrateToLatestVersion()
 
             sharedPreferences.edit().putInt("storage_version", StorageVersion.V3.rawValue).apply()
-        } catch (ex: Throwable) {
+        }.onFailure { ex ->
             logger.error("Failed to migrate storage: ${ex.message}")
         }
     }

--- a/android/src/main/java/com/amplitude/android/migration/RemnantDataMigration.kt
+++ b/android/src/main/java/com/amplitude/android/migration/RemnantDataMigration.kt
@@ -1,5 +1,6 @@
 package com.amplitude.android.migration
 
+import com.amplitude.android.utilities.runCatchingCancellable
 import com.amplitude.common.android.LogcatLogger
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Storage
@@ -14,7 +15,6 @@ import org.json.JSONObject
  *      3. saves the device/user id, converted events and identifies to current storage
  *      4. deletes data from sqlite table
  */
-
 public class RemnantDataMigration(public val amplitude: Amplitude, private val databaseStorage: DatabaseStorage) {
     public companion object {
         public const val DEVICE_ID_KEY: String = "device_id"
@@ -64,7 +64,7 @@ public class RemnantDataMigration(public val amplitude: Amplitude, private val d
     }
 
     private suspend fun moveSessionData() {
-        try {
+        runCatchingCancellable {
             val currentSessionId = amplitude.storage.read(Storage.Constants.PREVIOUS_SESSION_ID)?.toLongOrNull()
             val currentLastEventTime = amplitude.storage.read(Storage.Constants.LAST_EVENT_TIME)?.toLongOrNull()
             val currentLastEventId = amplitude.storage.read(Storage.Constants.LAST_EVENT_ID)?.toLongOrNull()
@@ -87,7 +87,7 @@ public class RemnantDataMigration(public val amplitude: Amplitude, private val d
                 amplitude.storage.write(Storage.Constants.LAST_EVENT_ID, lastEventId.toString())
                 databaseStorage.removeLongValue(LAST_EVENT_ID_KEY)
             }
-        } catch (e: Exception) {
+        }.onFailure { e ->
             LogcatLogger.logger.error(
                 "session data migration failed: ${e.message}",
             )
@@ -95,13 +95,13 @@ public class RemnantDataMigration(public val amplitude: Amplitude, private val d
     }
 
     private suspend fun moveEvents() {
-        try {
+        runCatchingCancellable {
             val remnantEvents = databaseStorage.readEventsContent()
 
             for (event in remnantEvents) {
                 moveEvent(event, amplitude.storage, databaseStorage::removeEvent)
             }
-        } catch (e: Exception) {
+        }.onFailure { e ->
             LogcatLogger.logger.error(
                 "events migration failed: ${e.message}",
             )
@@ -109,13 +109,13 @@ public class RemnantDataMigration(public val amplitude: Amplitude, private val d
     }
 
     private suspend fun moveIdentifies() {
-        try {
+        runCatchingCancellable {
             val remnantIdentifies = databaseStorage.readIdentifiesContent()
 
             for (event in remnantIdentifies) {
                 moveEvent(event, amplitude.storage, databaseStorage::removeIdentify)
             }
-        } catch (e: Exception) {
+        }.onFailure { e ->
             LogcatLogger.logger.error(
                 "identifies migration failed: ${e.message}",
             )
@@ -123,13 +123,13 @@ public class RemnantDataMigration(public val amplitude: Amplitude, private val d
     }
 
     private suspend fun moveInterceptedIdentifies() {
-        try {
+        runCatchingCancellable {
             val remnantIdentifies = databaseStorage.readInterceptedIdentifiesContent()
 
             for (event in remnantIdentifies) {
                 moveEvent(event, amplitude.identifyInterceptStorage, databaseStorage::removeInterceptedIdentify)
             }
-        } catch (e: Exception) {
+        }.onFailure { e ->
             LogcatLogger.logger.error(
                 "intercepted identifies migration failed: ${e.message}",
             )
@@ -141,11 +141,11 @@ public class RemnantDataMigration(public val amplitude: Amplitude, private val d
         destinationStorage: Storage,
         removeFromSource: (rowId: Long) -> Unit,
     ) {
-        try {
+        runCatchingCancellable {
             val rowId = convertLegacyEvent(event)
             destinationStorage.writeEvent(event.toBaseEvent())
             removeFromSource(rowId)
-        } catch (e: Exception) {
+        }.onFailure { e ->
             LogcatLogger.logger.error(
                 "event migration failed: ${e.message}",
             )

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -17,6 +17,7 @@ import com.amplitude.android.utilities.ActivityCallbackType
 import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.android.utilities.DefaultEventUtils
 import com.amplitude.android.utilities.getVersionCode
+import com.amplitude.android.utilities.runCatchingCancellable
 import com.amplitude.core.Amplitude
 import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.Storage
@@ -256,10 +257,10 @@ public class AndroidLifecyclePlugin(
 
         amplitude.amplitudeScope.launch(amplitude.storageIODispatcher) {
             amplitude.isBuilt.await()
-            try {
+            runCatchingCancellable {
                 storage.write(Storage.Constants.APP_VERSION, currentVersion)
                 storage.write(Storage.Constants.APP_BUILD, currentBuild)
-            } catch (e: Exception) {
+            }.onFailure { e ->
                 amplitude.logger.error("Failed to persist app version/build: $e")
             }
         }

--- a/android/src/main/java/com/amplitude/android/utilities/KotlinUtils.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/KotlinUtils.kt
@@ -1,0 +1,26 @@
+package com.amplitude.android.utilities
+
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Like [runCatching], but rethrows [CancellationException] so coroutine cancellation is not
+ * swallowed into a failed [Result].
+ *
+ * [finally] always runs, including when [CancellationException] is rethrown.
+ * Pass it by name so the trailing lambda remains [block]:
+ * `runCatchingCancellable(finally = { cleanup() }) { work() }`.
+ */
+internal inline fun <T, R> T.runCatchingCancellable(
+    finally: () -> Unit = {},
+    block: T.() -> R,
+): Result<R> {
+    return try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.failure(e)
+    } finally {
+        finally()
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/utilities/KotlinUtilsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/KotlinUtilsTest.kt
@@ -1,0 +1,64 @@
+package com.amplitude.android.utilities
+
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KotlinUtilsTest {
+    @Test
+    fun `runCatchingCancellable returns success when block completes`() {
+        val result = runCatchingCancellable { "ok" }
+
+        assertTrue(result.isSuccess)
+        assertEquals("ok", result.getOrNull())
+    }
+
+    @Test
+    fun `runCatchingCancellable returns failure for non-cancellation exceptions`() {
+        val result = runCatchingCancellable { error("boom") }
+
+        assertTrue(result.isFailure)
+        assertEquals("boom", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `runCatchingCancellable rethrows CancellationException`() {
+        assertThrows(CancellationException::class.java) {
+            runCatchingCancellable { throw CancellationException("cancelled") }
+        }
+    }
+
+    @Test
+    fun `runCatchingCancellable runs finally on success`() {
+        var ran = false
+
+        runCatchingCancellable(finally = { ran = true }) { "ok" }
+
+        assertTrue(ran)
+    }
+
+    @Test
+    fun `runCatchingCancellable runs finally on failure`() {
+        var ran = false
+
+        runCatchingCancellable(finally = { ran = true }) { error("boom") }
+
+        assertTrue(ran)
+    }
+
+    @Test
+    fun `runCatchingCancellable runs finally when CancellationException is rethrown`() {
+        var ran = false
+
+        assertThrows(CancellationException::class.java) {
+            runCatchingCancellable(finally = { ran = true }) {
+                throw CancellationException("cancelled")
+            }
+        }
+        assertTrue(ran)
+    }
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉
Please fill out the following sections to help us quickly review your pull request.
--->

### Describe what this PR is addressing
Broad `try / catch (Exception|Throwable)` and [runCatching](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/run-catching.html) on coroutine paths can swallow `CancellationException` into a failed `Result` or log it as an error, delaying/preventing cooperative cancellation on pipeline, remote config, diagnostics, and migration work.

### Describe the solution
* Add internal `runCatchingCancellable` (core + android) — like `runCatching`, but rethrows `CancellationException`. Optional `finally` always runs (including on cancel); pass it by name so the trailing lambda stays the work block.
* Migrate strong coroutine catch sites to use it: `EventPipeline`, `IdentifyInterceptor`, `RemoteConfigClient`, `DiagnosticsClientImpl`, Android migrations, `AndroidLifecyclePlugin`, and `Amplitude.retire()`.
* Widen `logWithStackTrace` to `Throwable` so failure handlers match the helper’s failure set.

### Steps to verify the change
* `./gradlew :analytics-core:test --tests 'com.amplitude.core.utilities.KotlinUtilsTest'`
* `./gradlew :android:testDebugUnitTest --tests 'com.amplitude.android.utilities.KotlinUtilsTest'`
* `./gradlew :analytics-core:test :android:test`

### Useful links and documentation (optional)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches critical event upload/write and remote-config coroutine paths, with a control-flow rewrite in `EventPipeline`. Risk is mostly around cancellation and retry behavior rather than new product logic.
> 
> **Overview**
> Stops broad `catch`/`runCatching` sites from swallowing `CancellationException` on coroutine paths, so cancellation can propagate through pipeline, remote config, diagnostics, and migration work.
> 
> Adds internal `runCatchingCancellable` in both `analytics-core` and `android` (like `runCatching`, but rethrows cancellation; optional `finally` always runs). Migrates the main coroutine catch sites to it, including `EventPipeline` write/upload, `RemoteConfigClient`, `DiagnosticsClientImpl`, identify intercept, Android storage migrations, and `Amplitude.retire()`.
> 
> Also widens `logWithStackTrace` to `Throwable` so failure handlers match the helper’s catch set. The `EventPipeline` upload loop is lightly restructured to return a `shouldStop` flag from the cancellable block while preserving retry/break behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e316b4650fc94674fb968494788f9730c0d58395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->