### PR TITLE
fix: safe-parse non-JSON 4xx upload responses

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/utilities/http/AnalyticsResponse.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/http/AnalyticsResponse.kt
@@ -20,9 +20,9 @@ public sealed class AnalyticsResponse(public val status: HttpStatus) {
         ): AnalyticsResponse {
             return when (responseCode) {
                 in SUCCESS.range -> SuccessResponse()
-                in BAD_REQUEST.range -> BadRequestResponse(JSONObject(responseBody))
-                in PAYLOAD_TOO_LARGE.range -> PayloadTooLargeResponse(JSONObject(responseBody))
-                in TOO_MANY_REQUESTS.range -> TooManyRequestsResponse(JSONObject(responseBody))
+                in BAD_REQUEST.range -> BadRequestResponse(parseResponseBodyOrGetDefault(responseBody))
+                in PAYLOAD_TOO_LARGE.range -> PayloadTooLargeResponse(parseResponseBodyOrGetDefault(responseBody))
+                in TOO_MANY_REQUESTS.range -> TooManyRequestsResponse(parseResponseBodyOrGetDefault(responseBody))
                 in TIMEOUT.range -> TimeoutResponse()
                 else -> FailedResponse(parseResponseBodyOrGetDefault(responseBody))
             }

--- a/analytics-core/src/main/java/com/amplitude/core/utilities/http/AnalyticsResponse.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/http/AnalyticsResponse.kt
@@ -29,14 +29,14 @@ public sealed class AnalyticsResponse(public val status: HttpStatus) {
         }
 
         private fun parseResponseBodyOrGetDefault(responseBody: String?): JSONObject {
-            val defaultObject = JSONObject()
-            if (responseBody.isNullOrEmpty()) return defaultObject
+            if (responseBody.isNullOrEmpty()) return JSONObject()
 
             return try {
                 JSONObject(responseBody)
             } catch (ignored: Exception) {
-                defaultObject.put("error", responseBody)
-                defaultObject
+                // Unparseable bodies must not populate "error" — that field drives
+                // terminal control flow such as isInvalidApiKeyResponse().
+                JSONObject()
             }
         }
     }

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/FileResponseHandlerTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/FileResponseHandlerTest.kt
@@ -7,6 +7,7 @@ import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.diagnostics.DiagnosticsClient
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.EventPipeline
+import com.amplitude.core.utilities.http.AnalyticsResponse
 import com.amplitude.core.utilities.http.BadRequestResponse
 import com.amplitude.core.utilities.http.FailedResponse
 import com.amplitude.core.utilities.http.PayloadTooLargeResponse
@@ -246,6 +247,51 @@ class FileResponseHandlerTest {
             storage.removeFile("file_path")
         }
         assertFalse(shouldRetryUploadOnFailure)
+    }
+
+    @Test
+    fun `bad request with plain text proxy body releases file for retry`() {
+        val response = AnalyticsResponse.create(400, "invalid_api_key") as BadRequestResponse
+        val shouldRetryUploadOnFailure =
+            handler.handleBadRequestResponse(
+                badRequestResponse = response,
+                events = "file_path",
+                eventsString =
+                    JSONUtil.eventsToString(
+                        listOf(
+                            generateBaseEvent("test1"),
+                            generateBaseEvent("test2"),
+                        ),
+                    ),
+            )
+
+        verify(exactly = 1) {
+            storage.releaseFile("file_path")
+        }
+        verify(exactly = 0) {
+            storage.removeFile("file_path")
+        }
+        assertTrue(shouldRetryUploadOnFailure)
+    }
+
+    @Test
+    fun `payload too large with plain text body splits the file`() {
+        val response = AnalyticsResponse.create(413, "Request too large.") as PayloadTooLargeResponse
+        handler.handlePayloadTooLargeResponse(
+            payloadTooLargeResponse = response,
+            events = "file_path",
+            eventsString =
+                JSONUtil.eventsToString(
+                    listOf(
+                        generateBaseEvent("test1"),
+                        generateBaseEvent("test2"),
+                    ),
+                ),
+        )
+
+        verify(exactly = 1) {
+            storage.splitEventFile("file_path", any())
+        }
     }
 
     @Test

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/HttpClientTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/HttpClientTest.kt
@@ -187,7 +187,7 @@ class HttpClientTest {
         runRequest()
         assertTrue(503 in response.status.range)
         val responseBody = response as FailedResponse
-        assertEquals("<html>Error occurred</html>", responseBody.error)
+        assertEquals("", responseBody.error)
     }
 
     @Test
@@ -208,15 +208,15 @@ class HttpClientTest {
 
         val badRequest = httpClient.upload(events)
         assertTrue(badRequest is BadRequestResponse)
-        assertEquals("invalid_api_key", (badRequest as BadRequestResponse).error)
+        assertEquals("", (badRequest as BadRequestResponse).error)
 
         val payloadTooLarge = httpClient.upload(events)
         assertTrue(payloadTooLarge is PayloadTooLargeResponse)
-        assertEquals("Request too large.", (payloadTooLarge as PayloadTooLargeResponse).error)
+        assertEquals("", (payloadTooLarge as PayloadTooLargeResponse).error)
 
         val tooManyRequests = httpClient.upload(events)
         assertTrue(tooManyRequests is TooManyRequestsResponse)
-        assertEquals("Too many requests", (tooManyRequests as TooManyRequestsResponse).error)
+        assertEquals("", (tooManyRequests as TooManyRequestsResponse).error)
     }
 
     @Test

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/HttpClientTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/HttpClientTest.kt
@@ -3,8 +3,11 @@ package com.amplitude.core.utilities
 import com.amplitude.common.Logger
 import com.amplitude.core.Configuration
 import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.utilities.http.BadRequestResponse
 import com.amplitude.core.utilities.http.FailedResponse
 import com.amplitude.core.utilities.http.HttpClient
+import com.amplitude.core.utilities.http.PayloadTooLargeResponse
+import com.amplitude.core.utilities.http.TooManyRequestsResponse
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
@@ -185,6 +188,35 @@ class HttpClientTest {
         assertTrue(503 in response.status.range)
         val responseBody = response as FailedResponse
         assertEquals("<html>Error occurred</html>", responseBody.error)
+    }
+
+    @Test
+    fun `upload does not throw on non-json 400 413 and 429`() {
+        server.enqueue(MockResponse().setResponseCode(400).setBody("invalid_api_key"))
+        server.enqueue(MockResponse().setResponseCode(413).setBody("Request too large."))
+        server.enqueue(MockResponse().setResponseCode(429).setBody("Too many requests"))
+
+        val config =
+            Configuration(
+                apiKey = apiKey,
+                serverUrl = server.url("/").toString(),
+            )
+        val event = BaseEvent()
+        event.eventType = "test"
+        val events = JSONUtil.eventsToString(listOf(event))
+        val httpClient = HttpClient(config, silentLogger)
+
+        val badRequest = httpClient.upload(events)
+        assertTrue(badRequest is BadRequestResponse)
+        assertEquals("invalid_api_key", (badRequest as BadRequestResponse).error)
+
+        val payloadTooLarge = httpClient.upload(events)
+        assertTrue(payloadTooLarge is PayloadTooLargeResponse)
+        assertEquals("Request too large.", (payloadTooLarge as PayloadTooLargeResponse).error)
+
+        val tooManyRequests = httpClient.upload(events)
+        assertTrue(tooManyRequests is TooManyRequestsResponse)
+        assertEquals("Too many requests", (tooManyRequests as TooManyRequestsResponse).error)
     }
 
     @Test

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/http/AnalyticsResponseTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/http/AnalyticsResponseTest.kt
@@ -6,6 +6,7 @@ import org.json.JSONObject
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class AnalyticsResponseTest {
@@ -16,6 +17,23 @@ class AnalyticsResponseTest {
             assertTrue(response is SuccessResponse)
             assertEquals(HttpStatus.SUCCESS, response.status)
         }
+    }
+
+    @Test
+    fun `test create bad request response`() {
+        val responseBody =
+            JSONObject().apply {
+                put("error", "Invalid API key")
+                put("events_with_invalid_fields", JSONObject().put("time", JSONArray().put(0)))
+            }.toString()
+
+        val response = AnalyticsResponse.create(400, responseBody)
+        assertTrue(response is BadRequestResponse)
+        response as BadRequestResponse
+        assertEquals(HttpStatus.BAD_REQUEST, response.status)
+        assertEquals("Invalid API key", response.error)
+        assertEquals(setOf(0), response.getEventIndicesToDrop())
+        assertTrue(response.isInvalidApiKeyResponse())
     }
 
     @Test
@@ -90,5 +108,52 @@ class AnalyticsResponseTest {
         assertTrue(response is FailedResponse)
         assertEquals(HttpStatus.FAILED, response.status)
         assertEquals("", (response as FailedResponse).error)
+    }
+
+    @Nested
+    inner class `non-json 4xx bodies` {
+        @Test
+        fun `should parse plain text 400 as bad request without throwing`() {
+            val response = AnalyticsResponse.create(400, "invalid_api_key")
+            assertTrue(response is BadRequestResponse)
+            response as BadRequestResponse
+            assertEquals(HttpStatus.BAD_REQUEST, response.status)
+            assertEquals("invalid_api_key", response.error)
+            assertTrue(response.getEventIndicesToDrop().isEmpty())
+            assertFalse(response.isInvalidApiKeyResponse())
+        }
+
+        @Test
+        fun `should parse plain text 413 as payload too large without throwing`() {
+            val response = AnalyticsResponse.create(413, "Request too large.")
+            assertTrue(response is PayloadTooLargeResponse)
+            assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, response.status)
+            assertEquals("Request too large.", (response as PayloadTooLargeResponse).error)
+        }
+
+        @Test
+        fun `should parse plain text 429 as too many requests without throwing`() {
+            val response = AnalyticsResponse.create(429, "Too many requests")
+            assertTrue(response is TooManyRequestsResponse)
+            response as TooManyRequestsResponse
+            assertEquals(HttpStatus.TOO_MANY_REQUESTS, response.status)
+            assertEquals("Too many requests", response.error)
+            assertTrue(response.throttledEvents.isEmpty())
+        }
+
+        @Test
+        fun `should parse null 4xx bodies without throwing`() {
+            listOf(400, 413, 429).forEach { statusCode ->
+                val response = AnalyticsResponse.create(statusCode, null)
+                assertEquals(
+                    when (statusCode) {
+                        400 -> HttpStatus.BAD_REQUEST
+                        413 -> HttpStatus.PAYLOAD_TOO_LARGE
+                        else -> HttpStatus.TOO_MANY_REQUESTS
+                    },
+                    response.status,
+                )
+            }
+        }
     }
 }

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/http/AnalyticsResponseTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/http/AnalyticsResponseTest.kt
@@ -98,7 +98,7 @@ class AnalyticsResponseTest {
             val response = AnalyticsResponse.create(it, "Invalid JSON")
             assertTrue(response is FailedResponse)
             assertEquals(HttpStatus.FAILED, response.status)
-            assertEquals("Invalid JSON", (response as FailedResponse).error)
+            assertEquals("", (response as FailedResponse).error)
         }
     }
 
@@ -118,9 +118,16 @@ class AnalyticsResponseTest {
             assertTrue(response is BadRequestResponse)
             response as BadRequestResponse
             assertEquals(HttpStatus.BAD_REQUEST, response.status)
-            assertEquals("invalid_api_key", response.error)
+            assertEquals("", response.error)
             assertTrue(response.getEventIndicesToDrop().isEmpty())
             assertFalse(response.isInvalidApiKeyResponse())
+        }
+
+        @Test
+        fun `should not treat plain text invalid api key as terminal`() {
+            val response = AnalyticsResponse.create(400, "Invalid API key: leaked-from-proxy")
+            assertTrue(response is BadRequestResponse)
+            assertFalse((response as BadRequestResponse).isInvalidApiKeyResponse())
         }
 
         @Test
@@ -128,7 +135,7 @@ class AnalyticsResponseTest {
             val response = AnalyticsResponse.create(413, "Request too large.")
             assertTrue(response is PayloadTooLargeResponse)
             assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, response.status)
-            assertEquals("Request too large.", (response as PayloadTooLargeResponse).error)
+            assertEquals("", (response as PayloadTooLargeResponse).error)
         }
 
         @Test
@@ -137,7 +144,7 @@ class AnalyticsResponseTest {
             assertTrue(response is TooManyRequestsResponse)
             response as TooManyRequestsResponse
             assertEquals(HttpStatus.TOO_MANY_REQUESTS, response.status)
-            assertEquals("Too many requests", response.error)
+            assertEquals("", response.error)
             assertTrue(response.throttledEvents.isEmpty())
         }
 


### PR DESCRIPTION
### Describe what this PR is addressing
Custom `serverUrl` proxies that return non-JSON 400/413/429 caused `AnalyticsResponse.create()` to throw before `responseHandler.handle()` ran. The event file was never released, removed, or split — permanent silent stall ([SDK-215](https://linear.app/amplitude/issue/SDK-215/android-sdk-strands-events-on-non-json-4xx-proxy-response)).

### Describe the solution
Route 400/413/429 through `parseResponseBodyOrGetDefault()` (same as 5xx). Keep status-specific types so existing handlers still run (proxy 400 → release+retry, 413 → split, 429 → retry).

Intent: stop stranding and match Swift/TS parse resilience. This does **not** turn a persistent plain-text 400 into a successful upload — proxies should still return [HTTP V2 JSON](https://amplitude.com/docs/apis/analytics/http-v2#response).

### Steps to verify the change
* `./gradlew :analytics-core:test --tests "com.amplitude.core.utilities.http.AnalyticsResponseTest" --tests "com.amplitude.core.utilities.HttpClientTest" --tests "com.amplitude.core.utilities.FileResponseHandlerTest"`
* Plain-text/null 400/413/429 parse without throw; plain-text 400 releases; plain-text 413 splits.

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes upload error parsing and invalid-API-key detection for malformed 4xx bodies; behavior shifts from discarding/stranding to retry/split, which is the intended fix but affects the event pipeline on proxy errors.
> 
> **Overview**
> Fixes **silent event-file stalls** when a custom `serverUrl` proxy returns plain-text or non-JSON bodies for HTTP 400, 413, or 429. Those statuses now go through `parseResponseBodyOrGetDefault()` (same path as 5xx) so `AnalyticsResponse.create()` no longer throws before upload response handling runs.
> 
> **Unparseable bodies** no longer copy the raw text into the JSON `error` field; they yield an empty `JSONObject` instead. That keeps proxy strings like `invalid_api_key` from tripping **`isInvalidApiKeyResponse()`** and dropping batches as a terminal invalid-key case. Status-specific types are unchanged, so handlers still run: proxy 400 → release and retry, 413 → split, 429 → retry.
> 
> Tests cover parsing, `HttpClient` uploads, and `FileResponseHandler` behavior for plain-text 4xx bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46400b8084299231c916580ba96c6405b3507a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->