### PR TITLE
feat: capture uncaught Android exceptions for diagnostics

### DIFF
--- a/analytics-core/api/analytics-core.api
+++ b/analytics-core/api/analytics-core.api
@@ -85,6 +85,7 @@ public class com/amplitude/core/Amplitude : com/amplitude/core/platform/PluginHo
 	public final fun identify (Ljava/util/Map;Lcom/amplitude/core/events/EventOptions;)Lcom/amplitude/core/Amplitude;
 	public static synthetic fun identify$default (Lcom/amplitude/core/Amplitude;Lcom/amplitude/core/events/Identify;Lcom/amplitude/core/events/EventOptions;ILjava/lang/Object;)Lcom/amplitude/core/Amplitude;
 	public static synthetic fun identify$default (Lcom/amplitude/core/Amplitude;Ljava/util/Map;Lcom/amplitude/core/events/EventOptions;ILjava/lang/Object;)Lcom/amplitude/core/Amplitude;
+	protected fun initWatchers ()V
 	public final fun isBuilt ()Lkotlinx/coroutines/Deferred;
 	public final fun logEvent (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/Amplitude;
 	public final fun logRevenue (Lcom/amplitude/core/events/Revenue;)Lcom/amplitude/core/Amplitude;

--- a/analytics-core/api/analytics-core.api
+++ b/analytics-core/api/analytics-core.api
@@ -378,6 +378,7 @@ public abstract interface class com/amplitude/core/StorageProvider {
 public abstract interface class com/amplitude/core/diagnostics/DiagnosticsClient {
 	public abstract fun close ()V
 	public abstract fun flush ()V
+	public abstract fun getShouldTrack ()Z
 	public abstract fun increment (Ljava/lang/String;J)V
 	public static synthetic fun increment$default (Lcom/amplitude/core/diagnostics/DiagnosticsClient;Ljava/lang/String;JILjava/lang/Object;)V
 	public abstract fun recordEvent (Ljava/lang/String;Ljava/util/Map;)V

--- a/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -60,6 +60,12 @@ public open class Amplitude(
     public val networkIODispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1),
     public val storageIODispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1),
 ) : PluginHost {
+    // Declared first so watchers start before any other field initializer or `init` runs.
+    init {
+        require(configuration.isValid()) { "invalid configuration" }
+        initWatchers()
+    }
+
     public open val identity: AnalyticsIdentity
         get() =
             object : AnalyticsIdentity {
@@ -169,7 +175,6 @@ public open class Amplitude(
     internal val analyticsClient: AnalyticsClient by lazy { AmplitudeAnalyticsClient(this) }
 
     init {
-        require(configuration.isValid()) { "invalid configuration" }
         timeline = this.createTimeline()
         isBuilt = this.build()
         isBuilt.start()
@@ -199,6 +204,13 @@ public open class Amplitude(
         idContainer = IdentityContainer.getInstance(identityConfiguration)
         identityCoordinator.bootstrap(idContainer.identityManager)
     }
+
+    /**
+     * Installs process-wide watchers, such as an uncaught exception handler, that must be in place
+     * before the SDK does any other work. Runs after configuration validation, ahead of every field
+     * initializer and [build], so a failure during initialization is still observed.
+     */
+    protected open fun initWatchers() {}
 
     protected open fun build(): Deferred<Boolean> {
         val amplitude = this

--- a/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClient.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClient.kt
@@ -9,6 +9,9 @@ import com.amplitude.core.RestrictedAmplitudeFeature
  */
 @RestrictedAmplitudeFeature
 public interface DiagnosticsClient {
+    /** Whether this instance should record diagnostics. */
+    public val shouldTrack: Boolean
+
     /**
      * Set a tag with the given name and value.
      * Tags are metadata labels associated with diagnostics data.

--- a/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
@@ -46,8 +46,9 @@ internal class DiagnosticsClientImpl(
     private val startTimestampSeed: String = startTimestamp.toString()
     private var sampleRate: Double = sampleRate.coerceIn(0.0, 1.0)
 
-    private var shouldTrack: Boolean =
+    override var shouldTrack: Boolean =
         enabled && Sample.isInSample(seed = startTimestampSeed, sampleRate = this.sampleRate)
+        private set
 
     private var didSetBasicTags: Boolean = false
     private var didFlushPreviousSession: Boolean = false

--- a/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
@@ -46,6 +46,7 @@ internal class DiagnosticsClientImpl(
     private val startTimestampSeed: String = startTimestamp.toString()
     private var sampleRate: Double = sampleRate.coerceIn(0.0, 1.0)
 
+    @Volatile
     override var shouldTrack: Boolean =
         enabled && Sample.isInSample(seed = startTimestampSeed, sampleRate = this.sampleRate)
         private set

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -2,6 +2,8 @@ package com.amplitude.android
 
 import android.app.Application
 import android.content.Context
+import com.amplitude.android.crash.CrashCatcher
+import com.amplitude.android.crash.recordCrash
 import com.amplitude.android.diagnostics.AndroidDiagnosticsContextProvider
 import com.amplitude.android.migration.MigrationManager
 import com.amplitude.android.plugins.AnalyticsConnectorIdentityPlugin
@@ -48,6 +50,18 @@ public open class Amplitude internal constructor(
         storageIODispatcher = storageIODispatcher,
     ) {
     public constructor(configuration: Configuration) : this(configuration, State())
+
+    // Assigned in [initWatchers], after configuration validation and before any other
+    // initialization, so the handler covers SDK init without leaking on invalid config.
+    private lateinit var crashCatcher: CrashCatcher
+
+    override fun initWatchers() {
+        crashCatcher =
+            CrashCatcher(
+                context = (configuration as Configuration).context,
+                ioDispatcher = storageIODispatcher,
+            )
+    }
 
     override val sessionId: Long
         get() {
@@ -121,6 +135,10 @@ public open class Amplitude internal constructor(
         // A build that outlives its instance must not install plugins or claim shared state:
         // the replacement owns both by then.
         if (!isActive) return
+
+        crashCatcher.consumePreviousCrash()?.let { previousCrash ->
+            diagnosticsClient.recordCrash(previousCrash)
+        }
 
         val migrationManager = MigrationManager(this)
         migrationManager.migrateOldStorage()

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -60,6 +60,7 @@ public open class Amplitude internal constructor(
             CrashCatcher(
                 context = (configuration as Configuration).context,
                 ioDispatcher = storageIODispatcher,
+                diagnosticsClientLazy = lazy { diagnosticsClient },
             )
     }
 

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -104,24 +104,32 @@ public open class Amplitude internal constructor(
         retired = AtomicBoolean(false)
         activityLifecycleCallbacks = ActivityLifecycleObserver()
         androidContextPlugin = AndroidContextPlugin()
-        val androidConfig = configuration as Configuration
-        crashTrackingRemoteConfig =
-            CrashTrackingRemoteConfig(
-                remoteConfigClient = remoteConfigClient,
-                sdkVersion = BuildConfig.AMPLITUDE_VERSION,
-            )
-        crashTrackingRemoteConfig.initialize()
-        autocaptureManager =
-            AutocaptureManager(
-                initialAutocapture = androidConfig.autocapture,
-                initialInteractionsOptions = androidConfig.interactionsOptions,
-                remoteConfigClient = if (androidConfig.enableAutocaptureRemoteConfig) remoteConfigClient else null,
-                logger = logger,
-                diagnosticsClient = diagnosticsClient,
-            )
-        // Claim the instance name before the build exists, so nothing the build installs can run
-        // before the claim, and a failed claim leaves no build behind.
-        AmplitudeRegistry.activate(this)
+        try {
+            val androidConfig = configuration as Configuration
+            crashTrackingRemoteConfig =
+                CrashTrackingRemoteConfig(
+                    remoteConfigClient = remoteConfigClient,
+                    sdkVersion = BuildConfig.AMPLITUDE_VERSION,
+                )
+            crashTrackingRemoteConfig.initialize()
+            autocaptureManager =
+                AutocaptureManager(
+                    initialAutocapture = androidConfig.autocapture,
+                    initialInteractionsOptions = androidConfig.interactionsOptions,
+                    remoteConfigClient = if (androidConfig.enableAutocaptureRemoteConfig) remoteConfigClient else null,
+                    logger = logger,
+                    diagnosticsClient = diagnosticsClient,
+                )
+            // Claim the instance name before the build exists, so nothing the build installs can run
+            // before the claim, and a failed claim leaves no build behind.
+            AmplitudeRegistry.activate(this)
+        } catch (error: Throwable) {
+            // Watchers are installed in the constructor, before this method. A throw here never
+            // reaches retire(), so drop them before the half-built instance is abandoned.
+            markRetired()
+            detachWatchers()
+            throw error
+        }
         return super.build()
     }
 
@@ -148,7 +156,9 @@ public open class Amplitude internal constructor(
         if (!isActive) return
 
         crashCatcher.consumePreviousCrash()?.let { previousCrash ->
-            diagnosticsClient.recordCrash(previousCrash)
+            AmplitudeRegistry.runIfActive(this) {
+                diagnosticsClient.recordCrash(previousCrash)
+            }
         }
 
         val migrationManager = MigrationManager(this)
@@ -222,6 +232,17 @@ public open class Amplitude internal constructor(
     internal fun markRetired(): Boolean = retired.compareAndSet(false, true)
 
     /**
+     * Releases process-wide watchers started in [initWatchers]. Safe before [retire], including
+     * when construction fails after those watchers are installed.
+     */
+    internal fun detachWatchers() {
+        if (::crashCatcher.isInitialized) {
+            runCatching { crashCatcher.detach() }
+                .onFailure { logger.warn("Failed to detach the crash handler: $it") }
+        }
+    }
+
+    /**
      * Releases what an inactive instance must not keep holding. Nothing here waits on this
      * instance, and queued events still drain to the storage the replacement shares by name.
      */
@@ -234,6 +255,9 @@ public open class Amplitude internal constructor(
         // takes no part in draining, so it goes now rather than behind the drain below.
         runCatching { findPlugin<AndroidLifecyclePlugin>()?.let { remove(it) } }
             .onFailure { logger.warn("Failed to stop Android autocapture: $it") }
+        // The uncaught exception handler cannot be unregistered, so it has to let go of this
+        // instance instead. Crash persistence belongs to whichever instance is still active.
+        detachWatchers()
 
         // The rest go last: they must outlive an in-flight build that is still adding them and the
         // queued events still draining through them. Off the constructor's thread either way, so

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -3,6 +3,7 @@ package com.amplitude.android
 import android.app.Application
 import android.content.Context
 import com.amplitude.android.crash.CrashCatcher
+import com.amplitude.android.crash.CrashTrackingRemoteConfig
 import com.amplitude.android.crash.recordCrash
 import com.amplitude.android.diagnostics.AndroidDiagnosticsContextProvider
 import com.amplitude.android.migration.MigrationManager
@@ -61,6 +62,7 @@ public open class Amplitude internal constructor(
                 context = (configuration as Configuration).context,
                 ioDispatcher = storageIODispatcher,
                 diagnosticsClientLazy = lazy { diagnosticsClient },
+                crashTrackingRemoteConfigLazy = lazy { crashTrackingRemoteConfig },
             )
     }
 
@@ -75,6 +77,8 @@ public open class Amplitude internal constructor(
 
     internal lateinit var autocaptureManager: AutocaptureManager
         private set
+
+    private lateinit var crashTrackingRemoteConfig: CrashTrackingRemoteConfig
 
     // Assigned in [build], not by a field initializer: initializers run after the core constructor,
     // where they would clobber a retirement from a same-name instance racing this one.
@@ -101,6 +105,12 @@ public open class Amplitude internal constructor(
         activityLifecycleCallbacks = ActivityLifecycleObserver()
         androidContextPlugin = AndroidContextPlugin()
         val androidConfig = configuration as Configuration
+        crashTrackingRemoteConfig =
+            CrashTrackingRemoteConfig(
+                remoteConfigClient = remoteConfigClient,
+                sdkVersion = BuildConfig.AMPLITUDE_VERSION,
+            )
+        crashTrackingRemoteConfig.initialize()
         autocaptureManager =
             AutocaptureManager(
                 initialAutocapture = androidConfig.autocapture,

--- a/android/src/main/java/com/amplitude/android/AmplitudeRegistry.kt
+++ b/android/src/main/java/com/amplitude/android/AmplitudeRegistry.kt
@@ -26,6 +26,9 @@ internal object AmplitudeRegistry {
                     // Nothing was claimed and the build does not exist yet, so retiring the
                     // half-built instance is enough; the previous instance keeps the name.
                     instance.markRetired()
+                    // Watchers are installed in the constructor, before this claim, so they
+                    // have to drop the half-built instance even though retire() never runs.
+                    instance.detachWatchers()
                     throw error
                 }
                 activeInstances[instanceName] = WeakReference(instance)

--- a/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
@@ -2,12 +2,16 @@ package com.amplitude.android.crash
 
 import android.content.Context
 import android.os.Process
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.diagnostics.DiagnosticsClient
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.system.exitProcess
 
+@OptIn(RestrictedAmplitudeFeature::class)
 internal class CrashCatcher(
     private val context: Context,
     ioDispatcher: CoroutineDispatcher,
+    private val diagnosticsClientLazy: Lazy<DiagnosticsClient>,
 ) {
     private val defaultCrashHandler = Thread.getDefaultUncaughtExceptionHandler()
     private val crashStorage by lazy {
@@ -20,7 +24,9 @@ internal class CrashCatcher(
     init {
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             try {
-                saveCrashReport(throwable)
+                if (diagnosticsClientLazy.value.shouldTrack) {
+                    saveCrashReport(throwable)
+                }
             } catch (_: Throwable) {
                 // Best-effort: never throw from the uncaught exception handler
             } finally {

--- a/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
@@ -7,6 +7,8 @@ import com.amplitude.core.diagnostics.DiagnosticsClient
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.system.exitProcess
 
+private const val AMPLITUDE_PACKAGE_PREFIX = "com.amplitude."
+
 @OptIn(RestrictedAmplitudeFeature::class)
 internal class CrashCatcher(
     private val context: Context,
@@ -26,6 +28,7 @@ internal class CrashCatcher(
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             try {
                 if (
+                    throwable.isAmplitudeSdkCrash() &&
                     crashTrackingRemoteConfigLazy.value.isCrashTrackingEnabled &&
                     diagnosticsClientLazy.value.shouldTrack
                 ) {
@@ -57,6 +60,18 @@ internal class CrashCatcher(
             lastPersistedThrowable = throwable
             crashStorage.saveCrashReport(throwable)
         }
+    }
+
+    private fun Throwable.isAmplitudeSdkCrash(): Boolean {
+        var current: Throwable? = this
+        val seen = mutableSetOf<Throwable>()
+        while (current != null && seen.add(current)) {
+            if (current.stackTrace.any { it.className.startsWith(AMPLITUDE_PACKAGE_PREFIX) }) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
     }
 
     companion object {

--- a/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
@@ -1,0 +1,56 @@
+package com.amplitude.android.crash
+
+import android.content.Context
+import android.os.Process
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.system.exitProcess
+
+internal class CrashCatcher(
+    private val context: Context,
+    ioDispatcher: CoroutineDispatcher,
+) {
+    private val defaultCrashHandler = Thread.getDefaultUncaughtExceptionHandler()
+    private val crashStorage by lazy {
+        CrashStorage(
+            appContext = context,
+            ioDispatcher = ioDispatcher,
+        )
+    }
+
+    init {
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            try {
+                saveCrashReport(throwable)
+            } catch (_: Throwable) {
+                // Best-effort: never throw from the uncaught exception handler
+            } finally {
+                defaultCrashHandler?.uncaughtException(thread, throwable)
+                    ?: run {
+                        // If no handler to chain to, kill the process
+                        Process.killProcess(Process.myPid())
+                        exitProcess(10)
+                    }
+            }
+        }
+    }
+
+    suspend fun consumePreviousCrash(): String? {
+        return crashStorage.consumePreviousCrash()
+    }
+
+    private fun saveCrashReport(throwable: Throwable) {
+        synchronized(storageLock) {
+            if (lastPersistedThrowable === throwable) {
+                // Already written; skip if another handler in the chain persists the same crash
+                return
+            }
+            lastPersistedThrowable = throwable
+            crashStorage.saveCrashReport(throwable)
+        }
+    }
+
+    companion object {
+        private val storageLock = Any()
+        private var lastPersistedThrowable: Throwable? = null
+    }
+}

--- a/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
@@ -12,6 +12,7 @@ internal class CrashCatcher(
     private val context: Context,
     ioDispatcher: CoroutineDispatcher,
     private val diagnosticsClientLazy: Lazy<DiagnosticsClient>,
+    private val crashTrackingRemoteConfigLazy: Lazy<CrashTrackingRemoteConfig>,
 ) {
     private val defaultCrashHandler = Thread.getDefaultUncaughtExceptionHandler()
     private val crashStorage by lazy {
@@ -24,7 +25,10 @@ internal class CrashCatcher(
     init {
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             try {
-                if (diagnosticsClientLazy.value.shouldTrack) {
+                if (
+                    crashTrackingRemoteConfigLazy.value.isCrashTrackingEnabled &&
+                    diagnosticsClientLazy.value.shouldTrack
+                ) {
                     saveCrashReport(throwable)
                 }
             } catch (_: Throwable) {

--- a/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
@@ -11,11 +11,12 @@ private const val AMPLITUDE_PACKAGE_PREFIX = "com.amplitude."
 
 @OptIn(RestrictedAmplitudeFeature::class)
 internal class CrashCatcher(
-    private val context: Context,
+    context: Context,
     ioDispatcher: CoroutineDispatcher,
     private val diagnosticsClientLazy: Lazy<DiagnosticsClient>,
     private val crashTrackingRemoteConfigLazy: Lazy<CrashTrackingRemoteConfig>,
 ) {
+    private val context = context.applicationContext
     private val defaultCrashHandler = Thread.getDefaultUncaughtExceptionHandler()
     private val crashStorage by lazy {
         CrashStorage(

--- a/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashCatcher.kt
@@ -13,39 +13,58 @@ private const val AMPLITUDE_PACKAGE_PREFIX = "com.amplitude."
 internal class CrashCatcher(
     context: Context,
     ioDispatcher: CoroutineDispatcher,
-    private val diagnosticsClientLazy: Lazy<DiagnosticsClient>,
-    private val crashTrackingRemoteConfigLazy: Lazy<CrashTrackingRemoteConfig>,
+    diagnosticsClientLazy: Lazy<DiagnosticsClient>,
+    crashTrackingRemoteConfigLazy: Lazy<CrashTrackingRemoteConfig>,
 ) {
-    private val context = context.applicationContext
-    private val defaultCrashHandler = Thread.getDefaultUncaughtExceptionHandler()
+    private val appContext = context.applicationContext
     private val crashStorage by lazy {
         CrashStorage(
-            appContext = context,
+            appContext = appContext,
             ioDispatcher = ioDispatcher,
         )
     }
 
+    // The handler outlives this instance and these capture the SDK instance that created it, so
+    // [detach] drops them once that instance is retired.
+    private var diagnosticsClientProvider: Lazy<DiagnosticsClient>? = diagnosticsClientLazy
+    private var crashTrackingRemoteConfigProvider: Lazy<CrashTrackingRemoteConfig>? = crashTrackingRemoteConfigLazy
+
     init {
-        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-            try {
-                if (
-                    throwable.isAmplitudeSdkCrash() &&
-                    crashTrackingRemoteConfigLazy.value.isCrashTrackingEnabled &&
-                    diagnosticsClientLazy.value.shouldTrack
-                ) {
-                    saveCrashReport(throwable)
-                }
-            } catch (_: Throwable) {
-                // Best-effort: never throw from the uncaught exception handler
-            } finally {
-                defaultCrashHandler?.uncaughtException(thread, throwable)
-                    ?: run {
-                        // If no handler to chain to, kill the process
-                        Process.killProcess(Process.myPid())
-                        exitProcess(10)
+        synchronized(handlerInstallLock) {
+            val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
+            Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+                try {
+                    if (
+                        throwable.isAmplitudeSdkCrash() &&
+                        crashTrackingRemoteConfigProvider?.value?.isCrashTrackingEnabled == true &&
+                        // Persist only when this session is already sampled in. That misses
+                        // crashes before remote config arrives (default sample rate is 0), but
+                        // avoids writing crash files in unsampled sessions.
+                        diagnosticsClientProvider?.value?.shouldTrack == true
+                    ) {
+                        saveCrashReport(throwable)
                     }
+                } catch (_: Throwable) {
+                    // Best-effort: never throw from the uncaught exception handler
+                } finally {
+                    previousHandler?.uncaughtException(thread, throwable)
+                        ?: run {
+                            // If no handler to chain to, kill the process
+                            Process.killProcess(Process.myPid())
+                            exitProcess(10)
+                        }
+                }
             }
         }
+    }
+
+    /**
+     * Stops persisting crashes and releases the SDK instance this catcher reads from. The handler
+     * stays in the chain, since it cannot be unregistered, but it holds nothing afterwards.
+     */
+    fun detach() {
+        diagnosticsClientProvider = null
+        crashTrackingRemoteConfigProvider = null
     }
 
     suspend fun consumePreviousCrash(): String? {
@@ -76,6 +95,7 @@ internal class CrashCatcher(
     }
 
     companion object {
+        private val handlerInstallLock = Any()
         private val storageLock = Any()
         private var lastPersistedThrowable: Throwable? = null
     }

--- a/android/src/main/java/com/amplitude/android/crash/CrashDiagnostics.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashDiagnostics.kt
@@ -1,0 +1,23 @@
+package com.amplitude.android.crash
+
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.diagnostics.DiagnosticsClient
+
+private const val CRASH_EVENT_NAME = "analytics.crash"
+private const val CRASH_REPORT_PROPERTY = "report"
+
+/**
+ * Records a crash report from the previous app run as an `analytics.crash` counter and an
+ * `analytics.crash` event carrying the report text, matching the iOS diagnostics schema.
+ *
+ * The report is buffered regardless of sampling; upload stays gated on the session being
+ * sampled in, so a crash consumed before remote config arrives is not lost.
+ */
+@OptIn(RestrictedAmplitudeFeature::class)
+internal fun DiagnosticsClient.recordCrash(crashString: String) {
+    increment(CRASH_EVENT_NAME)
+    recordEvent(
+        CRASH_EVENT_NAME,
+        mapOf(CRASH_REPORT_PROPERTY to crashString),
+    )
+}

--- a/android/src/main/java/com/amplitude/android/crash/CrashDiagnostics.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashDiagnostics.kt
@@ -10,8 +10,9 @@ private const val CRASH_REPORT_PROPERTY = "report"
  * Records a crash report from the previous app run as an `analytics.crash` counter and an
  * `analytics.crash` event carrying the report text, matching the iOS diagnostics schema.
  *
- * The report is buffered regardless of sampling; upload stays gated on the session being
- * sampled in, so a crash consumed before remote config arrives is not lost.
+ * Persistence at crash time is gated on diagnostics sampling ([DiagnosticsClient.shouldTrack]).
+ * Once a report has been consumed, this buffers it even if sampling has not yet resolved for
+ * the new session; upload stays gated on the session being sampled in.
  */
 @OptIn(RestrictedAmplitudeFeature::class)
 internal fun DiagnosticsClient.recordCrash(crashString: String) {

--- a/android/src/main/java/com/amplitude/android/crash/CrashStorage.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashStorage.kt
@@ -1,0 +1,104 @@
+package com.amplitude.android.crash
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+
+private const val STORAGE_PREFIX = "com.amplitude.crash_report"
+private const val CRASH_REPORT_FILE_NAME = "com.amplitude.crash_report"
+private const val MAX_STACK_FRAMES = 64
+private const val MAX_CAUSE_DEPTH = 4
+
+internal class CrashStorage(
+    private val appContext: Context,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
+
+    val directory: File by lazy {
+        File(
+            appContext.getDir("amplitude", Context.MODE_PRIVATE),
+            STORAGE_PREFIX,
+        ).also {
+            it.mkdirs()
+        }
+    }
+
+    /** This performs I/O but must be done synchronously */
+    fun saveCrashReport(throwable: Throwable) {
+        synchronized(fileLock) {
+            val file = File(directory, CRASH_REPORT_FILE_NAME)
+            FileOutputStream(file).use { stream ->
+                PrintWriter(OutputStreamWriter(stream, Charsets.UTF_8)).apply {
+                    print("Uncaught Exception: ")
+                    println(throwable.javaClass.name)
+                    print("Message: ")
+                    println(throwable.message ?: "")
+                    println()
+                    println("Stack Trace:")
+                    printThrowable(throwable)
+                    flush()
+                }
+                stream.fd.sync()
+            }
+        }
+    }
+
+    suspend fun consumePreviousCrash(): String? =
+        withContext(ioDispatcher) {
+            synchronized(fileLock) {
+                val file = File(directory, CRASH_REPORT_FILE_NAME)
+                if (!file.exists()) return@withContext null
+                try {
+                    file.readText().ifEmpty { null }
+                } catch (_: Exception) {
+                    null
+                } finally {
+                    file.delete()
+                }
+            }
+        }
+
+    private fun PrintWriter.printThrowable(throwable: Throwable) {
+        var current: Throwable? = throwable
+        var remainingFrames = MAX_STACK_FRAMES
+        var causeDepth = 0
+        var truncated = false
+
+        while (current != null && remainingFrames > 0 && causeDepth < MAX_CAUSE_DEPTH) {
+            if (causeDepth > 0) {
+                print("Caused by: ")
+                print(current.javaClass.name)
+                current.message?.let { message ->
+                    print(": ")
+                    print(message)
+                }
+                println()
+            }
+
+            val stackFrames = current.stackTrace
+            val framesToWrite = minOf(stackFrames.size, remainingFrames)
+            for (index in 0 until framesToWrite) {
+                print("\tat ")
+                println(stackFrames[index])
+            }
+            if (stackFrames.size > framesToWrite) {
+                truncated = true
+            }
+            remainingFrames -= framesToWrite
+            current = current.cause?.takeUnless { it === current }
+            causeDepth++
+        }
+
+        if (truncated || current != null) {
+            println("\t... crash report truncated")
+        }
+    }
+
+    companion object {
+        private val fileLock = Any()
+    }
+}

--- a/android/src/main/java/com/amplitude/android/crash/CrashTrackingRemoteConfig.kt
+++ b/android/src/main/java/com/amplitude/android/crash/CrashTrackingRemoteConfig.kt
@@ -1,0 +1,47 @@
+package com.amplitude.android.crash
+
+import com.amplitude.android.utilities.SemVer
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.remoteconfig.ConfigMap
+import com.amplitude.core.remoteconfig.RemoteConfigClient
+import java.util.concurrent.atomic.AtomicBoolean
+
+private const val AVAILABILITIES = "availabilities"
+private const val CRASH_TRACKING = "CrashTracking"
+
+@OptIn(RestrictedAmplitudeFeature::class)
+internal class CrashTrackingRemoteConfig(
+    private val remoteConfigClient: RemoteConfigClient,
+    private val sdkVersion: String,
+) {
+    private val crashTrackingEnabled = AtomicBoolean(false)
+
+    val isCrashTrackingEnabled: Boolean
+        get() = crashTrackingEnabled.get()
+
+    private val initialized = AtomicBoolean(false)
+
+    // Strong reference to prevent GC since RemoteConfigClient uses WeakReference
+    private lateinit var remoteConfigCallback: RemoteConfigClient.RemoteConfigCallback
+
+    /** idempotent */
+    fun initialize() {
+        if (!initialized.compareAndSet(false, true)) return
+        remoteConfigCallback =
+            RemoteConfigClient.RemoteConfigCallback { config, _, _ ->
+                handleRemoteConfig(config)
+            }.also { callback ->
+                remoteConfigClient.subscribe(RemoteConfigClient.Key.Diagnostics, callback = callback)
+            }
+    }
+
+    private fun handleRemoteConfig(config: ConfigMap?) {
+        if (config == null) return
+
+        val availabilities = config[AVAILABILITIES] as? Map<*, *>
+        val availableFrom = availabilities?.get(CRASH_TRACKING) as? String ?: return
+        val current = SemVer.create(sdkVersion) ?: return
+        val required = SemVer.create(availableFrom) ?: return
+        crashTrackingEnabled.set(current >= required)
+    }
+}

--- a/android/src/main/java/com/amplitude/android/utilities/SemVer.kt
+++ b/android/src/main/java/com/amplitude/android/utilities/SemVer.kt
@@ -1,0 +1,27 @@
+package com.amplitude.android.utilities
+
+internal data class SemVer(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+) : Comparable<SemVer> {
+    override fun compareTo(other: SemVer): Int =
+        compareValuesBy(this, other, SemVer::major, SemVer::minor, SemVer::patch)
+
+    companion object {
+        fun create(versionString: String): SemVer? {
+            val numbers =
+                versionString
+                    .removePrefix("v")
+                    .substringBefore("-")
+                    .split(".")
+                    .map { it.toIntOrNull() ?: return null }
+            if (numbers.isEmpty()) return null
+            return SemVer(
+                major = numbers.getOrElse(0) { 0 },
+                minor = numbers.getOrElse(1) { 0 },
+                patch = numbers.getOrElse(2) { 0 },
+            )
+        }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeAutocaptureInitOrderTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeAutocaptureInitOrderTest.kt
@@ -116,6 +116,7 @@ class AmplitudeAutocaptureInitOrderTest {
     private fun createAutocaptureConfiguration(): Configuration {
         setupMockAndroidContext()
         val context = mockk<Application>(relaxed = true)
+        every { context.applicationContext } returns context
         val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
         every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
         val dirNameSlot = slot<String>()

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeRegistryTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeRegistryTest.kt
@@ -1,0 +1,29 @@
+package com.amplitude.android
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+@RunWith(RobolectricTestRunner::class)
+class AmplitudeRegistryTest {
+    @Test
+    fun `failed activation detaches watchers without retiring`() {
+        val configuration = mockk<Configuration>(relaxed = true)
+        every { configuration.instanceName } returns "failed-crash-detach"
+        val instance = mockk<Amplitude>(relaxed = true)
+        every { instance.configuration } returns configuration
+        every { instance.startAsActiveInstance() } throws IllegalStateException("cannot register")
+
+        assertFailsWith<IllegalStateException> {
+            AmplitudeRegistry.activate(instance)
+        }
+
+        verify(exactly = 1) { instance.markRetired() }
+        verify(exactly = 1) { instance.detachWatchers() }
+        verify(exactly = 0) { instance.retire() }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeReplacementTest.kt
@@ -386,6 +386,7 @@ class AmplitudeReplacementTest {
     private fun mockApplication(): Application {
         setupMockAndroidContext()
         val context = mockk<Application>(relaxed = true)
+        every { context.applicationContext } returns context
         val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
         every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
         val dirNameSlot = slot<String>()

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeRobolectricTests.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeRobolectricTests.kt
@@ -41,6 +41,7 @@ class AmplitudeRobolectricTests {
     @Before
     fun setup() {
         context = mockk<Application>(relaxed = true)
+        every { context.applicationContext } returns context
         connectivityManager = mockk<ConnectivityManager>(relaxed = true)
         every { context.getDir(any(), any()) } returns temporaryFolder.newFolder("data")
         every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeSessionTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeSessionTest.kt
@@ -40,6 +40,7 @@ class AmplitudeSessionTest {
     ): Configuration {
         setupMockAndroidContext()
         val context = mockk<Application>(relaxed = true)
+        every { context.applicationContext } returns context
         val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
         every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
         val dirNameSlot = slot<String>()

--- a/android/src/test/kotlin/com/amplitude/android/AmplitudeTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AmplitudeTest.kt
@@ -60,6 +60,7 @@ class AmplitudeTest {
     ): Configuration {
         setupMockAndroidContext()
         val context = mockk<Application>(relaxed = true)
+        every { context.applicationContext } returns context
         val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
         every {
             context.getSystemService(

--- a/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/PluginContractAndroidTest.kt
@@ -146,6 +146,7 @@ class PluginContractAndroidTest {
     private fun configuration(storageProvider: StorageProvider): Configuration {
         setupMockAndroidContext()
         val context = mockk<Application>(relaxed = true)
+        every { context.applicationContext } returns context
         val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
         every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
         val dirNameSlot = slot<String>()

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherRegistrationTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherRegistrationTest.kt
@@ -12,8 +12,11 @@ import com.amplitude.core.utilities.InMemoryStorageProvider
 import com.amplitude.id.IMIdentityStorageProvider
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.slot
+import io.mockk.unmockkConstructor
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -21,8 +24,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.io.File
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotSame
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -48,6 +53,48 @@ class CrashCatcherRegistrationTest {
 
                 advanceUntilIdle()
             } finally {
+                Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+            }
+        }
+
+    @Test
+    fun `failed build before activate detaches watchers`() =
+        runTest {
+            val originalHandler = Thread.getDefaultUncaughtExceptionHandler()
+            Thread.setDefaultUncaughtExceptionHandler { _, _ -> }
+            mockkConstructor(CrashTrackingRemoteConfig::class)
+            every { anyConstructed<CrashTrackingRemoteConfig>().initialize() } throws
+                IllegalStateException("remote config failed")
+            try {
+                assertFailsWith<IllegalStateException> {
+                    createFakeAmplitude(
+                        scheduler = testScheduler,
+                        configuration = configuration("crash-build-failure"),
+                    )
+                }
+                Thread.getDefaultUncaughtExceptionHandler()!!
+                    .uncaughtException(
+                        Thread.currentThread(),
+                        RuntimeException("boom").apply {
+                            stackTrace =
+                                arrayOf(
+                                    StackTraceElement(
+                                        "com.amplitude.core.platform.EventPipeline",
+                                        "method",
+                                        "File.kt",
+                                        1,
+                                    ),
+                                )
+                        },
+                    )
+                assertNull(
+                    CrashStorage(
+                        appContext = application,
+                        ioDispatcher = StandardTestDispatcher(testScheduler),
+                    ).consumePreviousCrash(),
+                )
+            } finally {
+                unmockkConstructor(CrashTrackingRemoteConfig::class)
                 Thread.setDefaultUncaughtExceptionHandler(originalHandler)
             }
         }

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherRegistrationTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherRegistrationTest.kt
@@ -67,6 +67,7 @@ class CrashCatcherRegistrationTest {
     private fun mockApplication(): Application {
         setupMockAndroidContext()
         val context = mockk<Application>(relaxed = true)
+        every { context.applicationContext } returns context
         val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
         every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
         val dirNameSlot = slot<String>()

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherRegistrationTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherRegistrationTest.kt
@@ -1,0 +1,78 @@
+package com.amplitude.android.crash
+
+import android.app.Application
+import android.content.Context
+import android.net.ConnectivityManager
+import com.amplitude.MainDispatcherRule
+import com.amplitude.android.Configuration
+import com.amplitude.android.utilities.createFakeAmplitude
+import com.amplitude.android.utilities.setupMockAndroidContext
+import com.amplitude.core.utilities.ConsoleLoggerProvider
+import com.amplitude.core.utilities.InMemoryStorageProvider
+import com.amplitude.id.IMIdentityStorageProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class CrashCatcherRegistrationTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val application = mockApplication()
+
+    @Test
+    fun `crash handler is registered while the instance is still being constructed`() =
+        runTest {
+            val originalHandler = Thread.getDefaultUncaughtExceptionHandler()
+            try {
+                val amplitude =
+                    createFakeAmplitude(
+                        scheduler = testScheduler,
+                        configuration = configuration("crash-registration"),
+                    )
+
+                assertNotSame(originalHandler, Thread.getDefaultUncaughtExceptionHandler())
+                assertFalse(amplitude.isBuilt.isCompleted)
+
+                advanceUntilIdle()
+            } finally {
+                Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+            }
+        }
+
+    private fun configuration(instanceName: String) =
+        Configuration(
+            apiKey = "api-key",
+            context = application,
+            instanceName = instanceName,
+            autocapture = setOf(),
+            loggerProvider = ConsoleLoggerProvider(),
+            storageProvider = InMemoryStorageProvider(),
+            identifyInterceptStorageProvider = InMemoryStorageProvider(),
+            identityStorageProvider = IMIdentityStorageProvider(),
+        )
+
+    private fun mockApplication(): Application {
+        setupMockAndroidContext()
+        val context = mockk<Application>(relaxed = true)
+        val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
+        every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        val dirNameSlot = slot<String>()
+        every { context.getDir(capture(dirNameSlot), any()) } answers {
+            File("/tmp/amplitude-kotlin/${dirNameSlot.captured}")
+        }
+        return context
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
@@ -16,6 +16,9 @@ import org.junit.After
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
@@ -68,6 +71,42 @@ class CrashCatcherTest {
                     ioDispatcher = testDispatcher,
                 ).consumePreviousCrash()
             assertTrue(report!!.contains("boom"))
+        }
+
+    @Test
+    fun `concurrent catchers each wrap the previous handler`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            var chainedCount = 0
+            Thread.setDefaultUncaughtExceptionHandler { _, _ -> chainedCount++ }
+
+            val shouldTrackReads = AtomicInteger(0)
+            val start = CyclicBarrier(2)
+            val workers =
+                List(2) {
+                    thread {
+                        val diagnosticsClient = mockk<DiagnosticsClient>(relaxed = true)
+                        every { diagnosticsClient.shouldTrack } answers {
+                            shouldTrackReads.incrementAndGet()
+                            true
+                        }
+                        start.await()
+                        createCrashCatcher(
+                            dispatcher = testDispatcher,
+                            diagnosticsClient = diagnosticsClient,
+                        )
+                    }
+                }
+            workers.forEach { it.join() }
+
+            Thread.getDefaultUncaughtExceptionHandler()!!
+                .uncaughtException(
+                    Thread.currentThread(),
+                    throwableWithFrames("com.amplitude.core.platform.EventPipeline"),
+                )
+
+            assertEquals(1, chainedCount)
+            assertEquals(2, shouldTrackReads.get())
         }
 
     @Test
@@ -173,19 +212,42 @@ class CrashCatcherTest {
             assertTrue(report!!.contains("boom"))
         }
 
+    @Test
+    fun `does not persist after detach`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            Thread.setDefaultUncaughtExceptionHandler { _, _ -> }
+            createCrashCatcher(testDispatcher).detach()
+            Thread.getDefaultUncaughtExceptionHandler()!!
+                .uncaughtException(
+                    Thread.currentThread(),
+                    throwableWithFrames("com.amplitude.core.platform.EventPipeline"),
+                )
+
+            assertNull(
+                CrashStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                ).consumePreviousCrash(),
+            )
+        }
+
     private fun createCrashCatcher(
         dispatcher: CoroutineDispatcher,
         shouldTrack: Boolean = true,
         isCrashTrackingEnabled: Boolean = true,
+        diagnosticsClient: DiagnosticsClient? = null,
     ): CrashCatcher {
-        val diagnosticsClient = mockk<DiagnosticsClient>(relaxed = true)
-        every { diagnosticsClient.shouldTrack } returns shouldTrack
+        val client =
+            diagnosticsClient ?: mockk<DiagnosticsClient>(relaxed = true).also {
+                every { it.shouldTrack } returns shouldTrack
+            }
         val crashTrackingRemoteConfig = mockk<CrashTrackingRemoteConfig>()
         every { crashTrackingRemoteConfig.isCrashTrackingEnabled } returns isCrashTrackingEnabled
         return CrashCatcher(
             context = context,
             ioDispatcher = dispatcher,
-            diagnosticsClientLazy = lazy { diagnosticsClient },
+            diagnosticsClientLazy = lazy { client },
             crashTrackingRemoteConfigLazy = lazy { crashTrackingRemoteConfig },
         )
     }

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
@@ -113,16 +113,37 @@ class CrashCatcherTest {
             )
         }
 
+    @Test
+    fun `does not persist when crash tracking is not enabled`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            Thread.setDefaultUncaughtExceptionHandler { _, _ -> }
+            createCrashCatcher(testDispatcher, isCrashTrackingEnabled = false)
+            Thread.getDefaultUncaughtExceptionHandler()!!
+                .uncaughtException(Thread.currentThread(), RuntimeException("boom"))
+
+            assertNull(
+                CrashStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                ).consumePreviousCrash(),
+            )
+        }
+
     private fun createCrashCatcher(
         dispatcher: CoroutineDispatcher,
         shouldTrack: Boolean = true,
+        isCrashTrackingEnabled: Boolean = true,
     ): CrashCatcher {
         val diagnosticsClient = mockk<DiagnosticsClient>(relaxed = true)
         every { diagnosticsClient.shouldTrack } returns shouldTrack
+        val crashTrackingRemoteConfig = mockk<CrashTrackingRemoteConfig>()
+        every { crashTrackingRemoteConfig.isCrashTrackingEnabled } returns isCrashTrackingEnabled
         return CrashCatcher(
             context = context,
             ioDispatcher = dispatcher,
             diagnosticsClientLazy = lazy { diagnosticsClient },
+            crashTrackingRemoteConfigLazy = lazy { crashTrackingRemoteConfig },
         )
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
@@ -2,9 +2,13 @@ package com.amplitude.android.crash
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.diagnostics.DiagnosticsClient
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.unmockkConstructor
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -18,7 +22,7 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, RestrictedAmplitudeFeature::class)
 @RunWith(RobolectricTestRunner::class)
 class CrashCatcherTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
@@ -47,10 +51,10 @@ class CrashCatcherTest {
             var chainedCount = 0
             Thread.setDefaultUncaughtExceptionHandler { _, _ -> chainedCount++ }
 
-            CrashCatcher(context, testDispatcher)
+            createCrashCatcher(testDispatcher)
             val firstHandler = Thread.getDefaultUncaughtExceptionHandler()
 
-            CrashCatcher(context, testDispatcher)
+            createCrashCatcher(testDispatcher)
             val latestHandler = Thread.getDefaultUncaughtExceptionHandler()
 
             assertNotSame(firstHandler, latestHandler)
@@ -78,13 +82,13 @@ class CrashCatcherTest {
             }
 
             Thread.setDefaultUncaughtExceptionHandler { _, _ -> }
-            CrashCatcher(context, testDispatcher)
+            createCrashCatcher(testDispatcher)
             val firstHandler = Thread.getDefaultUncaughtExceptionHandler()!!
             Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
                 firstHandler.uncaughtException(thread, throwable)
             }
 
-            CrashCatcher(context, testDispatcher)
+            createCrashCatcher(testDispatcher)
             Thread.getDefaultUncaughtExceptionHandler()!!
                 .uncaughtException(Thread.currentThread(), RuntimeException("boom"))
 
@@ -99,7 +103,7 @@ class CrashCatcherTest {
                 appContext = context,
                 ioDispatcher = testDispatcher,
             ).saveCrashReport(RuntimeException("previous"))
-            val report = CrashCatcher(context, testDispatcher).consumePreviousCrash()
+            val report = createCrashCatcher(testDispatcher).consumePreviousCrash()
             assertTrue(report!!.contains("previous"))
             assertNull(
                 CrashStorage(
@@ -108,4 +112,17 @@ class CrashCatcherTest {
                 ).consumePreviousCrash(),
             )
         }
+
+    private fun createCrashCatcher(
+        dispatcher: CoroutineDispatcher,
+        shouldTrack: Boolean = true,
+    ): CrashCatcher {
+        val diagnosticsClient = mockk<DiagnosticsClient>(relaxed = true)
+        every { diagnosticsClient.shouldTrack } returns shouldTrack
+        return CrashCatcher(
+            context = context,
+            ioDispatcher = dispatcher,
+            diagnosticsClientLazy = lazy { diagnosticsClient },
+        )
+    }
 }

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
@@ -130,6 +130,49 @@ class CrashCatcherTest {
             )
         }
 
+    @Test
+    fun `does not persist consumer app crashes`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            Thread.setDefaultUncaughtExceptionHandler { _, _ -> }
+            createCrashCatcher(testDispatcher)
+            Thread.getDefaultUncaughtExceptionHandler()!!
+                .uncaughtException(
+                    Thread.currentThread(),
+                    throwableWithFrames("com.example.MainActivity"),
+                )
+
+            assertNull(
+                CrashStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                ).consumePreviousCrash(),
+            )
+        }
+
+    @Test
+    fun `persists crashes with Amplitude frames on a cause`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            Thread.setDefaultUncaughtExceptionHandler { _, _ -> }
+            createCrashCatcher(testDispatcher)
+            Thread.getDefaultUncaughtExceptionHandler()!!
+                .uncaughtException(
+                    Thread.currentThread(),
+                    throwableWithFrames(
+                        "com.example.Wrapper",
+                        cause = throwableWithFrames("com.amplitude.core.platform.EventPipeline"),
+                    ),
+                )
+
+            val report =
+                CrashStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                ).consumePreviousCrash()
+            assertTrue(report!!.contains("boom"))
+        }
+
     private fun createCrashCatcher(
         dispatcher: CoroutineDispatcher,
         shouldTrack: Boolean = true,
@@ -145,5 +188,17 @@ class CrashCatcherTest {
             diagnosticsClientLazy = lazy { diagnosticsClient },
             crashTrackingRemoteConfigLazy = lazy { crashTrackingRemoteConfig },
         )
+    }
+
+    private fun throwableWithFrames(
+        vararg classNames: String,
+        cause: Throwable? = null,
+    ): RuntimeException {
+        return RuntimeException("boom", cause).apply {
+            stackTrace =
+                classNames
+                    .map { StackTraceElement(it, "method", "File.kt", 1) }
+                    .toTypedArray()
+        }
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashCatcherTest.kt
@@ -1,0 +1,111 @@
+package com.amplitude.android.crash
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class CrashCatcherTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private var originalHandler: Thread.UncaughtExceptionHandler? = null
+
+    @Before
+    fun setUp() {
+        originalHandler = Thread.getDefaultUncaughtExceptionHandler()
+    }
+
+    @After
+    fun tearDown() =
+        runTest {
+            unmockkConstructor(CrashStorage::class)
+            Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+            CrashStorage(
+                appContext = context,
+                ioDispatcher = StandardTestDispatcher(testScheduler),
+            ).consumePreviousCrash()
+        }
+
+    @Test
+    fun `multiple catchers invoke the original handler once`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            var chainedCount = 0
+            Thread.setDefaultUncaughtExceptionHandler { _, _ -> chainedCount++ }
+
+            CrashCatcher(context, testDispatcher)
+            val firstHandler = Thread.getDefaultUncaughtExceptionHandler()
+
+            CrashCatcher(context, testDispatcher)
+            val latestHandler = Thread.getDefaultUncaughtExceptionHandler()
+
+            assertNotSame(firstHandler, latestHandler)
+
+            latestHandler!!.uncaughtException(Thread.currentThread(), RuntimeException("boom"))
+
+            assertEquals(1, chainedCount)
+            val report =
+                CrashStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                ).consumePreviousCrash()
+            assertTrue(report!!.contains("boom"))
+        }
+
+    @Test
+    fun `wrapped Amplitude handler persists a throwable only once`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            var saveCount = 0
+            mockkConstructor(CrashStorage::class)
+            every { anyConstructed<CrashStorage>().saveCrashReport(any()) } answers {
+                saveCount++
+                callOriginal()
+            }
+
+            Thread.setDefaultUncaughtExceptionHandler { _, _ -> }
+            CrashCatcher(context, testDispatcher)
+            val firstHandler = Thread.getDefaultUncaughtExceptionHandler()!!
+            Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+                firstHandler.uncaughtException(thread, throwable)
+            }
+
+            CrashCatcher(context, testDispatcher)
+            Thread.getDefaultUncaughtExceptionHandler()!!
+                .uncaughtException(Thread.currentThread(), RuntimeException("boom"))
+
+            assertEquals(1, saveCount)
+        }
+
+    @Test
+    fun `consumePreviousCrash returns the persisted report`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            CrashStorage(
+                appContext = context,
+                ioDispatcher = testDispatcher,
+            ).saveCrashReport(RuntimeException("previous"))
+            val report = CrashCatcher(context, testDispatcher).consumePreviousCrash()
+            assertTrue(report!!.contains("previous"))
+            assertNull(
+                CrashStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                ).consumePreviousCrash(),
+            )
+        }
+}

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashDiagnosticsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashDiagnosticsTest.kt
@@ -1,0 +1,23 @@
+package com.amplitude.android.crash
+
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.diagnostics.DiagnosticsClient
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+@OptIn(RestrictedAmplitudeFeature::class)
+class CrashDiagnosticsTest {
+    @Test
+    fun `recordCrash uses the correct diagnostics schema`() {
+        val diagnosticsClient = mockk<DiagnosticsClient>(relaxed = true)
+        val report = "java.lang.IllegalStateException: crash"
+
+        diagnosticsClient.recordCrash(report)
+
+        verify(exactly = 1) { diagnosticsClient.increment("analytics.crash", 1) }
+        verify(exactly = 1) {
+            diagnosticsClient.recordEvent("analytics.crash", mapOf("report" to report))
+        }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashStorageTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashStorageTest.kt
@@ -1,0 +1,59 @@
+package com.amplitude.android.crash
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class CrashStorageTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `directory is created without recursing`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val storage =
+                CrashStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                )
+            assertTrue(storage.directory.isDirectory)
+            storage.saveCrashReport(IllegalStateException("failed"))
+            val report = storage.consumePreviousCrash()
+            assertTrue(report!!.contains("IllegalStateException"))
+            assertTrue(report.contains("failed"))
+            assertNull(storage.consumePreviousCrash())
+        }
+
+    @Test
+    fun `crash report bounds the number of stack frames`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val throwable =
+                RuntimeException("large").apply {
+                    stackTrace =
+                        Array(200) { index ->
+                            StackTraceElement("example.Class$index", "method", "Source.kt", index)
+                        }
+                }
+            val storage =
+                CrashStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                )
+            storage.saveCrashReport(throwable)
+
+            val report = storage.consumePreviousCrash()!!
+            assertEquals(64, report.lineSequence().count { it.startsWith("\tat ") })
+            assertTrue(report.contains("crash report truncated"))
+        }
+}

--- a/android/src/test/kotlin/com/amplitude/android/crash/CrashTrackingRemoteConfigTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/crash/CrashTrackingRemoteConfigTest.kt
@@ -1,0 +1,103 @@
+@file:OptIn(RestrictedAmplitudeFeature::class)
+
+package com.amplitude.android.crash
+
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.remoteconfig.ConfigMap
+import com.amplitude.core.remoteconfig.RemoteConfigClient
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CrashTrackingRemoteConfigTest {
+    @Test
+    fun `stays disabled without remote config`() {
+        val remoteConfig = CrashTrackingRemoteConfig(TestRemoteConfigClient(), sdkVersion = "1.8.0")
+        remoteConfig.initialize()
+
+        assertFalse(remoteConfig.isCrashTrackingEnabled)
+    }
+
+    @Test
+    fun `stays disabled until initialize subscribes`() {
+        val client = TestRemoteConfigClient()
+        val remoteConfig = CrashTrackingRemoteConfig(client, sdkVersion = "1.8.0")
+
+        client.emit(mapOf("availabilities" to mapOf("CrashTracking" to "1.7.0")))
+        assertFalse(remoteConfig.isCrashTrackingEnabled)
+
+        remoteConfig.initialize()
+        client.emit(mapOf("availabilities" to mapOf("CrashTracking" to "1.7.0")))
+        assertTrue(remoteConfig.isCrashTrackingEnabled)
+    }
+
+    @Test
+    fun `enables crash tracking when SDK version meets availableFrom`() {
+        val client = TestRemoteConfigClient()
+        val remoteConfig = CrashTrackingRemoteConfig(client, sdkVersion = "1.8.0")
+        remoteConfig.initialize()
+
+        client.emit(mapOf("availabilities" to mapOf("CrashTracking" to "1.7.0")))
+
+        assertTrue(remoteConfig.isCrashTrackingEnabled)
+    }
+
+    @Test
+    fun `does not enable crash tracking below available version`() {
+        val client = TestRemoteConfigClient()
+        val remoteConfig = CrashTrackingRemoteConfig(client, sdkVersion = "1.6.9")
+        remoteConfig.initialize()
+
+        client.emit(mapOf("availabilities" to mapOf("CrashTracking" to "1.7.0")))
+
+        assertFalse(remoteConfig.isCrashTrackingEnabled)
+    }
+
+    @Test
+    fun `does not enable crash tracking without CrashTracking availability`() {
+        val client = TestRemoteConfigClient()
+        val remoteConfig = CrashTrackingRemoteConfig(client, sdkVersion = "1.8.0")
+        remoteConfig.initialize()
+
+        client.emit(mapOf("enabled" to true, "sampleRate" to 1.0))
+
+        assertFalse(remoteConfig.isCrashTrackingEnabled)
+    }
+
+    @Test
+    fun `disables crash tracking when minimum version increases`() {
+        val client = TestRemoteConfigClient()
+        val remoteConfig = CrashTrackingRemoteConfig(client, sdkVersion = "1.8.0")
+        remoteConfig.initialize()
+
+        client.emit(mapOf("availabilities" to mapOf("CrashTracking" to "1.8.0")))
+        assertTrue(remoteConfig.isCrashTrackingEnabled)
+
+        client.emit(mapOf("availabilities" to mapOf("CrashTracking" to "1.9.0")))
+        assertFalse(remoteConfig.isCrashTrackingEnabled)
+    }
+
+    private class TestRemoteConfigClient : RemoteConfigClient {
+        private val callbacks = mutableListOf<RemoteConfigClient.RemoteConfigCallback>()
+
+        override fun subscribe(
+            key: RemoteConfigClient.Key,
+            deliveryMode: RemoteConfigClient.DeliveryMode,
+            callback: RemoteConfigClient.RemoteConfigCallback,
+        ) {
+            if (key == RemoteConfigClient.Key.Diagnostics) {
+                callbacks.add(callback)
+            }
+        }
+
+        override fun updateConfigs() {}
+
+        fun emit(
+            config: ConfigMap,
+            source: RemoteConfigClient.Source = RemoteConfigClient.Source.REMOTE,
+            timestamp: Long = System.currentTimeMillis(),
+        ) {
+            callbacks.forEach { it.onUpdate(config, source, timestamp) }
+        }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/plugins/AndroidNetworkConnectivityCheckerPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/plugins/AndroidNetworkConnectivityCheckerPluginTest.kt
@@ -6,6 +6,7 @@ import com.amplitude.core.Amplitude
 import com.amplitude.core.utilities.ConsoleLoggerProvider
 import com.amplitude.core.utilities.InMemoryStorageProvider
 import com.amplitude.id.IMIdentityStorageProvider
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
@@ -18,7 +19,10 @@ class AndroidNetworkConnectivityCheckerPluginTest {
     private lateinit var amplitude: Amplitude
     private lateinit var plugin: AndroidNetworkConnectivityCheckerPlugin
 
-    private val context = mockk<Application>(relaxed = true)
+    private val context =
+        mockk<Application>(relaxed = true) {
+            every { applicationContext } returns this
+        }
 
     @Before
     fun setup() {

--- a/android/src/test/kotlin/com/amplitude/android/utilities/AndroidLoggerProviderTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/AndroidLoggerProviderTest.kt
@@ -28,6 +28,7 @@ class AndroidLoggerProviderTest {
     fun androidLoggerProvider_getLogger_returnsSingletonInstance() {
         val testApiKey = "test-123"
         val context = mockk<Application>(relaxed = true)
+        every { context.applicationContext } returns context
         every { context.getDir(any(), any()) } returns temporaryFolder.newFolder("testDir")
 
         val amplitude =

--- a/android/src/test/kotlin/com/amplitude/android/utilities/FakeAndroidAmplitude.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/FakeAndroidAmplitude.kt
@@ -62,6 +62,7 @@ fun setupMockAndroidContext() {
     every { anyConstructed<AndroidContextProvider>().appSetId } returns ""
 
     val context = mockk<Application>(relaxed = true)
+    every { context.applicationContext } returns context
     val connectivityManager = mockk<ConnectivityManager>(relaxed = true)
     every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
     val dirNameSlot = slot<String>()

--- a/android/src/test/kotlin/com/amplitude/android/utilities/SemVerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/utilities/SemVerTest.kt
@@ -1,0 +1,35 @@
+package com.amplitude.android.utilities
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SemVerTest {
+    @Test
+    fun `create parses major minor patch`() {
+        assertEquals(SemVer(1, 8, 0), SemVer.create("1.8.0"))
+    }
+
+    @Test
+    fun `create pads missing minor and patch`() {
+        assertEquals(SemVer(1, 0, 0), SemVer.create("1"))
+        assertEquals(SemVer(1, 8, 0), SemVer.create("1.8"))
+    }
+
+    @Test
+    fun `create strips v prefix and prerelease suffix`() {
+        assertEquals(SemVer(1, 8, 0), SemVer.create("v1.8.0-SNAPSHOT"))
+    }
+
+    @Test
+    fun `create returns null for invalid versions`() {
+        assertNull(SemVer.create("not-a-version"))
+    }
+
+    @Test
+    fun `compareTo orders by major minor patch`() {
+        assertTrue(SemVer.create("1.8.0")!! >= SemVer.create("1.7.9")!!)
+        assertTrue(SemVer.create("1.8.0")!! < SemVer.create("1.9.0")!!)
+    }
+}

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/ComposeActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/ComposeActivity.kt
@@ -132,9 +132,26 @@ class ComposeActivity : ComponentActivity() {
                         modifier =
                             Modifier
                                 .fillMaxWidth()
+                                .padding(bottom = 16.dp)
                                 .testTag("advanced_events_button"),
                     ) {
                         Text("Advanced Events")
+                    }
+
+                    Button(
+                        onClick = {
+                            throw RuntimeException("Sample app crash")
+                        },
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = Color(0xFFE53935),
+                            ),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .testTag("crash_button"),
+                    ) {
+                        Text("Crash")
                     }
                 }
             }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉
Please fill out the following sections to help us quickly review your pull request.
--->

### Describe what this PR is addressing
Android apps can crash without the SDK reporting anything useful through diagnostics. This adds capture of uncaught Java/Kotlin exceptions and reports a prior-session crash through the existing diagnostics pipeline, matching the iOS schema (`analytics.crash` counter + event with a `report` property).

### Describe the solution
- **`CrashCatcher` / `CrashStorage`**: install an uncaught-exception handler that streams a bounded crash report to disk (64 frames / 4 cause levels), chains to the previous handler, and kills the process when there is no handler to chain to.
- **Process-wide dedupe**: persist each throwable once when multiple Amplitude handlers are chained (stacked instances or wrapped handlers).
- **`Amplitude` init**: consume the prior crash on launch and record it via an internal `DiagnosticsClient.recordCrash` extension in `:android` (no public API change).
- **Sampling**: buffer the crash counter/event like other diagnostics data; upload remains gated on the session being sampled in.
- **Sample app**: add a Compose **Crash** button for manual end-to-end testing.

### Steps to verify the change
- [x] `./gradlew test ktlintCheck apiCheck`
- [x] Run the sample app, open Compose, tap **Crash**, relaunch, and confirm diagnostics receives an `analytics.crash` event when the session is sampled in
- [x] Unit tests: `CrashCatcherTest`, `CrashStorageTest`, `CrashDiagnosticsTest`

### Useful links and documentation (optional)
SDKA-65

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Installs a process-wide uncaught-exception handler and synchronous crash I/O on the crash path, with lifecycle coupling to instance retirement and diagnostics sampling—important for correctness but not end-user auth or payment flows.
> 
> **Overview**
> Adds **Android crash diagnostics** aligned with iOS: uncaught exceptions that involve Amplitude code can be persisted and reported on the next launch as `analytics.crash` (counter + event with a `report` property).
> 
> **Core hook:** `Amplitude` now runs config validation and a new protected **`initWatchers()`** in the first `init` block, before timeline/build, so process-wide watchers can cover early init failures. **`DiagnosticsClient`** exposes **`shouldTrack`** so crash persistence can respect diagnostics sampling.
> 
> **Android:** **`CrashCatcher`** chains the default uncaught-exception handler, writes a bounded stack report to disk when remote config enables crash tracking and the session is sampled in, then on **`buildInternal`** the SDK consumes that file and calls an internal **`recordCrash`** extension. **`CrashTrackingRemoteConfig`** gates feature availability by SDK semver from diagnostics remote config. **`detachWatchers()`** runs when build/activation fails or an instance retires so half-built instances do not keep persisting crashes (the handler stays installed but releases its references).
> 
> The Kotlin sample app adds a **Crash** button for manual testing; tests cover handler chaining, dedupe, detach paths, and storage bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3f864907ed47300546258a361fdd10533b44c82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->