### PR TITLE
feat: capture Android ANRs for diagnostics

### DIFF
--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -2,6 +2,9 @@ package com.amplitude.android
 
 import android.app.Application
 import android.content.Context
+import com.amplitude.android.anr.AnrCatcher
+import com.amplitude.android.anr.createAnrCatcher
+import com.amplitude.android.anr.recordAnr
 import com.amplitude.android.crash.CrashCatcher
 import com.amplitude.android.crash.CrashTrackingRemoteConfig
 import com.amplitude.android.crash.recordCrash
@@ -55,11 +58,18 @@ public open class Amplitude internal constructor(
     // Assigned in [initWatchers], after configuration validation and before any other
     // initialization, so the handler covers SDK init without leaking on invalid config.
     private lateinit var crashCatcher: CrashCatcher
+    private lateinit var anrCatcher: AnrCatcher
 
     override fun initWatchers() {
+        val androidConfig = configuration as Configuration
         crashCatcher =
             CrashCatcher(
-                context = (configuration as Configuration).context,
+                context = androidConfig.context,
+                ioDispatcher = storageIODispatcher,
+            )
+        anrCatcher =
+            createAnrCatcher(
+                context = androidConfig.context,
                 ioDispatcher = storageIODispatcher,
                 diagnosticsClientLazy = lazy { diagnosticsClient },
                 crashTrackingRemoteConfigLazy = lazy { crashTrackingRemoteConfig },
@@ -159,6 +169,9 @@ public open class Amplitude internal constructor(
             AmplitudeRegistry.runIfActive(this) {
                 diagnosticsClient.recordCrash(previousCrash)
             }
+        }
+        anrCatcher.consumePreviousAnrs().forEach { previousAnr ->
+            diagnosticsClient.recordAnr(previousAnr)
         }
 
         val migrationManager = MigrationManager(this)

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -255,6 +255,10 @@ public open class Amplitude internal constructor(
             runCatching { crashCatcher.detach() }
                 .onFailure { logger.warn("Failed to detach the crash handler: $it") }
         }
+        if (::anrCatcher.isInitialized) {
+            runCatching { anrCatcher.detach() }
+                .onFailure { logger.warn("Failed to detach the ANR catcher: $it") }
+        }
     }
 
     /**

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -66,13 +66,13 @@ public open class Amplitude internal constructor(
             CrashCatcher(
                 context = androidConfig.context,
                 ioDispatcher = storageIODispatcher,
+                diagnosticsClientLazy = lazy { diagnosticsClient },
+                crashTrackingRemoteConfigLazy = lazy { crashTrackingRemoteConfig },
             )
         anrCatcher =
             createAnrCatcher(
                 context = androidConfig.context,
                 ioDispatcher = storageIODispatcher,
-                diagnosticsClientLazy = lazy { diagnosticsClient },
-                crashTrackingRemoteConfigLazy = lazy { crashTrackingRemoteConfig },
             )
     }
 
@@ -171,7 +171,9 @@ public open class Amplitude internal constructor(
             }
         }
         anrCatcher.consumePreviousAnrs().forEach { previousAnr ->
-            diagnosticsClient.recordAnr(previousAnr)
+            AmplitudeRegistry.runIfActive(this) {
+                diagnosticsClient.recordAnr(previousAnr)
+            }
         }
 
         val migrationManager = MigrationManager(this)

--- a/android/src/main/java/com/amplitude/android/anr/AndroidRAnrCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/anr/AndroidRAnrCatcher.kt
@@ -5,6 +5,7 @@ import android.app.ApplicationExitInfo
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -57,6 +58,8 @@ internal class AndroidRAnrCatcher(
             try {
                 val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
                 am.getHistoricalProcessExitReasons(context.packageName, 0, 0)
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 null
             }
@@ -86,6 +89,8 @@ internal class AndroidRAnrCatcher(
             val stream =
                 try {
                     exit.traceInputStream
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (_: Exception) {
                     null
                 } ?: return@withContext null
@@ -94,6 +99,8 @@ internal class AndroidRAnrCatcher(
                 stream.use { input ->
                     readBounded(input)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Exception) {
                 null
             }

--- a/android/src/main/java/com/amplitude/android/anr/AndroidRAnrCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/anr/AndroidRAnrCatcher.kt
@@ -1,0 +1,122 @@
+package com.amplitude.android.anr
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.InputStream
+
+private const val MAX_TRACE_CHARS = 32 * 1024
+
+/**
+ * ANR capture via ApplicationExitInfo (API 30+).
+ */
+@RequiresApi(Build.VERSION_CODES.R)
+internal class AndroidRAnrCatcher(
+    private val context: Context,
+    private val ioDispatcher: CoroutineDispatcher,
+) : AnrCatcher {
+    private val anrStorage by lazy {
+        AnrStorage(
+            appContext = context.applicationContext,
+            ioDispatcher = ioDispatcher,
+        )
+    }
+
+    override suspend fun consumePreviousAnrs(): List<String> {
+        val exits = loadHistoricalExits() ?: return emptyList()
+        val unreadAnrs =
+            consumeMutex.withLock {
+                val lastTimestamp = anrStorage.loadLastAeiTimestamp()
+                val unread =
+                    exits
+                        .filter { exit ->
+                            exit.reason == ApplicationExitInfo.REASON_ANR &&
+                                exit.timestamp > lastTimestamp
+                        }
+                        .sortedBy { it.timestamp }
+                if (unread.isNotEmpty()) {
+                    anrStorage.saveLastAeiTimestamp(unread.maxOf { it.timestamp })
+                }
+                unread
+            }
+
+        return unreadAnrs
+            .map { exit ->
+                formatReport(exit)
+            }
+    }
+
+    private suspend fun loadHistoricalExits(): List<ApplicationExitInfo>? =
+        withContext(ioDispatcher) {
+            try {
+                val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+                am.getHistoricalProcessExitReasons(context.packageName, 0, 0)
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+    private suspend fun formatReport(exit: ApplicationExitInfo): String {
+        val trace = readTrace(exit)
+        return buildString {
+            appendLine("ANR detected")
+            appendLine("Source: ApplicationExitInfo")
+            append("Pid: ")
+            appendLine(exit.pid)
+            append("Timestamp: ")
+            appendLine(exit.timestamp)
+            append("Description: ")
+            appendLine(exit.description ?: "")
+            if (!trace.isNullOrEmpty()) {
+                appendLine()
+                appendLine("Trace:")
+                append(trace)
+            }
+        }
+    }
+
+    private suspend fun readTrace(exit: ApplicationExitInfo): String? =
+        withContext(ioDispatcher) {
+            val stream =
+                try {
+                    exit.traceInputStream
+                } catch (_: Exception) {
+                    null
+                } ?: return@withContext null
+
+            try {
+                stream.use { input ->
+                    readBounded(input)
+                }
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+    private fun readBounded(input: InputStream): String {
+        val reader = input.reader(Charsets.UTF_8)
+        val builder = StringBuilder()
+        val buffer = CharArray(4096)
+        var remaining = MAX_TRACE_CHARS
+        while (remaining > 0) {
+            val count = reader.read(buffer, 0, minOf(buffer.size, remaining))
+            if (count <= 0) break
+            builder.append(buffer, 0, count)
+            remaining -= count
+        }
+        if (remaining <= 0) {
+            builder.append("\n\t... anr report truncated")
+        }
+        return builder.toString()
+    }
+
+    private companion object {
+        private val consumeMutex = Mutex()
+    }
+}

--- a/android/src/main/java/com/amplitude/android/anr/AnrCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/anr/AnrCatcher.kt
@@ -1,0 +1,26 @@
+package com.amplitude.android.anr
+
+import android.content.Context
+import android.os.Build
+import kotlinx.coroutines.CoroutineDispatcher
+
+internal interface AnrCatcher {
+    suspend fun consumePreviousAnrs(): List<String>
+}
+
+internal fun createAnrCatcher(
+    context: Context,
+    ioDispatcher: CoroutineDispatcher,
+): AnrCatcher {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        AndroidRAnrCatcher(
+            context = context,
+            ioDispatcher = ioDispatcher,
+        )
+    } else {
+        LegacyAnrCatcher(
+            context = context,
+            ioDispatcher = ioDispatcher,
+        )
+    }
+}

--- a/android/src/main/java/com/amplitude/android/anr/AnrCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/anr/AnrCatcher.kt
@@ -6,6 +6,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 
 internal interface AnrCatcher {
     suspend fun consumePreviousAnrs(): List<String>
+
+    fun detach() {}
 }
 
 internal fun createAnrCatcher(

--- a/android/src/main/java/com/amplitude/android/anr/AnrDiagnostics.kt
+++ b/android/src/main/java/com/amplitude/android/anr/AnrDiagnostics.kt
@@ -1,0 +1,23 @@
+package com.amplitude.android.anr
+
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.diagnostics.DiagnosticsClient
+
+private const val ANR_EVENT_NAME = "analytics.anr"
+private const val ANR_REPORT_PROPERTY = "report"
+
+/**
+ * Records an ANR report from the previous app run as an `analytics.anr` counter and an
+ * `analytics.anr` event carrying the report text.
+ *
+ * The report is buffered regardless of sampling; upload stays gated on the session being
+ * sampled in, so an ANR consumed before remote config arrives is not lost.
+ */
+@OptIn(RestrictedAmplitudeFeature::class)
+internal fun DiagnosticsClient.recordAnr(anrString: String) {
+    increment(ANR_EVENT_NAME)
+    recordEvent(
+        ANR_EVENT_NAME,
+        mapOf(ANR_REPORT_PROPERTY to anrString),
+    )
+}

--- a/android/src/main/java/com/amplitude/android/anr/AnrStorage.kt
+++ b/android/src/main/java/com/amplitude/android/anr/AnrStorage.kt
@@ -2,6 +2,7 @@ package com.amplitude.android.anr
 
 import android.content.Context
 import android.os.Looper
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -54,6 +55,8 @@ internal class AnrStorage(
                 if (!file.exists()) return@withContext null
                 try {
                     file.readText().ifEmpty { null }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (_: Exception) {
                     null
                 } finally {
@@ -69,6 +72,8 @@ internal class AnrStorage(
                 if (!file.exists()) return@withContext 0L
                 try {
                     file.readText().trim().toLongOrNull() ?: 0L
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (_: Exception) {
                     0L
                 }

--- a/android/src/main/java/com/amplitude/android/anr/AnrStorage.kt
+++ b/android/src/main/java/com/amplitude/android/anr/AnrStorage.kt
@@ -1,0 +1,131 @@
+package com.amplitude.android.anr
+
+import android.content.Context
+import android.os.Looper
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+
+private const val STORAGE_PREFIX = "com.amplitude.anr_report"
+private const val ANR_REPORT_FILE_NAME = "com.amplitude.anr_report"
+private const val AEI_TIMESTAMP_FILE_NAME = "com.amplitude.anr_aei_timestamp"
+private const val MAX_STACK_FRAMES = 64
+private const val MAX_THREADS = 16
+
+internal class AnrStorage(
+    private val appContext: Context,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
+    val directory: File by lazy {
+        File(
+            appContext.getDir("amplitude", Context.MODE_PRIVATE),
+            STORAGE_PREFIX,
+        ).also {
+            it.mkdirs()
+        }
+    }
+
+    /** This performs I/O but must be done synchronously */
+    fun saveAnrReport(timeoutMs: Long) {
+        synchronized(fileLock) {
+            val file = File(directory, ANR_REPORT_FILE_NAME)
+            FileOutputStream(file).use { stream ->
+                PrintWriter(OutputStreamWriter(stream, Charsets.UTF_8)).apply {
+                    println("ANR detected")
+                    print("Timeout: ")
+                    print(timeoutMs)
+                    println("ms")
+                    println()
+                    printThreadDump()
+                    flush()
+                }
+                stream.fd.sync()
+            }
+        }
+    }
+
+    suspend fun consumePreviousAnr(): String? =
+        withContext(ioDispatcher) {
+            synchronized(fileLock) {
+                val file = File(directory, ANR_REPORT_FILE_NAME)
+                if (!file.exists()) return@withContext null
+                try {
+                    file.readText().ifEmpty { null }
+                } catch (_: Exception) {
+                    null
+                } finally {
+                    file.delete()
+                }
+            }
+        }
+
+    suspend fun loadLastAeiTimestamp(): Long =
+        withContext(ioDispatcher) {
+            synchronized(fileLock) {
+                val file = File(directory, AEI_TIMESTAMP_FILE_NAME)
+                if (!file.exists()) return@withContext 0L
+                try {
+                    file.readText().trim().toLongOrNull() ?: 0L
+                } catch (_: Exception) {
+                    0L
+                }
+            }
+        }
+
+    suspend fun saveLastAeiTimestamp(timestamp: Long) {
+        withContext(ioDispatcher) {
+            synchronized(fileLock) {
+                File(directory, AEI_TIMESTAMP_FILE_NAME).writeText(timestamp.toString())
+            }
+        }
+    }
+
+    private fun PrintWriter.printThreadDump() {
+        val traces = Thread.getAllStackTraces()
+        val mainThread = Looper.getMainLooper().thread
+        var remainingThreads = MAX_THREADS
+
+        printThread(mainThread, traces[mainThread] ?: mainThread.stackTrace)
+        remainingThreads--
+
+        for ((thread, stack) in traces) {
+            if (remainingThreads <= 0) {
+                println("\t... anr report truncated")
+                return
+            }
+            if (thread === mainThread) continue
+            printThread(thread, stack)
+            remainingThreads--
+        }
+    }
+
+    private fun PrintWriter.printThread(
+        thread: Thread,
+        stack: Array<StackTraceElement>,
+    ) {
+        print("Thread: ")
+        print(thread.name)
+        print(" (id=")
+        print(thread.id)
+        print(", state=")
+        print(thread.state)
+        println(")")
+
+        val framesToWrite = minOf(stack.size, MAX_STACK_FRAMES)
+        for (index in 0 until framesToWrite) {
+            print("\tat ")
+            println(stack[index])
+        }
+        if (stack.size > framesToWrite) {
+            println("\t... anr report truncated")
+        }
+        println()
+    }
+
+    companion object {
+        private val fileLock = Any()
+    }
+}

--- a/android/src/main/java/com/amplitude/android/anr/LegacyAnrCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/anr/LegacyAnrCatcher.kt
@@ -35,6 +35,23 @@ internal class LegacyAnrCatcher(
         return if (report == null) emptyList() else listOf(report)
     }
 
+    /**
+     * Stops the process-wide watchdog if this catcher still owns it. A replacement that has
+     * already [register]ed keeps the thread and is left alone.
+     */
+    override fun detach() {
+        val thread =
+            synchronized(watchdogLock) {
+                if (activeCatcher !== this) return
+                activeCatcher = null
+                val running = watchdogThread
+                watchdogThread = null
+                running
+            }
+        thread?.interrupt()
+        thread?.join(1_000)
+    }
+
     private fun persistAnrReport() {
         synchronized(storageLock) {
             anrStorage.saveAnrReport(ANR_TIMEOUT_MS)

--- a/android/src/main/java/com/amplitude/android/anr/LegacyAnrCatcher.kt
+++ b/android/src/main/java/com/amplitude/android/anr/LegacyAnrCatcher.kt
@@ -1,0 +1,123 @@
+package com.amplitude.android.anr
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import kotlinx.coroutines.CoroutineDispatcher
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.min
+
+private const val PING_INTERVAL_MS = 2_000L
+private const val ANR_TIMEOUT_MS = 5_000L
+
+/**
+ * ANR capture via a main-thread watchdog (pre-API 30).
+ */
+internal class LegacyAnrCatcher(
+    context: Context,
+    ioDispatcher: CoroutineDispatcher,
+) : AnrCatcher {
+    private val appContext = context.applicationContext
+    private val anrStorage by lazy {
+        AnrStorage(
+            appContext = appContext,
+            ioDispatcher = ioDispatcher,
+        )
+    }
+    private val mainHandler: Handler by lazy { Handler(Looper.getMainLooper()) }
+
+    init {
+        register(this)
+    }
+
+    override suspend fun consumePreviousAnrs(): List<String> {
+        val report = anrStorage.consumePreviousAnr()
+        return if (report == null) emptyList() else listOf(report)
+    }
+
+    private fun persistAnrReport() {
+        synchronized(storageLock) {
+            anrStorage.saveAnrReport(ANR_TIMEOUT_MS)
+        }
+    }
+
+    companion object {
+        private val storageLock = Any()
+        private val watchdogLock = Any()
+        private var watchdogThread: Thread? = null
+
+        @Volatile
+        private var activeCatcher: LegacyAnrCatcher? = null
+
+        private fun register(catcher: LegacyAnrCatcher) {
+            synchronized(watchdogLock) {
+                activeCatcher = catcher
+                if (watchdogThread?.isAlive == true) return
+
+                val thread =
+                    Thread(
+                        { runWatchdog() },
+                        "amplitude-anr-watchdog",
+                    )
+                thread.isDaemon = true
+                watchdogThread = thread
+                thread.start()
+            }
+        }
+
+        internal fun stopWatchdog() {
+            val thread =
+                synchronized(watchdogLock) {
+                    val running = watchdogThread
+                    watchdogThread = null
+                    activeCatcher = null
+                    running
+                }
+            thread?.interrupt()
+            thread?.join(1_000)
+        }
+
+        private fun runWatchdog() {
+            try {
+                while (!Thread.currentThread().isInterrupted) {
+                    val catcher = activeCatcher ?: break
+                    val responded = AtomicBoolean(false)
+                    catcher.mainHandler.post { responded.set(true) }
+                    Thread.sleep(PING_INTERVAL_MS)
+                    if (responded.get()) continue
+                    if (!waitUntil(responded, ANR_TIMEOUT_MS - PING_INTERVAL_MS)) {
+                        try {
+                            catcher.persistAnrReport()
+                        } catch (_: Throwable) {
+                            // Best-effort: never throw from the watchdog
+                        }
+                        waitUntil(responded, Long.MAX_VALUE)
+                    }
+                }
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+        }
+
+        private fun waitUntil(
+            flag: AtomicBoolean,
+            timeoutMs: Long,
+        ): Boolean {
+            val deadline =
+                if (timeoutMs == Long.MAX_VALUE) {
+                    Long.MAX_VALUE
+                } else {
+                    System.currentTimeMillis() + timeoutMs
+                }
+            while (!flag.get()) {
+                if (Thread.currentThread().isInterrupted) {
+                    throw InterruptedException()
+                }
+                val remaining = deadline - System.currentTimeMillis()
+                if (remaining <= 0L) return false
+                Thread.sleep(min(50L, remaining))
+            }
+            return true
+        }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/anr/AnrCatcherTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/anr/AnrCatcherTest.kt
@@ -1,0 +1,177 @@
+package com.amplitude.android.anr
+
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class AndroidRAnrCatcherTest {
+    private val context = spyk(ApplicationProvider.getApplicationContext<Context>())
+    private val activityManager = mockk<ActivityManager>()
+
+    @Before
+    fun setUp() =
+        runTest {
+            every { context.getSystemService(Context.ACTIVITY_SERVICE) } returns activityManager
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            AnrStorage(
+                appContext = context,
+                ioDispatcher = testDispatcher,
+            ).saveLastAeiTimestamp(0L)
+            AnrStorage(
+                appContext = context,
+                ioDispatcher = testDispatcher,
+            ).consumePreviousAnr()
+        }
+
+    @Test
+    fun `reports unread ANR exits and ignores them on the next consume`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val first = mockExit(timestamp = 1_000L, description = "first anr", trace = "trace-one")
+            val second = mockExit(timestamp = 2_000L, description = "second anr", trace = "trace-two")
+            every {
+                activityManager.getHistoricalProcessExitReasons(any(), 0, 0)
+            } returns listOf(second, first)
+
+            val reports =
+                AndroidRAnrCatcher(
+                    context = context,
+                    ioDispatcher = testDispatcher,
+                ).consumePreviousAnrs()
+            assertEquals(2, reports.size)
+            assertTrue(reports[0].contains("first anr"))
+            assertTrue(reports[0].contains("trace-one"))
+            assertTrue(reports[0].contains("Source: ApplicationExitInfo"))
+            assertTrue(reports[1].contains("second anr"))
+
+            val again =
+                AndroidRAnrCatcher(
+                    context = context,
+                    ioDispatcher = testDispatcher,
+                ).consumePreviousAnrs()
+            assertEquals(emptyList(), again)
+        }
+
+    @Test
+    fun `concurrent catchers claim each ANR once`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val first = mockExit(timestamp = 1_000L, description = "first anr", trace = "trace-one")
+            val second = mockExit(timestamp = 2_000L, description = "second anr", trace = "trace-two")
+            every {
+                activityManager.getHistoricalProcessExitReasons(any(), 0, 0)
+            } returns listOf(second, first)
+
+            val reports =
+                List(2) {
+                    async {
+                        AndroidRAnrCatcher(
+                            context = context,
+                            ioDispatcher = testDispatcher,
+                        ).consumePreviousAnrs()
+                    }
+                }.awaitAll().flatten()
+
+            assertEquals(2, reports.size)
+            assertTrue(reports.any { it.contains("first anr") })
+            assertTrue(reports.any { it.contains("second anr") })
+        }
+
+    @Test
+    fun `skips non-ANR exits`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val crash =
+                mockk<ApplicationExitInfo> {
+                    every { reason } returns ApplicationExitInfo.REASON_CRASH
+                    every { timestamp } returns 3_000L
+                }
+            every {
+                activityManager.getHistoricalProcessExitReasons(any(), 0, 0)
+            } returns listOf(crash)
+
+            assertEquals(
+                emptyList(),
+                AndroidRAnrCatcher(
+                    context = context,
+                    ioDispatcher = testDispatcher,
+                ).consumePreviousAnrs(),
+            )
+        }
+
+    private fun mockExit(
+        timestamp: Long,
+        description: String,
+        trace: String,
+    ): ApplicationExitInfo {
+        return mockk {
+            every { reason } returns ApplicationExitInfo.REASON_ANR
+            every { this@mockk.timestamp } returns timestamp
+            every { pid } returns 42
+            every { this@mockk.description } returns description
+            every { traceInputStream } returns trace.byteInputStream()
+        }
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AnrCatcherFactoryTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @After
+    fun tearDown() =
+        runTest {
+            LegacyAnrCatcher.stopWatchdog()
+            AnrStorage(
+                appContext = context,
+                ioDispatcher = StandardTestDispatcher(testScheduler),
+            ).consumePreviousAnr()
+        }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun `uses legacy watchdog below Android 11`() =
+        runTest {
+            assertIs<LegacyAnrCatcher>(
+                createAnrCatcher(
+                    context = context,
+                    ioDispatcher = StandardTestDispatcher(testScheduler),
+                ),
+            )
+        }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.R])
+    fun `uses AndroidRAnrCatcher on Android 11 and above`() =
+        runTest {
+            assertIs<AndroidRAnrCatcher>(
+                createAnrCatcher(
+                    context = context,
+                    ioDispatcher = StandardTestDispatcher(testScheduler),
+                ),
+            )
+        }
+}

--- a/android/src/test/kotlin/com/amplitude/android/anr/AnrCatcherTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/anr/AnrCatcherTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -20,6 +21,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -72,6 +74,21 @@ class AndroidRAnrCatcherTest {
                     ioDispatcher = testDispatcher,
                 ).consumePreviousAnrs()
             assertEquals(emptyList(), again)
+        }
+
+    @Test
+    fun `cancellation from historical exits is not swallowed`() =
+        runTest {
+            every {
+                activityManager.getHistoricalProcessExitReasons(any(), 0, 0)
+            } throws CancellationException()
+
+            assertFailsWith<CancellationException> {
+                AndroidRAnrCatcher(
+                    context = context,
+                    ioDispatcher = StandardTestDispatcher(testScheduler),
+                ).consumePreviousAnrs()
+            }
         }
 
     @Test

--- a/android/src/test/kotlin/com/amplitude/android/anr/AnrDiagnosticsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/anr/AnrDiagnosticsTest.kt
@@ -1,0 +1,23 @@
+package com.amplitude.android.anr
+
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.diagnostics.DiagnosticsClient
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+@OptIn(RestrictedAmplitudeFeature::class)
+class AnrDiagnosticsTest {
+    @Test
+    fun `recordAnr uses the correct diagnostics schema`() {
+        val diagnosticsClient = mockk<DiagnosticsClient>(relaxed = true)
+        val report = "ANR detected"
+
+        diagnosticsClient.recordAnr(report)
+
+        verify(exactly = 1) { diagnosticsClient.increment("analytics.anr", 1) }
+        verify(exactly = 1) {
+            diagnosticsClient.recordEvent("analytics.anr", mapOf("report" to report))
+        }
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/anr/AnrStorageTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/anr/AnrStorageTest.kt
@@ -1,0 +1,50 @@
+package com.amplitude.android.anr
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AnrStorageTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `directory is created without recursing`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val storage =
+                AnrStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                )
+            assertTrue(storage.directory.isDirectory)
+            storage.saveAnrReport(5_000)
+            val report = storage.consumePreviousAnr()
+            assertTrue(report!!.contains("ANR detected"))
+            assertTrue(report.contains("Timeout: 5000ms"))
+            assertNull(storage.consumePreviousAnr())
+        }
+
+    @Test
+    fun `anr report includes the main thread`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val storage =
+                AnrStorage(
+                    appContext = context,
+                    ioDispatcher = testDispatcher,
+                )
+            storage.saveAnrReport(5_000)
+            val report = storage.consumePreviousAnr()!!
+            assertTrue(report.contains("Thread: "))
+            assertTrue(report.contains("\tat "))
+        }
+}

--- a/android/src/test/kotlin/com/amplitude/android/anr/LegacyAnrCatcherTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/anr/LegacyAnrCatcherTest.kt
@@ -1,0 +1,65 @@
+package com.amplitude.android.anr
+
+import android.content.Context
+import android.os.Looper
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class LegacyAnrCatcherTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Before
+    fun setUp() =
+        runTest {
+            LegacyAnrCatcher.stopWatchdog()
+            AnrStorage(
+                appContext = context,
+                ioDispatcher = StandardTestDispatcher(testScheduler),
+            ).consumePreviousAnr()
+        }
+
+    @After
+    fun tearDown() =
+        runTest {
+            LegacyAnrCatcher.stopWatchdog()
+            shadowOf(Looper.getMainLooper()).idle()
+            AnrStorage(
+                appContext = context,
+                ioDispatcher = StandardTestDispatcher(testScheduler),
+            ).consumePreviousAnr()
+        }
+
+    @Test
+    fun `watchdog persists an ANR when the main thread does not respond`() =
+        runTest {
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            shadowOf(Looper.getMainLooper()).pause()
+            val catcher =
+                LegacyAnrCatcher(
+                    context = context,
+                    ioDispatcher = testDispatcher,
+                )
+
+            val deadline = System.currentTimeMillis() + 7_000
+            var reports: List<String> = emptyList()
+            while (reports.isEmpty() && System.currentTimeMillis() < deadline) {
+                Thread.sleep(50)
+                reports = catcher.consumePreviousAnrs()
+            }
+
+            assertTrue(reports.isNotEmpty())
+            assertTrue(reports.first().contains("ANR detected"))
+            assertTrue(reports.first().contains("Timeout: 5000ms"))
+        }
+}

--- a/android/src/test/kotlin/com/amplitude/android/anr/LegacyAnrCatcherTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/anr/LegacyAnrCatcherTest.kt
@@ -62,4 +62,34 @@ class LegacyAnrCatcherTest {
             assertTrue(reports.first().contains("ANR detected"))
             assertTrue(reports.first().contains("Timeout: 5000ms"))
         }
+
+    @Test
+    fun `detach stops the watchdog if this catcher still owns it`() {
+        val catcher =
+            LegacyAnrCatcher(
+                context = context,
+                ioDispatcher = StandardTestDispatcher(),
+            )
+        assertTrue(watchdogThreads().isNotEmpty())
+        catcher.detach()
+        assertTrue(watchdogThreads().isEmpty())
+    }
+
+    @Test
+    fun `detach leaves a replacement's watchdog running`() {
+        val first =
+            LegacyAnrCatcher(
+                context = context,
+                ioDispatcher = StandardTestDispatcher(),
+            )
+        LegacyAnrCatcher(
+            context = context,
+            ioDispatcher = StandardTestDispatcher(),
+        )
+        first.detach()
+        assertTrue(watchdogThreads().isNotEmpty())
+    }
+
+    private fun watchdogThreads(): List<Thread> =
+        Thread.getAllStackTraces().keys.filter { it.name == "amplitude-anr-watchdog" && it.isAlive }
 }

--- a/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/ComposeActivity.kt
+++ b/samples/kotlin-android-app/src/main/java/com/amplitude/android/sample/ComposeActivity.kt
@@ -149,9 +149,26 @@ class ComposeActivity : ComponentActivity() {
                         modifier =
                             Modifier
                                 .fillMaxWidth()
+                                .padding(bottom = 16.dp)
                                 .testTag("crash_button"),
                     ) {
                         Text("Crash")
+                    }
+
+                    Button(
+                        onClick = {
+                            Thread.sleep(10_000)
+                        },
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor = Color(0xFFFF8F00),
+                            ),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .testTag("anr_button"),
+                    ) {
+                        Text("ANR")
                     }
                 }
             }


### PR DESCRIPTION
### Describe what this PR is addressing
Stacked on #471. Capture Android ANRs for SDK diagnostics so a prior-session hang can be reported with the same schema as crash (`analytics.anr` counter + event, `report` property).

### Describe the solution
Two catchers behind `createAnrCatcher()`:
* **API 30+:** `ApplicationExitInfo` unread `REASON_ANR` exits, claimed once under a process-wide mutex so concurrent Amplitude instances do not double-count.
* **Pre-30:** main-thread watchdog that pings every 2s and persists if a ping is unanswered for 5s.

Watchers are installed in `initWatchers()` next to crash capture. Consume is suspend I/O on the storage dispatcher at the call site; persist on the watchdog stays synchronous. A pending legacy report after an OS upgrade to 11+ is not drained (one-off).

### Steps to verify the change
* `./gradlew :android:testDebugUnitTest --tests com.amplitude.android.anr.*`
* Sample app **ANR** button (`Thread.sleep(10_000)` on main) on an API 29 emulator, then relaunch and confirm `analytics.anr` in diagnostics when sampled in.
* On API 31+, force an ANR, relaunch, confirm AEI-backed report.

### Useful links and documentation (optional)
Depends on #471.

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a process-wide background watchdog and startup I/O on all API levels; reports can contain stack traces, similar to existing crash diagnostics but with extra runtime overhead on pre-Android 11.
> 
> **Overview**
> Adds **prior-session ANR reporting** to the Android SDK, wired like existing crash capture: an `AnrCatcher` is started in `initWatchers()`, reports are consumed during `buildInternal()`, and each is sent via `diagnosticsClient.recordAnr` as an **`analytics.anr`** counter plus event with a **`report`** property.
> 
> **API 30+** uses `ApplicationExitInfo` (`REASON_ANR`), tracks the last consumed exit timestamp so each ANR is reported once (mutex for concurrent Amplitude instances), and includes bounded trace text. **Below API 30**, a process-wide main-thread watchdog pings every 2s and synchronously persists a truncated thread dump after ~5s of no response; the legacy file is read on the next launch.
> 
> `detachWatchers()` now tears down the legacy watchdog when the owning instance retires. The sample app gains an **ANR** button that blocks the main thread for manual testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b91ae295cf29e56e9cbe8f4293c8e91ea59fc8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->