### PR TITLE
feat: tag diagnostics with host app release vs debug

### DIFF
--- a/analytics-core/api/analytics-core.api
+++ b/analytics-core/api/analytics-core.api
@@ -393,16 +393,18 @@ public abstract interface class com/amplitude/core/diagnostics/DiagnosticsClient
 }
 
 public final class com/amplitude/core/diagnostics/DiagnosticsContextInfo {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/amplitude/core/diagnostics/DiagnosticsContextInfo;
-	public static synthetic fun copy$default (Lcom/amplitude/core/diagnostics/DiagnosticsContextInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/amplitude/core/diagnostics/DiagnosticsContextInfo;
+	public final fun component7 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lcom/amplitude/core/diagnostics/DiagnosticsContextInfo;
+	public static synthetic fun copy$default (Lcom/amplitude/core/diagnostics/DiagnosticsContextInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/amplitude/core/diagnostics/DiagnosticsContextInfo;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppRelease ()Z
 	public final fun getAppVersion ()Ljava/lang/String;
 	public final fun getManufacturer ()Ljava/lang/String;
 	public final fun getModel ()Ljava/lang/String;

--- a/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsClientImpl.kt
@@ -315,6 +315,7 @@ internal class DiagnosticsClientImpl(
                 put("os_version", contextInfo?.osVersion ?: "")
                 put("platform", contextInfo?.platform ?: "")
                 put("sdk.${Constants.SDK_LIBRARY}.version", Constants.SDK_VERSION)
+                put("app.release", (contextInfo?.appRelease ?: false).toString())
             }
 
         setTags(staticContext)

--- a/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsContextProvider.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/diagnostics/DiagnosticsContextProvider.kt
@@ -1,5 +1,16 @@
 package com.amplitude.core.diagnostics
 
+/**
+ * Device and app context attached as basic diagnostics tags.
+ *
+ * @param manufacturer Device manufacturer.
+ * @param model Device model.
+ * @param osName Operating system name.
+ * @param osVersion Operating system version.
+ * @param platform Platform name.
+ * @param appVersion Host app version name, if known.
+ * @param appRelease Whether this is a release (non-debuggable) host app build.
+ */
 public data class DiagnosticsContextInfo(
     val manufacturer: String,
     val model: String,
@@ -7,6 +18,7 @@ public data class DiagnosticsContextInfo(
     val osVersion: String,
     val platform: String,
     val appVersion: String?,
+    val appRelease: Boolean,
 )
 
 public fun interface DiagnosticsContextProvider {

--- a/analytics-core/src/test/kotlin/com/amplitude/core/diagnostics/DiagnosticsClientTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/diagnostics/DiagnosticsClientTest.kt
@@ -44,6 +44,7 @@ class DiagnosticsClientTest {
                                 osVersion = "14",
                                 platform = "Android",
                                 appVersion = "1.2.3",
+                                appRelease = false,
                             )
                         },
                 )
@@ -91,6 +92,41 @@ class DiagnosticsClientTest {
                 }
             }
             assertTrue(foundEvent, "Expected to find event_a in events")
+        }
+
+    @Test
+    fun `flush includes app release tag from context`() =
+        runBlocking {
+            val requestSlot = slot<HttpClient.Request>()
+            val httpClient = mockk<HttpClient>()
+            every {
+                httpClient.request(capture(requestSlot))
+            } returns HttpClient.Response(200, "ok")
+
+            val client =
+                createClient(
+                    httpClient = httpClient,
+                    sampleRate = 1.0,
+                    contextProvider =
+                        DiagnosticsContextProvider {
+                            DiagnosticsContextInfo(
+                                manufacturer = "Google",
+                                model = "Pixel",
+                                osName = "Android",
+                                osVersion = "14",
+                                platform = "Android",
+                                appVersion = "1.2.3",
+                                appRelease = true,
+                            )
+                        },
+                )
+
+            delay(100)
+            client.flush()
+            delay(200)
+
+            val tags = JSONObject(requestSlot.captured.body).getJSONObject("tags")
+            assertEquals("true", tags.getString("app.release"))
         }
 
     @Test

--- a/android/src/main/java/com/amplitude/android/diagnostics/AndroidDiagnosticsContextProvider.kt
+++ b/android/src/main/java/com/amplitude/android/diagnostics/AndroidDiagnosticsContextProvider.kt
@@ -1,6 +1,7 @@
 package com.amplitude.android.diagnostics
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.os.Build
 import com.amplitude.core.diagnostics.DiagnosticsContextInfo
 import com.amplitude.core.diagnostics.DiagnosticsContextProvider
@@ -9,6 +10,7 @@ public class AndroidDiagnosticsContextProvider(
     private val context: Context,
 ) : DiagnosticsContextProvider {
     override fun getContextInfo(): DiagnosticsContextInfo {
+        val appContext = context.applicationContext
         return DiagnosticsContextInfo(
             manufacturer = Build.MANUFACTURER,
             model = Build.MODEL,
@@ -16,6 +18,7 @@ public class AndroidDiagnosticsContextProvider(
             osVersion = Build.VERSION.RELEASE,
             platform = "Android",
             appVersion = fetchVersionName(),
+            appRelease = appContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE == 0,
         )
     }
 

--- a/android/src/test/kotlin/com/amplitude/android/diagnostics/AndroidDiagnosticsContextProviderTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/diagnostics/AndroidDiagnosticsContextProviderTest.kt
@@ -1,0 +1,37 @@
+package com.amplitude.android.diagnostics
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import androidx.test.core.app.ApplicationProvider
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class AndroidDiagnosticsContextProviderTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `app release is false for a debuggable application`() {
+        val originalFlags = context.applicationInfo.flags
+        try {
+            context.applicationInfo.flags = originalFlags or ApplicationInfo.FLAG_DEBUGGABLE
+            assertFalse(AndroidDiagnosticsContextProvider(context).getContextInfo().appRelease)
+        } finally {
+            context.applicationInfo.flags = originalFlags
+        }
+    }
+
+    @Test
+    fun `app release is true for a non-debuggable application`() {
+        val originalFlags = context.applicationInfo.flags
+        try {
+            context.applicationInfo.flags = originalFlags and ApplicationInfo.FLAG_DEBUGGABLE.inv()
+            assertTrue(AndroidDiagnosticsContextProvider(context).getContextInfo().appRelease)
+        } finally {
+            context.applicationInfo.flags = originalFlags
+        }
+    }
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Kotlin SDK! 🎉
Please fill out the following sections to help us quickly review your pull request.
--->

### Describe what this PR is addressing
Diagnostics payloads did not distinguish a debuggable host APK from a release install. iOS already sends `app.release`; Android crash/ANR reports need the same tag (SDKA-64).

### Describe the solution
- Add required `appRelease` on public `DiagnosticsContextInfo`.
- Android sets it from `ApplicationInfo.FLAG_DEBUGGABLE == 0`.
- `DiagnosticsClientImpl` always includes the `app.release` tag (`false` when there is no context provider).

Stacked on [SDKA-65](https://github.com/amplitude/Amplitude-Kotlin/pull/471) (`ianmeyer/sdka-65`), not `main`.

### Steps to verify the change
- [x] `./gradlew test ktlintCheck apiCheck` (run separately from `apiDump` if dumps change)
- [x] Unit tests: `DiagnosticsClientTest` flush tag, `AndroidDiagnosticsContextProviderTest` debug vs release flags

### Useful links and documentation (optional)
- [SDKA-64](https://linear.app/amplitude/issue/SDKA-64)
- Parent [SDKA-63](https://linear.app/amplitude/issue/SDKA-63)
- Capture/report PR: https://github.com/amplitude/Amplitude-Kotlin/pull/471

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking public API change on `DiagnosticsContextInfo` and adds a new diagnostics dimension; runtime behavior is limited to tagging with low blast radius beyond compile-time breakage for custom providers.
> 
> **Overview**
> Diagnostics uploads now include an **`app.release`** tag so crash/ANR-style reports can tell release installs from debuggable builds (aligned with iOS).
> 
> **Public API:** `DiagnosticsContextInfo` gains a required **`appRelease`** boolean (breaking for custom `DiagnosticsContextProvider` implementations). `DiagnosticsClientImpl` always sets `app.release` in static tags, using the provider value or **`false`** when no context is supplied.
> 
> **Android:** `AndroidDiagnosticsContextProvider` sets `appRelease` when `ApplicationInfo.FLAG_DEBUGGABLE` is clear, using `applicationContext` for `ApplicationInfo`. Unit tests cover the tag on flush and debug vs non-debuggable flag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4790bcf986dd3ea7efefe056ed7b765eb06d2526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->