### PR TITLE
docs: use gagent for Gradle in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,15 @@ Analytics SDK for Android. Two modules: **`analytics-core`** (pure Kotlin/JVM) a
 ## Build
 
 ```bash
-./gradlew build -x test           # Build
-./gradlew :android:test            # Android tests
-./gradlew :analytics-core:test     # Core tests
-./gradlew ktlintFormat             # Auto-format
-./gradlew apiDump                  # Update API dumps after public API changes
-./gradlew apiCheck                 # Binary compat check (CI enforced)
+gagent build -x test              # Build
+gagent :android:test               # Android tests
+gagent :analytics-core:test        # Core tests
+gagent ktlintFormat                # Auto-format
+gagent apiDump                     # Update API dumps after public API changes
+gagent apiCheck                    # Binary compat check (CI enforced)
 ```
+
+`gagent` is `./gradlew --priority low` — isolated low-priority daemon so agent builds do not share IntelliJ's daemon. Use `./gradlew` in the IDE or for interactive work.
 
 ## What Gets Merged
 
@@ -40,7 +42,7 @@ This is a published SDK and we guard the public surface:
 
 ### Binary Compatibility
 
-Public API changes require `./gradlew apiDump` and committed `.api` files (`analytics-core/api/analytics-core.api`, `android/api/android.api`). CI fails on stale dumps.
+Public API changes require `gagent apiDump` and committed `.api` files (`analytics-core/api/analytics-core.api`, `android/api/android.api`). CI fails on stale dumps.
 
 ### Thread Safety
 


### PR DESCRIPTION
## Summary
- Switch AGENTS.md Gradle commands from `./gradlew` to `gagent` (`./gradlew --priority low`)
- Keep `./gradlew` for IDE / interactive use

## Test plan
- [ ] Agents follow AGENTS.md and invoke `gagent` from repo root

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, build script, or API changes.
> 
> **Overview**
> Updates **AGENTS.md** so automated agents run Gradle via **`gagent`** instead of **`./gradlew`** in the Build code block and in the binary-compatibility **`apiDump`** note.
> 
> Adds a short note that **`gagent`** means **`./gradlew --priority low`** (separate low-priority daemon so agent builds do not contend with IntelliJ’s Gradle daemon), while **`./gradlew`** remains the recommendation for IDE and interactive use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a93a965761e646dbed3908bebfef994054d0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->