### PR TITLE
feat: add @JvmOverloads to NetworkTrackingOptions constructors

### DIFF
--- a/android/api/android.api
+++ b/android/api/android.api
@@ -718,6 +718,10 @@ public final class com/amplitude/android/migration/RemnantDataMigration$Companio
 
 public final class com/amplitude/android/network/NetworkTrackingOptions {
 	public static final field Companion Lcom/amplitude/android/network/NetworkTrackingOptions$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Z)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;ZZ)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;ZZZ)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCaptureRules ()Ljava/util/List;
@@ -728,6 +732,7 @@ public final class com/amplitude/android/network/NetworkTrackingOptions {
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureBody {
+	public fun <init> (Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAllowlist ()Ljava/util/List;
@@ -736,6 +741,7 @@ public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureB
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureHeader {
 	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Z)V
 	public synthetic fun <init> (Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAllowlist ()Ljava/util/List;
@@ -743,6 +749,7 @@ public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureH
 }
 
 public final class com/amplitude/android/network/NetworkTrackingOptions$CaptureRule {
+	public fun <init> (Ljava/util/List;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureHeader;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;Lcom/amplitude/android/network/NetworkTrackingOptions$CaptureBody;)V

--- a/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
+++ b/android/src/main/java/com/amplitude/android/network/NetworkTrackingOptions.kt
@@ -69,13 +69,15 @@ internal val BLOCK_HEADERS: Set<String> =
         "proxy-authorization",
     )
 
-public class NetworkTrackingOptions(
-    captureRules: List<CaptureRule>,
-    ignoreHosts: List<String> = emptyList(),
-    public val ignoreAmplitudeRequests: Boolean = true,
-    public val enabled: Boolean = true,
-    public val enableRemoteConfig: Boolean = true,
-) {
+public class NetworkTrackingOptions
+    @JvmOverloads
+    constructor(
+        captureRules: List<CaptureRule>,
+        ignoreHosts: List<String> = emptyList(),
+        public val ignoreAmplitudeRequests: Boolean = true,
+        public val enabled: Boolean = true,
+        public val enableRemoteConfig: Boolean = true,
+    ) {
     public val captureRules: List<CaptureRule> = captureRules.toList()
     public val ignoreHosts: List<String> = ignoreHosts.toList()
 
@@ -92,10 +94,12 @@ public class NetworkTrackingOptions(
         }
     }
 
-    public class CaptureHeader(
-        allowlist: List<String> = emptyList(),
-        public val captureSafeHeaders: Boolean = true,
-    ) {
+    public class CaptureHeader
+        @JvmOverloads
+        constructor(
+            allowlist: List<String> = emptyList(),
+            public val captureSafeHeaders: Boolean = true,
+        ) {
         public val allowlist: List<String> = allowlist.toList()
 
         internal fun filterHeaders(headers: Headers): Map<String, Any>? {
@@ -124,10 +128,12 @@ public class NetworkTrackingOptions(
         }
     }
 
-    public class CaptureBody(
-        allowlist: List<String>,
-        excludelist: List<String> = emptyList(),
-    ) {
+    public class CaptureBody
+        @JvmOverloads
+        constructor(
+            allowlist: List<String>,
+            excludelist: List<String> = emptyList(),
+        ) {
         public val allowlist: List<String> = allowlist.toList()
         public val excludelist: List<String> = excludelist.toList()
         private val objectFilter = ObjectFilter(this.allowlist, this.excludelist)
@@ -178,6 +184,7 @@ public class NetworkTrackingOptions(
         /**
          * Creates a rule that matches requests by host patterns.
          */
+        @JvmOverloads
         public constructor(
             hosts: List<String>,
             statusCodeRange: List<Int> = (500..599).toList(),

--- a/android/src/test/java/com/amplitude/android/network/NetworkTrackingOptionsJavaOverloadsTest.java
+++ b/android/src/test/java/com/amplitude/android/network/NetworkTrackingOptionsJavaOverloadsTest.java
@@ -1,0 +1,95 @@
+package com.amplitude.android.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureBody;
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureHeader;
+import com.amplitude.android.network.NetworkTrackingOptions.CaptureRule;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class NetworkTrackingOptionsJavaOverloadsTest {
+    private static List<CaptureRule> sampleRules() {
+        return Collections.singletonList(new CaptureRule(Collections.singletonList("api.example.com")));
+    }
+
+    @Test
+    public void oneArgumentConstructorUsesDefaultedFields() {
+        List<CaptureRule> captureRules = sampleRules();
+        NetworkTrackingOptions options = new NetworkTrackingOptions(captureRules);
+
+        assertEquals(1, options.getCaptureRules().size());
+        assertEquals(
+                Collections.singletonList("api.example.com"),
+                options.getCaptureRules().get(0).getHosts());
+        assertEquals(100, options.getCaptureRules().get(0).getStatusCodeRange().size());
+        assertEquals(500, options.getCaptureRules().get(0).getStatusCodeRange().get(0).intValue());
+        assertEquals(599, options.getCaptureRules().get(0).getStatusCodeRange().get(99).intValue());
+        assertTrue(options.getIgnoreHosts().isEmpty());
+        assertTrue(options.getIgnoreAmplitudeRequests());
+        assertTrue(options.getEnabled());
+        assertTrue(options.getEnableRemoteConfig());
+    }
+
+    @Test
+    public void twoArgumentConstructorSetsIgnoreHostsAndKeepsRemainingDefaults() {
+        List<CaptureRule> captureRules = sampleRules();
+        List<String> ignoreHosts = Arrays.asList("ignored.example.com");
+        NetworkTrackingOptions options = new NetworkTrackingOptions(captureRules, ignoreHosts);
+
+        assertEquals(ignoreHosts, options.getIgnoreHosts());
+        assertTrue(options.getIgnoreAmplitudeRequests());
+        assertTrue(options.getEnabled());
+        assertTrue(options.getEnableRemoteConfig());
+    }
+
+    @Test
+    public void threeArgumentConstructorSetsIgnoreAmplitudeRequests() {
+        List<CaptureRule> captureRules = sampleRules();
+        List<String> ignoreHosts = Arrays.asList("ignored.example.com");
+        NetworkTrackingOptions options =
+                new NetworkTrackingOptions(captureRules, ignoreHosts, false);
+
+        assertEquals(ignoreHosts, options.getIgnoreHosts());
+        assertFalse(options.getIgnoreAmplitudeRequests());
+        assertTrue(options.getEnabled());
+        assertTrue(options.getEnableRemoteConfig());
+    }
+
+    @Test
+    public void fourArgumentConstructorSetsEnabled() {
+        List<CaptureRule> captureRules = sampleRules();
+        List<String> ignoreHosts = Arrays.asList("ignored.example.com");
+        NetworkTrackingOptions options =
+                new NetworkTrackingOptions(captureRules, ignoreHosts, false, false);
+
+        assertFalse(options.getIgnoreAmplitudeRequests());
+        assertFalse(options.getEnabled());
+        assertTrue(options.getEnableRemoteConfig());
+    }
+
+    @Test
+    public void captureHeaderOverloadsUseDefaultedFields() {
+        CaptureHeader empty = new CaptureHeader();
+        assertTrue(empty.getAllowlist().isEmpty());
+        assertTrue(empty.getCaptureSafeHeaders());
+
+        List<String> allowlist = Collections.singletonList("X-Custom");
+        CaptureHeader withAllowlist = new CaptureHeader(allowlist);
+        assertEquals(allowlist, withAllowlist.getAllowlist());
+        assertTrue(withAllowlist.getCaptureSafeHeaders());
+    }
+
+    @Test
+    public void captureBodyOneArgumentConstructorUsesEmptyExcludelist() {
+        List<String> allowlist = Collections.singletonList("user");
+        CaptureBody body = new CaptureBody(allowlist);
+
+        assertEquals(allowlist, body.getAllowlist());
+        assertTrue(body.getExcludelist().isEmpty());
+    }
+}


### PR DESCRIPTION
### Describe what this PR is addressing
Java callers cannot omit defaulted constructor parameters on `NetworkTrackingOptions` and nested capture types.

### Describe the solution
Add `@JvmOverloads` to `NetworkTrackingOptions`, `CaptureHeader`, `CaptureBody`, and the host-based `CaptureRule` constructor. Additive bytecode only; existing signatures unchanged.

The URL-based `CaptureRule` constructor is left unaugmented: both constructors erase to `List`, so overloads would clash. A builder for that form can land separately.

### Steps to verify the change
- `./gradlew :android:test`
- `./gradlew ktlintCheck`
- `./gradlew apiCheck`

### Useful links and documentation (optional)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?

Made with [Cursor](https://cursor.com)