### PR TITLE
feat: give UniversalPlugins platform context and interface signals

### DIFF
--- a/analytics-core/api/analytics-core.api
+++ b/analytics-core/api/analytics-core.api
@@ -43,6 +43,7 @@ public class com/amplitude/core/Amplitude : com/amplitude/core/platform/PluginHo
 	public final fun add (Lcom/amplitude/core/platform/Plugin;)Lcom/amplitude/core/Amplitude;
 	public final fun add (Lcom/amplitude/core/platform/UniversalPlugin;)Lcom/amplitude/core/Amplitude;
 	protected fun build ()Lkotlinx/coroutines/Deferred;
+	protected fun buildAmplitudeContext ()Lcom/amplitude/core/AmplitudeContext;
 	protected fun buildInternal (Lcom/amplitude/id/IdentityConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected fun createIdentityConfiguration ()Lcom/amplitude/id/IdentityConfiguration;
 	protected final fun createIdentityContainer (Lcom/amplitude/id/IdentityConfiguration;)V
@@ -62,6 +63,7 @@ public class com/amplitude/core/Amplitude : com/amplitude/core/platform/PluginHo
 	public final fun getIdentifyInterceptStorage ()Lcom/amplitude/core/Storage;
 	public fun getIdentity ()Lcom/amplitude/core/AnalyticsIdentity;
 	public final fun getIdentityStorage ()Lcom/amplitude/id/IdentityStorage;
+	public final fun getInterfaceSignalProvider ()Lcom/amplitude/core/platform/InterfaceSignalProvider;
 	public final fun getLogger ()Lcom/amplitude/common/Logger;
 	public final fun getNetworkIODispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getOptOut ()Z
@@ -89,6 +91,7 @@ public class com/amplitude/core/Amplitude : com/amplitude/core/platform/PluginHo
 	public final fun logEvent (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/Amplitude;
 	public final fun logRevenue (Lcom/amplitude/core/events/Revenue;)Lcom/amplitude/core/Amplitude;
 	protected final fun notifyAllPlugins (Lkotlin/jvm/functions/Function1;)V
+	protected fun onInterfaceSignalProviderChanged (Lcom/amplitude/core/platform/InterfaceSignalProvider;Lcom/amplitude/core/platform/InterfaceSignalProvider;)V
 	public fun plugin (Ljava/lang/String;)Lcom/amplitude/core/platform/UniversalPlugin;
 	public fun plugins (Ljava/lang/Class;)Ljava/util/List;
 	public final fun remove (Lcom/amplitude/core/platform/Plugin;)Lcom/amplitude/core/Amplitude;
@@ -119,10 +122,13 @@ public class com/amplitude/core/Amplitude : com/amplitude/core/platform/PluginHo
 
 public class com/amplitude/core/AmplitudeContext {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/amplitude/core/ServerZone;Lcom/amplitude/common/Logger;Lcom/amplitude/core/remoteconfig/RemoteConfigClient;Lcom/amplitude/core/diagnostics/DiagnosticsClient;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/amplitude/core/ServerZone;Lcom/amplitude/common/Logger;Lcom/amplitude/core/remoteconfig/RemoteConfigClient;Lcom/amplitude/core/diagnostics/DiagnosticsClient;Ljava/lang/Object;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/amplitude/core/ServerZone;Lcom/amplitude/common/Logger;Lcom/amplitude/core/remoteconfig/RemoteConfigClient;Lcom/amplitude/core/diagnostics/DiagnosticsClient;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getApiKey ()Ljava/lang/String;
 	public final fun getDiagnosticsClient ()Lcom/amplitude/core/diagnostics/DiagnosticsClient;
 	public final fun getInstanceName ()Ljava/lang/String;
 	public final fun getLogger ()Lcom/amplitude/common/Logger;
+	public final fun getPlatformContext ()Ljava/lang/Object;
 	public final fun getRemoteConfigClient ()Lcom/amplitude/core/remoteconfig/RemoteConfigClient;
 	public final fun getServerZone ()Lcom/amplitude/core/ServerZone;
 }
@@ -837,6 +843,23 @@ public abstract interface class com/amplitude/core/platform/EventPlugin : com/am
 	public fun identify (Lcom/amplitude/core/events/IdentifyEvent;)Lcom/amplitude/core/events/IdentifyEvent;
 	public fun revenue (Lcom/amplitude/core/events/RevenueEvent;)Lcom/amplitude/core/events/RevenueEvent;
 	public fun track (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;
+}
+
+public class com/amplitude/core/platform/InterfaceChangeSignal {
+	public fun <init> (Ljava/util/Date;)V
+	public final fun getTime ()Ljava/util/Date;
+}
+
+public abstract interface class com/amplitude/core/platform/InterfaceSignalProvider {
+	public abstract fun addInterfaceSignalReceiver (Lcom/amplitude/core/platform/InterfaceSignalReceiver;)V
+	public abstract fun isProviding ()Z
+	public abstract fun removeInterfaceSignalReceiver (Lcom/amplitude/core/platform/InterfaceSignalReceiver;)V
+}
+
+public abstract interface class com/amplitude/core/platform/InterfaceSignalReceiver {
+	public abstract fun onInterfaceChanged (Lcom/amplitude/core/platform/InterfaceChangeSignal;)V
+	public abstract fun onStartProviding ()V
+	public abstract fun onStopProviding ()V
 }
 
 public abstract class com/amplitude/core/platform/ObservePlugin : com/amplitude/core/platform/Plugin {

--- a/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/Amplitude.kt
@@ -12,6 +12,7 @@ import com.amplitude.core.events.IdentifyEvent
 import com.amplitude.core.events.Revenue
 import com.amplitude.core.events.RevenueEvent
 import com.amplitude.core.platform.EventPlugin
+import com.amplitude.core.platform.InterfaceSignalProvider
 import com.amplitude.core.platform.Plugin
 import com.amplitude.core.platform.PluginHost
 import com.amplitude.core.platform.Signal
@@ -124,8 +125,20 @@ public open class Amplitude(
 
     public val amplitudeContext: AmplitudeContext by lazy { buildAmplitudeContext() }
 
+    /**
+     * The [InterfaceSignalProvider] currently registered via [add], typically Session Replay.
+     * Null when no such plugin is installed.
+     */
+    public var interfaceSignalProvider: InterfaceSignalProvider? = null
+        private set
+
+    /**
+     * Builds the [AmplitudeContext] handed to universal plugins at setup.
+     * Platform subclasses (such as Android) override this to supply platform-specific handles
+     * like the application context via [AmplitudeContext.platformContext].
+     */
     @OptIn(RestrictedAmplitudeFeature::class)
-    private fun buildAmplitudeContext(): AmplitudeContext =
+    protected open fun buildAmplitudeContext(): AmplitudeContext =
         AmplitudeContext(
             apiKey = configuration.apiKey,
             instanceName = configuration.instanceName,
@@ -586,15 +599,19 @@ public open class Amplitude(
      */
     public fun add(plugin: Plugin): Amplitude {
         timeline.add(plugin)
+        bindInterfaceSignalProviderOnAdd(plugin)
         return this
     }
 
     /**
      * Add a [UniversalPlugin]. If the plugin is also a [Plugin], it is added directly.
      * Otherwise it is hosted in the enrichment stage.
+     *
+     * If [plugin] implements [InterfaceSignalProvider], it becomes [interfaceSignalProvider].
      */
     public fun add(plugin: UniversalPlugin): Amplitude {
         timeline.add(plugin)
+        bindInterfaceSignalProviderOnAdd(plugin)
         return this
     }
 
@@ -618,15 +635,52 @@ public open class Amplitude(
 
     public fun remove(plugin: Plugin): Amplitude {
         timeline.remove(plugin)
+        unbindInterfaceSignalProviderOnRemove(plugin)
         return this
     }
 
     /**
      * Remove a [UniversalPlugin], including a bare plugin hosted in the enrichment stage.
+     *
+     * If [plugin] is the current [interfaceSignalProvider], that reference is cleared.
      */
     public fun remove(plugin: UniversalPlugin): Amplitude {
         timeline.remove(plugin)
+        unbindInterfaceSignalProviderOnRemove(plugin)
         return this
+    }
+
+    /**
+     * Called when [interfaceSignalProvider] is replaced. Android overrides this so
+     * frustration autocapture can subscribe to the new provider.
+     */
+    protected open fun onInterfaceSignalProviderChanged(
+        from: InterfaceSignalProvider?,
+        to: InterfaceSignalProvider?,
+    ) {
+    }
+
+    private fun bindInterfaceSignalProviderOnAdd(plugin: UniversalPlugin) {
+        val name = plugin.name
+        if (name != null && plugin(name) !== plugin) {
+            return
+        }
+        val provider = plugin as? InterfaceSignalProvider ?: return
+        if (interfaceSignalProvider === provider) {
+            return
+        }
+        val previous = interfaceSignalProvider
+        interfaceSignalProvider = provider
+        onInterfaceSignalProviderChanged(previous, provider)
+    }
+
+    private fun unbindInterfaceSignalProviderOnRemove(plugin: UniversalPlugin) {
+        if (interfaceSignalProvider !== plugin) {
+            return
+        }
+        val previous = interfaceSignalProvider
+        interfaceSignalProvider = null
+        onInterfaceSignalProviderChanged(previous, null)
     }
 
     public fun flush() {

--- a/analytics-core/src/main/java/com/amplitude/core/AmplitudeContext.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/AmplitudeContext.kt
@@ -13,6 +13,10 @@ import com.amplitude.core.remoteconfig.RemoteConfigClient
  * @property instanceName the host's instance name.
  * @property serverZone the server zone events are sent to.
  * @property logger the host's logger.
+ * @property platformContext host-provided platform handle. On Android this is the
+ *   application [android.content.Context]; on JVM hosts it is `null`. Typed as [Any] so
+ *   `:analytics-core` stays platform-independent. Android plugins should cast:
+ *   `amplitudeContext.platformContext as? android.content.Context`.
  */
 public open class AmplitudeContext
     @RestrictedAmplitudeFeature
@@ -23,8 +27,10 @@ public open class AmplitudeContext
         public val logger: Logger,
         remoteConfigClientProvider: () -> RemoteConfigClient,
         diagnosticsClientProvider: () -> DiagnosticsClient,
+        public val platformContext: Any? = null,
     ) {
         @RestrictedAmplitudeFeature
+        @JvmOverloads
         public constructor(
             apiKey: String,
             instanceName: String,
@@ -32,6 +38,7 @@ public open class AmplitudeContext
             logger: Logger,
             remoteConfigClient: RemoteConfigClient,
             diagnosticsClient: DiagnosticsClient,
+            platformContext: Any? = null,
         ) : this(
             apiKey,
             instanceName,
@@ -39,6 +46,7 @@ public open class AmplitudeContext
             logger,
             { remoteConfigClient },
             { diagnosticsClient },
+            platformContext,
         )
 
         @RestrictedAmplitudeFeature

--- a/analytics-core/src/main/java/com/amplitude/core/platform/InterfaceSignal.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/InterfaceSignal.kt
@@ -1,0 +1,48 @@
+package com.amplitude.core.platform
+
+import java.util.Date
+
+/**
+ * A UI or interface mutation observed by an [InterfaceSignalProvider].
+ *
+ * Session Replay emits these so frustration autocapture can tell a click produced a visible
+ * change. The payload is only a timestamp; receivers decide what to do with it.
+ *
+ * @property time when the interface change was observed.
+ */
+public open class InterfaceChangeSignal(
+    public val time: Date,
+)
+
+/**
+ * Pull-model source of [InterfaceChangeSignal]s. Session Replay implements this on its
+ * [UniversalPlugin]; [com.amplitude.core.Amplitude] holds the provider when the plugin is added
+ * and clears it on remove.
+ *
+ * Analytics never pushes into the plugin. Receivers register here and the provider notifies them
+ * when it starts, stops, or observes a change.
+ */
+public interface InterfaceSignalProvider {
+    /** Whether the provider is currently emitting interface changes. */
+    public val isProviding: Boolean
+
+    /** Registers [receiver] to observe interface changes. Duplicate adds are ignored. */
+    public fun addInterfaceSignalReceiver(receiver: InterfaceSignalReceiver)
+
+    /** Unregisters [receiver]. No-op if it is not registered. */
+    public fun removeInterfaceSignalReceiver(receiver: InterfaceSignalReceiver)
+}
+
+/**
+ * Observer of an [InterfaceSignalProvider].
+ */
+public interface InterfaceSignalReceiver {
+    /** A visible interface change occurred at [signal].time. */
+    public fun onInterfaceChanged(signal: InterfaceChangeSignal)
+
+    /** The provider began emitting interface changes. */
+    public fun onStartProviding()
+
+    /** The provider stopped emitting interface changes. */
+    public fun onStopProviding()
+}

--- a/analytics-core/src/main/java/com/amplitude/core/platform/UniversalPlugin.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/UniversalPlugin.kt
@@ -28,7 +28,8 @@ public interface UniversalPlugin {
     /**
      * Called when the plugin is registered with a host. [client] exposes live identity,
      * session, and opt-out state; [context] carries shared configuration such as the API key,
-     * server zone, and logger.
+     * server zone, and logger. On Android, [AmplitudeContext.platformContext] is the
+     * application context.
      */
     public fun setup(
         client: AnalyticsClient,

--- a/analytics-core/src/test/kotlin/com/amplitude/core/AmplitudeContextTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/AmplitudeContextTest.kt
@@ -43,4 +43,36 @@ class AmplitudeContextTest {
         assertEquals(1, remoteConfigInitializations)
         assertEquals(1, diagnosticsInitializations)
     }
+
+    @Test
+    fun `platformContext defaults to null`() {
+        val context =
+            AmplitudeContext(
+                apiKey = "api-key",
+                instanceName = "instance",
+                serverZone = ServerZone.US,
+                logger = ConsoleLogger.logger,
+                remoteConfigClient = mockk(),
+                diagnosticsClient = mockk(),
+            )
+
+        assertEquals(null, context.platformContext)
+    }
+
+    @Test
+    fun `platformContext is the value passed to the constructor`() {
+        val platform = Any()
+        val context =
+            AmplitudeContext(
+                apiKey = "api-key",
+                instanceName = "instance",
+                serverZone = ServerZone.US,
+                logger = ConsoleLogger.logger,
+                remoteConfigClient = mockk(),
+                diagnosticsClient = mockk(),
+                platformContext = platform,
+            )
+
+        assertSame(platform, context.platformContext)
+    }
 }

--- a/analytics-core/src/test/kotlin/com/amplitude/core/platform/InterfaceSignalProviderTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/platform/InterfaceSignalProviderTest.kt
@@ -1,0 +1,159 @@
+package com.amplitude.core.platform
+
+import com.amplitude.core.AmplitudeContext
+import com.amplitude.core.AnalyticsClient
+import com.amplitude.core.Configuration
+import com.amplitude.core.utils.FakeAmplitude
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.Date
+
+class InterfaceSignalProviderTest {
+    private class RecordingReceiver : InterfaceSignalReceiver {
+        val changes = mutableListOf<InterfaceChangeSignal>()
+        var startCount = 0
+        var stopCount = 0
+
+        override fun onInterfaceChanged(signal: InterfaceChangeSignal) {
+            changes += signal
+        }
+
+        override fun onStartProviding() {
+            startCount += 1
+        }
+
+        override fun onStopProviding() {
+            stopCount += 1
+        }
+    }
+
+    private class FakeProviderPlugin(
+        override val name: String? = null,
+        override var isProviding: Boolean = true,
+    ) : UniversalPlugin, InterfaceSignalProvider {
+        val receivers = mutableListOf<InterfaceSignalReceiver>()
+        var setupClient: AnalyticsClient? = null
+        var setupContext: AmplitudeContext? = null
+
+        override fun setup(
+            client: AnalyticsClient,
+            context: AmplitudeContext,
+        ) {
+            setupClient = client
+            setupContext = context
+        }
+
+        override fun addInterfaceSignalReceiver(receiver: InterfaceSignalReceiver) {
+            if (receiver !in receivers) {
+                receivers.add(receiver)
+            }
+        }
+
+        override fun removeInterfaceSignalReceiver(receiver: InterfaceSignalReceiver) {
+            receivers.remove(receiver)
+        }
+    }
+
+    @Nested
+    inner class AmplitudeAddRemove {
+        @Test
+        fun `adding an InterfaceSignalProvider plugin sets amplitude interfaceSignalProvider`() {
+            val amplitude = FakeAmplitude(Configuration("test-api-key"))
+            val provider = FakeProviderPlugin()
+
+            amplitude.add(provider)
+
+            assertSame(provider, amplitude.interfaceSignalProvider)
+        }
+
+        @Test
+        fun `removing the current InterfaceSignalProvider plugin clears interfaceSignalProvider`() {
+            val amplitude = FakeAmplitude(Configuration("test-api-key"))
+            val provider = FakeProviderPlugin()
+            amplitude.add(provider)
+
+            amplitude.remove(provider)
+
+            assertNull(amplitude.interfaceSignalProvider)
+        }
+
+        @Test
+        fun `removing a different plugin leaves interfaceSignalProvider in place`() {
+            val amplitude = FakeAmplitude(Configuration("test-api-key"))
+            val provider = FakeProviderPlugin()
+            val other = object : UniversalPlugin {}
+            amplitude.add(provider)
+            amplitude.add(other)
+
+            amplitude.remove(other)
+
+            assertSame(provider, amplitude.interfaceSignalProvider)
+        }
+
+        @Test
+        fun `a later InterfaceSignalProvider replaces the previous one`() {
+            val amplitude = FakeAmplitude(Configuration("test-api-key"))
+            val first = FakeProviderPlugin()
+            val second = FakeProviderPlugin()
+            amplitude.add(first)
+
+            amplitude.add(second)
+
+            assertSame(second, amplitude.interfaceSignalProvider)
+        }
+
+        @Test
+        fun `named duplicate InterfaceSignalProvider does not replace the incumbent`() {
+            val amplitude = FakeAmplitude(Configuration("test-api-key"))
+            val first = FakeProviderPlugin(name = "session-replay")
+            val second = FakeProviderPlugin(name = "session-replay")
+            amplitude.add(first)
+
+            amplitude.add(second)
+
+            assertSame(first, amplitude.interfaceSignalProvider)
+        }
+
+        @Test
+        fun `Amplitude notifies when the provider changes`() {
+            val changes = mutableListOf<Pair<InterfaceSignalProvider?, InterfaceSignalProvider?>>()
+            val amplitude =
+                object : FakeAmplitude(Configuration("test-api-key")) {
+                    override fun onInterfaceSignalProviderChanged(
+                        from: InterfaceSignalProvider?,
+                        to: InterfaceSignalProvider?,
+                    ) {
+                        changes += from to to
+                    }
+                }
+            val provider = FakeProviderPlugin()
+
+            amplitude.add(provider)
+            amplitude.remove(provider)
+
+            assertSame(provider, changes[0].second)
+            assertNull(changes[0].first)
+            assertSame(provider, changes[1].first)
+            assertNull(changes[1].second)
+        }
+    }
+
+    @Nested
+    inner class ProviderContract {
+        @Test
+        fun `provider delivers InterfaceChangeSignal to registered receivers`() {
+            val provider = FakeProviderPlugin()
+            val receiver = RecordingReceiver()
+            provider.addInterfaceSignalReceiver(receiver)
+            val signal = InterfaceChangeSignal(Date(1_700_000_000_000L))
+
+            provider.receivers.forEach { it.onInterfaceChanged(signal) }
+
+            assertSame(signal, receiver.changes.single())
+            assertTrue(signal.time.time == 1_700_000_000_000L)
+        }
+    }
+}

--- a/analytics-core/src/test/kotlin/com/amplitude/core/platform/UniversalPluginTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/platform/UniversalPluginTest.kt
@@ -167,6 +167,7 @@ class UniversalPluginTest {
 
             assertSame(a.analyticsClient, blade.setupClient)
             assertEquals("FAKE-API-KEY", blade.setupContext?.apiKey)
+            assertNull(blade.setupContext?.platformContext)
         }
 
         @Test

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utils/FakeAmplitude.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utils/FakeAmplitude.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class FakeAmplitude(
+open class FakeAmplitude(
     configuration: Configuration = Configuration("FAKE-API-KEY"),
     store: State = State(),
     val testDispatcher: TestDispatcher = StandardTestDispatcher(),

--- a/android/api/android.api
+++ b/android/api/android.api
@@ -4,6 +4,7 @@ public class com/amplitude/android/Amplitude : com/amplitude/core/Amplitude {
 	public static final field START_SESSION_EVENT Ljava/lang/String;
 	public fun <init> (Lcom/amplitude/android/Configuration;)V
 	protected fun build ()Lkotlinx/coroutines/Deferred;
+	protected fun buildAmplitudeContext ()Lcom/amplitude/core/AmplitudeContext;
 	protected fun buildInternal (Lcom/amplitude/id/IdentityConfiguration;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected fun createIdentityConfiguration ()Lcom/amplitude/id/IdentityConfiguration;
 	public fun createTimeline ()Lcom/amplitude/android/Timeline;
@@ -13,6 +14,7 @@ public class com/amplitude/android/Amplitude : com/amplitude/core/Amplitude {
 	public fun getSessionId ()J
 	public final fun onEnterForeground (J)V
 	public final fun onExitForeground (J)V
+	protected fun onInterfaceSignalProviderChanged (Lcom/amplitude/core/platform/InterfaceSignalProvider;Lcom/amplitude/core/platform/InterfaceSignalProvider;)V
 	public fun reset ()Lcom/amplitude/android/Amplitude;
 	public synthetic fun reset ()Lcom/amplitude/core/Amplitude;
 }
@@ -369,9 +371,12 @@ public final class com/amplitude/android/FrustrationAnalyticsUtilsKt {
 	public static synthetic fun ignoreFrustrationAnalytics$default (Landroidx/compose/ui/Modifier;ZZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 }
 
-public final class com/amplitude/android/FrustrationInteractionsDetector {
+public final class com/amplitude/android/FrustrationInteractionsDetector : com/amplitude/core/platform/InterfaceSignalReceiver {
 	public static final field Companion Lcom/amplitude/android/FrustrationInteractionsDetector$Companion;
 	public fun <init> (Lcom/amplitude/core/Amplitude;Lcom/amplitude/common/Logger;FLkotlin/jvm/functions/Function0;)V
+	public fun onInterfaceChanged (Lcom/amplitude/core/platform/InterfaceChangeSignal;)V
+	public fun onStartProviding ()V
+	public fun onStopProviding ()V
 	public final fun processClick (Lcom/amplitude/android/FrustrationInteractionsDetector$ClickInfo;Lcom/amplitude/android/FrustrationInteractionsDetector$TargetInfo;Lcom/amplitude/android/internal/ViewTarget;Ljava/lang/String;)V
 	public final fun start ()V
 	public final fun stop ()V

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -12,9 +12,11 @@ import com.amplitude.android.plugins.AndroidNetworkConnectivityCheckerPlugin
 import com.amplitude.android.storage.AndroidStorageContextV3
 import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.android.utilities.runCatchingCancellable
+import com.amplitude.core.AmplitudeContext
 import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.State
 import com.amplitude.core.diagnostics.DiagnosticsContextProvider
+import com.amplitude.core.platform.InterfaceSignalProvider
 import com.amplitude.core.platform.UniversalPlugin
 import com.amplitude.core.platform.plugins.AmplitudeDestination
 import com.amplitude.core.platform.plugins.ContextPlugin
@@ -99,6 +101,26 @@ public open class Amplitude internal constructor(
         // before the claim, and a failed claim leaves no build behind.
         AmplitudeRegistry.activate(this)
         return super.build()
+    }
+
+    override fun buildAmplitudeContext(): AmplitudeContext {
+        val androidConfig = configuration as Configuration
+        return AmplitudeContext(
+            apiKey = configuration.apiKey,
+            instanceName = configuration.instanceName,
+            serverZone = configuration.serverZone,
+            logger = logger,
+            remoteConfigClient = remoteConfigClient,
+            diagnosticsClient = diagnosticsClient,
+            platformContext = androidConfig.context.applicationContext,
+        )
+    }
+
+    override fun onInterfaceSignalProviderChanged(
+        from: InterfaceSignalProvider?,
+        to: InterfaceSignalProvider?,
+    ) {
+        findPlugin<AndroidLifecyclePlugin>()?.onInterfaceSignalProviderChanged(from, to)
     }
 
     override fun createTimeline(): Timeline {

--- a/android/src/main/java/com/amplitude/android/FrustrationInteractionsDetector.kt
+++ b/android/src/main/java/com/amplitude/android/FrustrationInteractionsDetector.kt
@@ -17,6 +17,9 @@ import com.amplitude.android.internal.buildElementInteractedProperties
 import com.amplitude.android.signals.UiChangeSignal
 import com.amplitude.common.Logger
 import com.amplitude.core.Amplitude
+import com.amplitude.core.platform.InterfaceChangeSignal
+import com.amplitude.core.platform.InterfaceSignalProvider
+import com.amplitude.core.platform.InterfaceSignalReceiver
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
@@ -27,15 +30,16 @@ import java.util.concurrent.ConcurrentHashMap
  * Core frustration interactions detector that handles rage click and dead click detection.
  *
  * **Important**: Call `start()` to enable proper dead click detection. Dead clicks require
- * active subscription to UI change signals to function correctly. If `start()` is not called,
- * dead click events will not be tracked and a warning will be logged.
+ * UI-change observation from an [InterfaceSignalProvider] (typically Session Replay) or,
+ * until Session Replay migrates, [UiChangeSignal]s on [Amplitude.signalFlow]. If `start()`
+ * is not called, dead click events will not be tracked and a warning will be logged.
  */
 public class FrustrationInteractionsDetector(
     private val amplitude: Amplitude,
     private val logger: Logger,
     density: Float,
     private val autocaptureStateProvider: () -> AutocaptureState,
-) {
+) : InterfaceSignalReceiver {
     private val autocaptureState: AutocaptureState
         get() = autocaptureStateProvider()
 
@@ -52,32 +56,63 @@ public class FrustrationInteractionsDetector(
     // Convert pt to pixels for density-independent behavior
     private val rageClickDistanceThresholdPx: Float = RAGE_CLICK_DISTANCE_THRESHOLD * density
 
+    @Volatile
+    private var started = false
     private var uiChangeCollectionJob: Job? = null
-
-    // Rage click detection
     private val pendingRageClicks = ConcurrentHashMap<String, RageClickSession>()
-
-    // Dead click detection
     private val pendingDeadClicks = ConcurrentHashMap<String, DeadClickSession>()
+    @Volatile
     private var lastUiChangeTime = 0L
 
     /**
-     * Starts the detector and begins subscribing to UI change signals.
+     * Starts the detector and subscribes to UI-change sources.
      * This is required for proper dead click detection.
      */
     public fun start() {
+        if (started) {
+            return
+        }
+        started = true
+        amplitude.interfaceSignalProvider?.addInterfaceSignalReceiver(this)
         startUiChangeCollection()
-        logger.debug("FrustrationInteractionsDetector started - UI change collection is now active")
+        logger.debug("FrustrationInteractionsDetector started - interface signal collection is now active")
     }
 
+    /**
+     * Stops the detector and unsubscribes from UI-change sources.
+     */
     public fun stop() {
+        started = false
         lastUiChangeTime = 0L
         uiChangeCollectionJob?.cancel()
+        uiChangeCollectionJob = null
+        amplitude.interfaceSignalProvider?.removeInterfaceSignalReceiver(this)
         // Cancel all pending dead click jobs to prevent resource leaks
         pendingDeadClicks.values.forEach { it.job?.cancel() }
         pendingDeadClicks.clear()
         pendingRageClicks.clear()
-        logger.debug("FrustrationInteractionsDetector stopped - UI change collection is now inactive")
+        logger.debug("FrustrationInteractionsDetector stopped - interface signal collection is now inactive")
+    }
+
+    internal fun interfaceSignalProviderDidChange(
+        from: InterfaceSignalProvider?,
+        to: InterfaceSignalProvider?,
+    ) {
+        from?.removeInterfaceSignalReceiver(this)
+        if (started) {
+            to?.addInterfaceSignalReceiver(this)
+        }
+    }
+
+    override fun onInterfaceChanged(signal: InterfaceChangeSignal) {
+        lastUiChangeTime = signal.time.time
+        logger.debug("UI change detected at $lastUiChangeTime")
+    }
+
+    override fun onStartProviding() {
+    }
+
+    override fun onStopProviding() {
     }
 
     /**
@@ -167,14 +202,15 @@ public class FrustrationInteractionsDetector(
         clickTime: Long,
         clickId: String,
     ) {
-        if (uiChangeCollectionJob?.isActive != true) {
+        if (!started) {
             logger.error("Dead click detection is disabled - call start() to enable.")
             return
         }
 
-        // Dead click detection requires an active SignalProvider plugin to emit UI change signals
-        if (!hasActiveSignalProvider()) {
-            logger.error("Dead click detection is disabled - no UI change signals observed yet. Ensure SessionReplay plugin is active.")
+        if (amplitude.interfaceSignalProvider?.isProviding != true && lastUiChangeTime <= 0L) {
+            logger.error(
+                "Dead click detection is disabled - no UI change source is active. Ensure SessionReplay plugin is active.",
+            )
             return
         }
 
@@ -222,12 +258,6 @@ public class FrustrationInteractionsDetector(
                 }
             }
     }
-
-    /**
-     * This is used to determine if a SignalProvider-backed plugin is active.
-     * So if we have seen at least one UiChangeSignal, lastUiChangeTime will be > 0.
-     */
-    private fun hasActiveSignalProvider(): Boolean = lastUiChangeTime > 0L
 
     private fun startNewRageClickSession(
         locationKey: String,

--- a/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/AndroidLifecyclePlugin.kt
@@ -21,6 +21,7 @@ import com.amplitude.android.utilities.runCatchingCancellable
 import com.amplitude.core.Amplitude
 import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.Storage
+import com.amplitude.core.platform.InterfaceSignalProvider
 import com.amplitude.core.platform.Plugin
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -333,6 +334,13 @@ public class AndroidLifecyclePlugin(
                 )
             windowCallbackManager?.start()
         }
+    }
+
+    internal fun onInterfaceSignalProviderChanged(
+        from: InterfaceSignalProvider?,
+        to: InterfaceSignalProvider?,
+    ) {
+        frustrationInteractionsDetector?.interfaceSignalProviderDidChange(from, to)
     }
 
     override fun teardown() {

--- a/android/src/test/kotlin/com/amplitude/android/AndroidAmplitudeContextTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/AndroidAmplitudeContextTest.kt
@@ -1,0 +1,27 @@
+package com.amplitude.android
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.amplitude.android.utilities.createFakeAmplitude
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class AndroidAmplitudeContextTest {
+    @Test
+    fun `platformContext is the application context`() =
+        runTest {
+            val amplitude = createFakeAmplitude(server = null, scheduler = testScheduler)
+            amplitude.isBuilt.await()
+            advanceUntilIdle()
+
+            val appContext = ApplicationProvider.getApplicationContext<Context>().applicationContext
+            assertSame(appContext, amplitude.amplitudeContext.platformContext)
+        }
+}

--- a/android/src/test/kotlin/com/amplitude/android/FrustrationInteractionsDetectorTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/FrustrationInteractionsDetectorTest.kt
@@ -11,6 +11,9 @@ import com.amplitude.android.internal.ViewTarget
 import com.amplitude.android.signals.UiChangeSignal
 import com.amplitude.common.Logger
 import com.amplitude.core.Amplitude
+import com.amplitude.core.platform.InterfaceChangeSignal
+import com.amplitude.core.platform.InterfaceSignalProvider
+import com.amplitude.core.platform.InterfaceSignalReceiver
 import com.amplitude.core.platform.Signal
 import io.mockk.clearMocks
 import io.mockk.every
@@ -37,6 +40,7 @@ class FrustrationInteractionsDetectorTest {
     private lateinit var mockLogger: Logger
     private lateinit var mockViewTarget: ViewTarget
     private val testActivityName = "TestActivity"
+    private lateinit var interfaceSignalProvider: FakeInterfaceSignalProvider
     private lateinit var uiChangeFlow: MutableSharedFlow<Signal>
     private lateinit var detector: FrustrationInteractionsDetector
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -58,6 +62,7 @@ class FrustrationInteractionsDetectorTest {
         mockAmplitude = mockk(relaxed = true)
         mockLogger = mockk(relaxed = true)
         mockViewTarget = mockk(relaxed = true)
+        interfaceSignalProvider = FakeInterfaceSignalProvider(isProviding = true)
         uiChangeFlow = MutableSharedFlow(extraBufferCapacity = 1)
 
         // Setup mock ViewTarget properties to match testTargetInfo
@@ -70,6 +75,7 @@ class FrustrationInteractionsDetectorTest {
         every { mockViewTarget.ampIgnoreRageClick } returns false
         every { mockViewTarget.ampIgnoreDeadClick } returns false
 
+        every { mockAmplitude.interfaceSignalProvider } returns interfaceSignalProvider
         every { mockAmplitude.signalFlow } returns uiChangeFlow
         every { mockAmplitude.amplitudeScope } returns CoroutineScope(testDispatcher)
         every { mockAmplitude.amplitudeDispatcher } returns testDispatcher
@@ -190,10 +196,11 @@ class FrustrationInteractionsDetectorTest {
     }
 
     @Test
-    fun `dead click - detector should be started for signal flow subscription`() {
-        // This test validates that start() is needed for proper signal flow subscription
-        // We'll test this by confirming that the startUiChangeCollection method is called
+    fun `dead click - detector should be started to subscribe to InterfaceSignalProvider`() {
         val mockAmplitudeWithStart = mockk<Amplitude>(relaxed = true)
+        val provider = FakeInterfaceSignalProvider(isProviding = true)
+        every { mockAmplitudeWithStart.interfaceSignalProvider } returns provider
+        every { mockAmplitudeWithStart.signalFlow } returns MutableSharedFlow<Signal>(extraBufferCapacity = 1)
         every { mockAmplitudeWithStart.amplitudeScope } returns CoroutineScope(testDispatcher)
         every { mockAmplitudeWithStart.amplitudeDispatcher } returns testDispatcher
 
@@ -209,14 +216,13 @@ class FrustrationInteractionsDetectorTest {
                 },
             )
 
-        // Call start() to ensure signal flow subscription
         detectorWithStart.start()
 
-        // Verify that the detector is now set up to receive UI change signals
-        // (In real usage, this would prevent false dead click detection)
-        verify { mockAmplitudeWithStart.signalFlow }
+        assertEquals(1, provider.receivers.size)
+        assertEquals(detectorWithStart, provider.receivers.single())
 
         detectorWithStart.stop()
+        assertEquals(0, provider.receivers.size)
     }
 
     //endregion
@@ -321,62 +327,64 @@ class FrustrationInteractionsDetectorTest {
 
     @Test
     fun `dead click detection should work after start()`() {
-        // Start the detector and ensure the signal collector is subscribed
         detector.start()
         testDispatcher.scheduler.runCurrent()
-        // Emit a UiChangeSignal to enable dead click detection
-        uiChangeFlow.tryEmit(UiChangeSignal(Date(System.currentTimeMillis())))
-        testDispatcher.scheduler.runCurrent()
 
-        // Process a click
         val clickInfo = FrustrationInteractionsDetector.ClickInfo(100f, 100f)
         detector.processClick(clickInfo, testTargetInfo, mockViewTarget, testActivityName)
 
-        // Verify no warning was logged about UI change collection being inactive
         verify(exactly = 0) {
             mockLogger.error("Dead click detection is disabled - call start() to enable.")
         }
 
-        // Advance time to trigger dead click timeout
         testDispatcher.scheduler.advanceTimeBy(4000L)
         testDispatcher.scheduler.runCurrent()
 
-        // Verify dead click was tracked
         verify { mockAmplitude.track(DEAD_CLICK, any()) }
     }
 
     @Test
-    fun `dead click detection should not work after start() until UiChangeSignal is observed`() {
+    fun `dead click detection should not work after start() until provider is providing`() {
+        interfaceSignalProvider.isProviding = false
         detector.start()
 
         val clickInfo = FrustrationInteractionsDetector.ClickInfo(100f, 100f)
         detector.processClick(clickInfo, testTargetInfo, mockViewTarget, testActivityName)
 
-        // Advance time past timeout
         testDispatcher.scheduler.advanceTimeBy(4000L)
         testDispatcher.scheduler.runCurrent()
 
-        // Should not track without UiChangeSignal and should log the gating error
         verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
         verify {
             mockLogger.error(
-                match { it.contains("no UI change signals observed yet") },
+                match { it.contains("no UI change source is active") },
             )
         }
     }
 
     @Test
-    fun `dead click detection should reset after stop()`() {
-        // Enable by emitting a UiChangeSignal after start
+    fun `dead click detection still works from UiChangeSignal when no InterfaceSignalProvider is registered`() {
+        every { mockAmplitude.interfaceSignalProvider } returns null
         detector.start()
+        testDispatcher.scheduler.runCurrent()
         uiChangeFlow.tryEmit(UiChangeSignal(Date(System.currentTimeMillis())))
         testDispatcher.scheduler.runCurrent()
 
-        // Stop should reset gating state
-        detector.stop()
+        val clickInfo = FrustrationInteractionsDetector.ClickInfo(100f, 100f)
+        detector.processClick(clickInfo, testTargetInfo, mockViewTarget, testActivityName)
 
-        // Restart but do NOT emit UiChangeSignal again
+        testDispatcher.scheduler.advanceTimeBy(4000L)
+        testDispatcher.scheduler.runCurrent()
+
+        verify { mockAmplitude.track(DEAD_CLICK, any()) }
+    }
+
+    @Test
+    fun `dead click detection should reset after stop()`() {
         detector.start()
+        testDispatcher.scheduler.runCurrent()
+
+        detector.stop()
 
         val clickInfo = FrustrationInteractionsDetector.ClickInfo(100f, 100f)
         detector.processClick(clickInfo, testTargetInfo, mockViewTarget, testActivityName)
@@ -386,9 +394,7 @@ class FrustrationInteractionsDetectorTest {
 
         verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
         verify {
-            mockLogger.error(
-                match { it.contains("no UI change signals observed yet") },
-            )
+            mockLogger.error("Dead click detection is disabled - call start() to enable.")
         }
     }
 
@@ -427,10 +433,6 @@ class FrustrationInteractionsDetectorTest {
                 autocaptureStateProvider = { AutocaptureState(interactions = listOf(InteractionType.RageClick)) },
             )
         detectorWithOptions.start()
-
-        // Emit initial UI change to indicate signal provider is active
-        testDispatcher.scheduler.advanceUntilIdle()
-        uiChangeFlow.tryEmit(UiChangeSignal(Date()))
         testDispatcher.scheduler.advanceUntilIdle()
 
         val clickInfo = FrustrationInteractionsDetector.ClickInfo(100f, 100f)
@@ -454,10 +456,6 @@ class FrustrationInteractionsDetectorTest {
                 autocaptureStateProvider = { AutocaptureState(interactions = emptyList()) },
             )
         detectorWithOptions.start()
-
-        // Emit initial UI change
-        testDispatcher.scheduler.advanceUntilIdle()
-        uiChangeFlow.tryEmit(UiChangeSignal(Date()))
         testDispatcher.scheduler.advanceUntilIdle()
 
         val clickInfo = FrustrationInteractionsDetector.ClickInfo(100f, 100f)
@@ -514,10 +512,6 @@ class FrustrationInteractionsDetectorTest {
                 },
             )
         detectorWithOptions.start()
-
-        // Emit initial UI change to indicate signal provider is active
-        testDispatcher.scheduler.advanceUntilIdle()
-        uiChangeFlow.tryEmit(UiChangeSignal(Date()))
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Test dead click
@@ -570,11 +564,7 @@ class FrustrationInteractionsDetectorTest {
                 },
             )
         detectorWithDefaultOptions.start()
-
-        // Emit initial UI change
         testDispatcher.scheduler.advanceUntilIdle()
-        uiChangeFlow.tryEmit(UiChangeSignal(Date(System.currentTimeMillis())))
-        testDispatcher.scheduler.runCurrent()
 
         // Test dead click
         val deadClickInfo = FrustrationInteractionsDetector.ClickInfo(500f, 500f)
@@ -588,5 +578,49 @@ class FrustrationInteractionsDetectorTest {
         verify(exactly = 1) { mockAmplitude.track(DEAD_CLICK, any()) }
     }
 
+    @Test
+    fun `interface change after click prevents dead click`() {
+        detector.start()
+        val clickInfo = FrustrationInteractionsDetector.ClickInfo(100f, 100f)
+        detector.processClick(clickInfo, testTargetInfo, mockViewTarget, testActivityName)
+
+        interfaceSignalProvider.emit(InterfaceChangeSignal(Date()))
+        testDispatcher.scheduler.advanceTimeBy(4000L)
+        testDispatcher.scheduler.runCurrent()
+
+        verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
+    }
+
+    @Test
+    fun `provider change while started resubscribes the detector`() {
+        detector.start()
+        val next = FakeInterfaceSignalProvider(isProviding = true)
+
+        detector.interfaceSignalProviderDidChange(interfaceSignalProvider, next)
+
+        assertEquals(0, interfaceSignalProvider.receivers.size)
+        assertEquals(listOf(detector), next.receivers)
+    }
+
     //endregion
+}
+
+private class FakeInterfaceSignalProvider(
+    override var isProviding: Boolean,
+) : InterfaceSignalProvider {
+    val receivers = mutableListOf<InterfaceSignalReceiver>()
+
+    override fun addInterfaceSignalReceiver(receiver: InterfaceSignalReceiver) {
+        if (receiver !in receivers) {
+            receivers.add(receiver)
+        }
+    }
+
+    override fun removeInterfaceSignalReceiver(receiver: InterfaceSignalReceiver) {
+        receivers.remove(receiver)
+    }
+
+    fun emit(signal: InterfaceChangeSignal) {
+        receivers.toList().forEach { it.onInterfaceChanged(signal) }
+    }
 }

--- a/android/src/test/kotlin/com/amplitude/android/internal/gestures/AutocaptureWindowCallbackTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/internal/gestures/AutocaptureWindowCallbackTest.kt
@@ -19,7 +19,7 @@ class AutocaptureWindowCallbackTest {
         val decorView = mockk<View>(relaxed = true)
         val activityName = "TestActivity"
         val delegate = mockk<Window.Callback>(relaxed = true)
-        val track = mockk<TrackFunction>()
+        val track: TrackFunction = { _, _ -> }
         val gestureDetector = mockk<GestureDetector>(relaxed = true)
         val gestureListener = mockk<AutocaptureGestureListener>(relaxed = true)
         val motionEventCopy = mockk<MotionEvent>(relaxed = true)

--- a/android/src/test/kotlin/com/amplitude/android/internal/gestures/FrustrationAwareWindowCallbackTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/internal/gestures/FrustrationAwareWindowCallbackTest.kt
@@ -23,7 +23,7 @@ import org.robolectric.annotation.Config
 class FrustrationAwareWindowCallbackTest {
     private val delegate = mockk<Window.Callback>(relaxed = true)
     private val decorView = View(ApplicationProvider.getApplicationContext())
-    private val track = mockk<TrackFunction>(relaxed = true)
+    private val track: TrackFunction = { _, _ -> }
     private val logger = mockk<Logger>(relaxed = true)
     private val frustrationDetector = mockk<FrustrationInteractionsDetector>(relaxed = true)
 

--- a/android/src/test/kotlin/com/amplitude/android/internal/gestures/WindowCallbackManagerTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/internal/gestures/WindowCallbackManagerTest.kt
@@ -23,7 +23,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class WindowCallbackManagerTest {
-    private val track = mockk<TrackFunction>(relaxed = true)
+    private val track: TrackFunction = { _, _ -> }
     private val logger = mockk<Logger>(relaxed = true)
     private val autocaptureState = AutocaptureState(interactions = emptyList())
     private val appContext: Context get() = ApplicationProvider.getApplicationContext()


### PR DESCRIPTION
### Describe what this PR is addressing
Session Replay Android needs `amplitude.add(SessionReplayPlugin())` without an analytics-android dependency or Class.forName shims. iOS already has UniversalPlugin setup plus a pull-model InterfaceSignalProvider.

### Describe the solution
- Add nullable `AmplitudeContext.platformContext` (Android fills `applicationContext`; core stays JVM-only).
- Make `buildAmplitudeContext()` protected open so Android can populate it.
- Add `InterfaceChangeSignal` / `InterfaceSignalProvider` / `InterfaceSignalReceiver`; `Amplitude.add`/`remove` hold the provider like Swift.
- Frustration autocapture consumes the provider and still accepts `UiChangeSignal` on `signalFlow` until SR migrates.

Existing constructors, `SignalProvider`, and `signalFlow` remain.

### Steps to verify the change
- `gagent ktlintCheck`
- `gagent apiCheck`
- `gagent :analytics-core:test`
- `gagent :android:testDebugUnitTest`

### Useful links and documentation (optional)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?