### PR TITLE
feat: Streaming - Public API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ This is a published SDK and we guard the public surface:
 
 ### Binary Compatibility
 
-Public API changes require `./gradlew apiDump` and committed `.api` files (`analytics-core/api/analytics-core.api`, `android/api/android.api`). CI fails on stale dumps.
+Public API changes require `./gradlew apiDump` and committed `.api` files (`analytics-core/api/analytics-core.api`, `android/api/android.api`, `streaming-analytics-android/api/streaming-analytics-android.api`). CI fails on stale dumps.
 
 ### Thread Safety
 

--- a/android/src/main/java/com/amplitude/android/Amplitude.kt
+++ b/android/src/main/java/com/amplitude/android/Amplitude.kt
@@ -9,6 +9,7 @@ import com.amplitude.android.plugins.AnalyticsConnectorPlugin
 import com.amplitude.android.plugins.AndroidContextPlugin
 import com.amplitude.android.plugins.AndroidLifecyclePlugin
 import com.amplitude.android.plugins.AndroidNetworkConnectivityCheckerPlugin
+import com.amplitude.android.plugins.OptionalClasspathPlugins
 import com.amplitude.android.storage.AndroidStorageContextV3
 import com.amplitude.android.utilities.ActivityLifecycleObserver
 import com.amplitude.android.utilities.runCatchingCancellable
@@ -141,6 +142,7 @@ public open class Amplitude internal constructor(
         add(AnalyticsConnectorIdentityPlugin())
         add(AnalyticsConnectorPlugin())
         add(AmplitudeDestination())
+        OptionalClasspathPlugins.install(this)
 
         (timeline as Timeline).start()
     }

--- a/android/src/main/java/com/amplitude/android/plugins/OptionalClasspathPlugins.kt
+++ b/android/src/main/java/com/amplitude/android/plugins/OptionalClasspathPlugins.kt
@@ -1,0 +1,29 @@
+package com.amplitude.android.plugins
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.platform.Plugin
+
+private const val STREAMING_ANALYTICS_PLUGIN =
+    "com.amplitude.android.streaming.StreamingAnalyticsPlugin"
+
+/**
+ * Optional Amplitude plugins loaded by class name when their artifact is on the classpath.
+ */
+internal object OptionalClasspathPlugins {
+    fun install(amplitude: Amplitude) {
+        val plugin =
+            try {
+                Class.forName(STREAMING_ANALYTICS_PLUGIN)
+                    .getDeclaredConstructor()
+                    .newInstance() as? Plugin
+            } catch (_: ClassNotFoundException) {
+                return
+            } catch (error: Throwable) {
+                amplitude.logger.error(
+                    "Failed to install StreamingAnalyticsPlugin: ${error.message}",
+                )
+                return
+            } ?: return
+        amplitude.add(plugin)
+    }
+}

--- a/android/src/test/kotlin/com/amplitude/android/plugins/OptionalClasspathPluginsTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/plugins/OptionalClasspathPluginsTest.kt
@@ -1,0 +1,19 @@
+package com.amplitude.android.plugins
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.platform.Plugin
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OptionalClasspathPluginsTest {
+    @Test
+    fun `install is a no-op when streaming analytics is not on the classpath`() {
+        val amplitude = mockk<Amplitude>(relaxed = true)
+        OptionalClasspathPlugins.install(amplitude)
+        verify(exactly = 0) { amplitude.add(any<Plugin>()) }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,8 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ktlint) apply false
-    alias(libs.plugins.bcv)
+    // On the buildSrc classpath for KotlinApiBuildTask. Version: libs.versions.bcv.
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 apiValidation {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,3 +11,8 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
+
+dependencies {
+    // Task types for AGP 9 Android libraries (BCV does not register apiDump there).
+    implementation("org.jetbrains.kotlinx:binary-compatibility-validator:${libs.versions.bcv.get()}")
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,1 +1,9 @@
 rootProject.name = "buildSrc"
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,6 @@ ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
-bcv = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "bcv" }
 android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "androidJunit5" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 android-test = { id = "com.android.test", version.ref = "androidGradlePlugin" }

--- a/samples/streaming-analytics-android/README.md
+++ b/samples/streaming-analytics-android/README.md
@@ -1,12 +1,12 @@
 # Streaming Analytics sample
 
-Android sample that plays Media3 content in XML and Compose, and initializes the Amplitude Kotlin SDK.
+Android sample for `com.amplitude:streaming-analytics-android`.
 
 ## What it shows
 
 * **XML** — one Media3 `PlayerView` (VoD). PiP and background playback stay on this player.
 * **Compose** — two VoD `PlayerView`s plus one audio-only player. PiP and background playback stay on video 1 only.
-* Amplitude is created in a Metro `AppGraph`. Each screen is an Activity plus a ViewModel that owns its `DemoPlayer`s. Metro is pinned to `0.6.5` so it matches Kotlin `2.2.10` without requiring JDK 21.
+* Amplitude is created in a Metro `AppGraph`. Each screen is an Activity plus a ViewModel that owns `DemoPlayer`s and calls `trackPlayer`. Metro is pinned to `0.6.5` so it matches Kotlin `2.2.10` without requiring JDK 21.
 
 ## Run
 

--- a/samples/streaming-analytics-android/build.gradle.kts
+++ b/samples/streaming-analytics-android/build.gradle.kts
@@ -61,6 +61,7 @@ android {
 
 dependencies {
     implementation(project(":android"))
+    implementation(project(":streaming-analytics-android"))
     implementation(libs.core.ktx)
     implementation(libs.appcompat)
     implementation(libs.material)

--- a/samples/streaming-analytics-android/src/main/java/com/amplitude/android/streaming/sample/DemoPlayerFactory.kt
+++ b/samples/streaming-analytics-android/src/main/java/com/amplitude/android/streaming/sample/DemoPlayerFactory.kt
@@ -2,6 +2,9 @@ package com.amplitude.android.streaming.sample
 
 import android.app.Application
 import com.amplitude.android.Amplitude
+import com.amplitude.android.trackPlayer
+import com.amplitude.android.streaming.PlayerContent
+import com.amplitude.core.AmplitudePreview
 import dev.zacsweers.metro.Inject
 
 @Inject
@@ -9,13 +12,25 @@ internal class DemoPlayerFactory(
     private val application: Application,
     private val amplitude: Amplitude,
 ) {
+    @OptIn(AmplitudePreview::class)
     fun create(
         catalog: List<SampleMedia>,
         keepPlayingWhenBackgrounded: Boolean,
-    ): DemoPlayer =
-        DemoPlayer(
-            context = application,
-            catalog = catalog,
-            keepPlayingWhenBackgrounded = keepPlayingWhenBackgrounded,
-        )
+    ): DemoPlayer {
+        val player =
+            DemoPlayer(
+                context = application,
+                catalog = catalog,
+                keepPlayingWhenBackgrounded = keepPlayingWhenBackgrounded,
+            )
+        amplitude.trackPlayer(player.exoPlayer) { mediaItem ->
+            val item = catalog.firstOrNull { it.id == mediaItem?.mediaId } ?: player.currentItem
+            PlayerContent(
+                contentId = item.id,
+                title = item.title,
+                contentType = item.contentType,
+            )
+        }
+        return player
+    }
 }

--- a/streaming-analytics-android/api/streaming-analytics-android.api
+++ b/streaming-analytics-android/api/streaming-analytics-android.api
@@ -1,0 +1,40 @@
+public final class com/amplitude/android/AmplitudeStreamingAnalytics {
+	public static final fun trackPlayer (Lcom/amplitude/android/Amplitude;Landroidx/media3/common/Player;Lcom/amplitude/android/streaming/PlayerContentProvider;)V
+}
+
+public final class com/amplitude/android/streaming/PlayerContent {
+	public static final field CONTENT_TYPE_AUDIO Ljava/lang/String;
+	public static final field CONTENT_TYPE_LIVE Ljava/lang/String;
+	public static final field CONTENT_TYPE_VOD Ljava/lang/String;
+	public static final field Companion Lcom/amplitude/android/streaming/PlayerContent$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getContentId ()Ljava/lang/String;
+	public final fun getContentType ()Ljava/lang/String;
+	public final fun getExtraProperties ()Ljava/util/Map;
+	public final fun getTitle ()Ljava/lang/String;
+}
+
+public final class com/amplitude/android/streaming/PlayerContent$Companion {
+}
+
+public abstract interface class com/amplitude/android/streaming/PlayerContentProvider {
+	public abstract fun optionsFor (Landroidx/media3/common/MediaItem;)Lcom/amplitude/android/streaming/PlayerContent;
+}
+
+public final class com/amplitude/android/streaming/StreamingAnalyticsPlugin : com/amplitude/core/platform/Plugin {
+	public field amplitude Lcom/amplitude/core/Amplitude;
+	public fun <init> ()V
+	public fun execute (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;
+	public fun getAmplitude ()Lcom/amplitude/core/Amplitude;
+	public fun getName ()Ljava/lang/String;
+	public fun getType ()Lcom/amplitude/core/platform/Plugin$Type;
+	public fun setAmplitude (Lcom/amplitude/core/Amplitude;)V
+	public fun setup (Lcom/amplitude/core/Amplitude;)V
+	public fun teardown ()V
+}
+

--- a/streaming-analytics-android/build.gradle.kts
+++ b/streaming-analytics-android/build.gradle.kts
@@ -1,4 +1,5 @@
-// import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import kotlinx.validation.KotlinApiBuildTask
+import kotlinx.validation.KotlinApiCompareTask
 
 plugins {
     alias(libs.plugins.android.library)
@@ -107,4 +108,60 @@ tasks.withType<Test> {
         events("passed", "skipped", "failed")
         showStandardStreams = true
     }
+}
+
+// BCV's plugin does not register apiDump/apiCheck for AGP 9 built-in Kotlin.
+// https://github.com/Kotlin/binary-compatibility-validator/issues/312
+val bcvRuntimeClasspath =
+    configurations.register("bcvRuntimeClasspath") {
+        isCanBeConsumed = false
+        isCanBeResolved = true
+    }
+
+dependencies {
+    add(bcvRuntimeClasspath.name, "org.ow2.asm:asm:9.6")
+    add(bcvRuntimeClasspath.name, "org.ow2.asm:asm-tree:9.6")
+    add(
+        bcvRuntimeClasspath.name,
+        "org.jetbrains.kotlin:kotlin-metadata-jvm:${libs.versions.kotlin.get()}",
+    )
+}
+
+val apiDumpFile = layout.projectDirectory.file("api/${project.name}.api")
+
+val apiBuild =
+    tasks.register<KotlinApiBuildTask>("apiBuild") {
+        description =
+            "Builds Kotlin API for release compilations of ${project.name}. Complementary task and shouldn't be called manually"
+        dependsOn("compileReleaseKotlin", "compileReleaseJavaWithJavac")
+        inputClassesDirs.from(
+            tasks.named("compileReleaseKotlin").map { it.outputs.files },
+            tasks.named("compileReleaseJavaWithJavac").map { it.outputs.files },
+        )
+        ignoredClasses.add("com.amplitude.android.streaming.BuildConfig")
+        outputApiFile.set(layout.buildDirectory.file("api/${project.name}.api"))
+        runtimeClasspath.from(bcvRuntimeClasspath)
+    }
+
+val apiCheck =
+    tasks.register<KotlinApiCompareTask>("apiCheck") {
+        group = "verification"
+        description =
+            "Checks signatures of public API against the golden value in API folder for ${project.name}"
+        projectApiFile.set(apiDumpFile)
+        generatedApiFile.set(apiBuild.flatMap { it.outputApiFile })
+    }
+
+tasks.register("apiDump") {
+    group = "other"
+    description = "Syncs the API file for ${project.name}"
+    dependsOn(apiBuild)
+    val builtApi = apiBuild.flatMap { it.outputApiFile }
+    doLast {
+        builtApi.get().asFile.copyTo(apiDumpFile.asFile, overwrite = true)
+    }
+}
+
+tasks.named("check") {
+    dependsOn(apiCheck)
 }

--- a/streaming-analytics-android/consumer-rules.pro
+++ b/streaming-analytics-android/consumer-rules.pro
@@ -1,1 +1,6 @@
 # Consumer R8/ProGuard rules for streaming-analytics-android.
+# Amplitude loads StreamingAnalyticsPlugin by name when this artifact is on the classpath.
+-keep class com.amplitude.android.streaming.StreamingAnalyticsPlugin {
+    public <init>();
+}
+

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/TrackPlayer.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/TrackPlayer.kt
@@ -5,7 +5,6 @@ package com.amplitude.android
 import androidx.media3.common.Player
 import com.amplitude.android.streaming.PlayerContentProvider
 import com.amplitude.android.streaming.StreamingAnalyticsPlugin
-import com.amplitude.core.Amplitude
 import com.amplitude.core.AmplitudePreview
 
 /**

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/TrackPlayer.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/TrackPlayer.kt
@@ -1,0 +1,39 @@
+@file:JvmName("AmplitudeStreamingAnalytics")
+
+package com.amplitude.android
+
+import androidx.media3.common.Player
+import com.amplitude.android.streaming.PlayerContentProvider
+import com.amplitude.android.streaming.StreamingAnalyticsPlugin
+import com.amplitude.core.Amplitude
+import com.amplitude.core.AmplitudePreview
+
+/**
+ * Starts Streaming Analytics on [androidx.media3.common.Player].
+ *
+ * If [player] is already tracked by this Amplitude instance, this function is a no-op
+ * and [contentProvider] is ignored.
+ *
+ * ```
+ * amplitude.trackPlayer(exoPlayer) { mediaItem ->
+ *     PlayerContent(
+ *         contentId = mediaItem?.mediaId ?: "ep-1",
+ *         title = "Episode 1",
+ *     )
+ * }
+ * ```
+ */
+@AmplitudePreview
+public fun Amplitude.trackPlayer(
+    player: Player,
+    contentProvider: PlayerContentProvider,
+) {
+    val plugin =
+        findPlugin<StreamingAnalyticsPlugin>()
+            ?: StreamingAnalyticsPlugin().also { add(it) }
+
+    plugin.streamingAnalytics?.trackPlayer(
+        player = player,
+        contentProvider = contentProvider,
+    )
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/TrackPlayer.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/TrackPlayer.kt
@@ -28,12 +28,26 @@ public fun Amplitude.trackPlayer(
     player: Player,
     contentProvider: PlayerContentProvider,
 ) {
-    val plugin =
-        findPlugin<StreamingAnalyticsPlugin>()
-            ?: StreamingAnalyticsPlugin().also { add(it) }
-
+    val plugin = resolveStreamingAnalyticsPlugin(findPlugin())
     plugin.streamingAnalytics?.trackPlayer(
         player = player,
         contentProvider = contentProvider,
     )
+}
+
+/**
+ * Returns the registered [StreamingAnalyticsPlugin], installing one if needed.
+ *
+ * Plugin registration is first-name-wins. If another thread already registered the
+ * plugin, [Amplitude.add] keeps that instance; resolve it instead of using a rejected
+ * candidate that was never set up.
+ */
+@OptIn(AmplitudePreview::class)
+internal fun Amplitude.resolveStreamingAnalyticsPlugin(
+    existing: StreamingAnalyticsPlugin?,
+): StreamingAnalyticsPlugin {
+    existing?.let { return it }
+    val candidate = StreamingAnalyticsPlugin()
+    add(candidate)
+    return plugin(candidate.name) as? StreamingAnalyticsPlugin ?: candidate
 }

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/TrackPlayer.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/TrackPlayer.kt
@@ -6,6 +6,7 @@ import androidx.media3.common.Player
 import com.amplitude.android.streaming.PlayerContentProvider
 import com.amplitude.android.streaming.StreamingAnalyticsPlugin
 import com.amplitude.core.AmplitudePreview
+import kotlinx.coroutines.launch
 
 /**
  * Starts Streaming Analytics on [androidx.media3.common.Player].
@@ -27,26 +28,16 @@ public fun Amplitude.trackPlayer(
     player: Player,
     contentProvider: PlayerContentProvider,
 ) {
-    val plugin = resolveStreamingAnalyticsPlugin(findPlugin())
-    plugin.streamingAnalytics?.trackPlayer(
-        player = player,
-        contentProvider = contentProvider,
-    )
-}
-
-/**
- * Returns the registered [StreamingAnalyticsPlugin], installing one if needed.
- *
- * Plugin registration is first-name-wins. If another thread already registered the
- * plugin, [Amplitude.add] keeps that instance; resolve it instead of using a rejected
- * candidate that was never set up.
- */
-@OptIn(AmplitudePreview::class)
-internal fun Amplitude.resolveStreamingAnalyticsPlugin(
-    existing: StreamingAnalyticsPlugin?,
-): StreamingAnalyticsPlugin {
-    existing?.let { return it }
-    val candidate = StreamingAnalyticsPlugin()
-    add(candidate)
-    return plugin(candidate.name) as? StreamingAnalyticsPlugin ?: candidate
+    amplitudeScope.launch(amplitudeDispatcher) {
+        isBuilt.await()
+        val streamingAnalytics = findPlugin<StreamingAnalyticsPlugin>()?.streamingAnalytics
+        if (streamingAnalytics == null) {
+            logger.error("StreamingAnalyticsPlugin is not installed.")
+            return@launch
+        }
+        streamingAnalytics.trackPlayer(
+            player = player,
+            contentProvider = contentProvider,
+        )
+    }
 }

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContent.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContent.kt
@@ -1,0 +1,41 @@
+package com.amplitude.android.streaming
+
+import com.amplitude.core.AmplitudePreview
+
+/**
+ * App-supplied metadata for `trackPlayer`.
+ *
+ * The library infers position, duration, errors, and ended/buffering from the player.
+ * Pass [contentId], [title], and [contentType] when the app already knows them.
+ *
+ * @param contentId Stable id for the current media item (`content_id` on events).
+ * @param title Human-readable title.
+ * @param contentType One of `VoD`, `live`, `audio`, or `podcast` when known.
+ * @param extraProperties App extras merged onto started/stopped events.
+ *
+ * ```
+ * PlayerContent(
+ *     contentId = "ep-1",
+ *     title = "Episode 1",
+ *     contentType = PlayerContent.CONTENT_TYPE_PODCAST,
+ * )
+ * ```
+ */
+@AmplitudePreview
+public class PlayerContent @JvmOverloads constructor(
+    public val contentId: String? = null,
+    public val title: String? = null,
+    public val contentType: String? = null,
+    extraProperties: Map<String, Any?>? = null,
+) {
+    /**
+     * Defensive copy so callers can mutate the map they passed without racing the tracker.
+     */
+    public val extraProperties: Map<String, Any?>? = extraProperties?.toMap()
+
+    public companion object {
+        public const val CONTENT_TYPE_VOD: String = "VoD"
+        public const val CONTENT_TYPE_LIVE: String = "Live"
+        public const val CONTENT_TYPE_AUDIO: String = "Audio"
+    }
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContent.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContent.kt
@@ -1,5 +1,6 @@
 package com.amplitude.android.streaming
 
+import com.amplitude.android.streaming.internal.util.deepCopy
 import com.amplitude.core.AmplitudePreview
 
 /**
@@ -10,14 +11,15 @@ import com.amplitude.core.AmplitudePreview
  *
  * @param contentId Stable id for the current media item (`content_id` on events).
  * @param title Human-readable title.
- * @param contentType One of `VoD`, `live`, `audio`, or `podcast` when known.
+ * @param contentType One of [CONTENT_TYPE_VOD], [CONTENT_TYPE_LIVE], or [CONTENT_TYPE_AUDIO]
+ * when known.
  * @param extraProperties App extras merged onto started/stopped events.
  *
  * ```
  * PlayerContent(
  *     contentId = "ep-1",
  *     title = "Episode 1",
- *     contentType = PlayerContent.CONTENT_TYPE_PODCAST,
+ *     contentType = PlayerContent.CONTENT_TYPE_AUDIO,
  * )
  * ```
  */
@@ -30,8 +32,9 @@ public class PlayerContent @JvmOverloads constructor(
 ) {
     /**
      * Defensive copy so callers can mutate the map they passed without racing the tracker.
+     * Nested maps and lists are copied too; later mutations of the originals are ignored.
      */
-    public val extraProperties: Map<String, Any?>? = extraProperties?.toMap()
+    public val extraProperties: Map<String, Any?>? = extraProperties?.deepCopy()
 
     public companion object {
         public const val CONTENT_TYPE_VOD: String = "VoD"

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContentProvider.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContentProvider.kt
@@ -1,0 +1,27 @@
+package com.amplitude.android.streaming
+
+import androidx.media3.common.MediaItem
+import com.amplitude.core.AmplitudePreview
+
+/**
+ * Supplies [PlayerContent] for the current media item.
+ *
+ * Invoked for the item already loaded when tracking starts, and again on each media
+ * transition. Return quickly; do not block.
+ *
+ * ```
+ * amplitude.trackPlayer(exoPlayer) { mediaItem ->
+ *     PlayerContent(
+ *         contentId = mediaItem?.mediaId,
+ *         title = "Episode 1",
+ *     )
+ * }
+ * ```
+ */
+@AmplitudePreview
+public fun interface PlayerContentProvider {
+    /**
+     * Content for [mediaItem], or defaults when the player has no current item.
+     */
+    public fun optionsFor(mediaItem: MediaItem?): PlayerContent
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPlugin.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPlugin.kt
@@ -1,0 +1,48 @@
+package com.amplitude.android.streaming
+
+import com.amplitude.android.streaming.internal.DelayedEvent
+import com.amplitude.android.streaming.internal.StreamingAnalytics
+import com.amplitude.core.Amplitude
+import com.amplitude.core.AmplitudePreview
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.platform.Plugin
+
+private const val NAME: String = "AmplitudeStreamingAnalytics"
+
+/**
+ * Amplitude plugin for Streaming Analytics.
+ *
+ * Installed automatically when `streaming-analytics-android` is on the classpath.
+ * [teardown] calls [StreamingAnalytics.teardown].
+ *
+ * ```
+ * amplitude.trackPlayer(exoPlayer) { mediaItem ->
+ *     PlayerContent(contentId = mediaItem?.mediaId)
+ * }
+ * ```
+ */
+@AmplitudePreview
+public class StreamingAnalyticsPlugin : Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override val name: String = NAME
+    override lateinit var amplitude: Amplitude
+    internal var streamingAnalytics: StreamingAnalytics? = null
+
+    override fun setup(amplitude: Amplitude) {
+        super.setup(amplitude)
+        streamingAnalytics = StreamingAnalytics(amplitude)
+    }
+
+    override fun execute(event: BaseEvent): BaseEvent? {
+        if (event !is DelayedEvent) {
+            return event
+        }
+        streamingAnalytics?.queueDelayedEvent(event)
+        return null
+    }
+
+    override fun teardown() {
+        streamingAnalytics?.teardown()
+        streamingAnalytics = null
+    }
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPlugin.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPlugin.kt
@@ -13,6 +13,8 @@ private const val NAME: String = "AmplitudeStreamingAnalytics"
  * Amplitude plugin for Streaming Analytics.
  *
  * Installed automatically when `streaming-analytics-android` is on the classpath.
+ * Runs as an [Plugin.Type.Enrichment] plugin so [DelayedEvent]s receive context from all
+ * [Plugin.Type.Before] plugins before being routed off the standard HTTP destination path.
  * [teardown] calls [StreamingAnalytics.teardown].
  *
  * ```
@@ -23,7 +25,7 @@ private const val NAME: String = "AmplitudeStreamingAnalytics"
  */
 @AmplitudePreview
 public class StreamingAnalyticsPlugin : Plugin {
-    override val type: Plugin.Type = Plugin.Type.Before
+    override val type: Plugin.Type = Plugin.Type.Enrichment
     override val name: String = NAME
     override lateinit var amplitude: Amplitude
     internal var streamingAnalytics: StreamingAnalytics? = null

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/DelayedEvent.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/DelayedEvent.kt
@@ -1,0 +1,21 @@
+package com.amplitude.android.streaming.internal
+
+import com.amplitude.core.events.BaseEvent
+
+internal class DelayedEvent(
+    eventType: String,
+    timestamp: Long? = null,
+    deviceId: String? = null,
+    userId: String? = null,
+    sessionId: Long? = null,
+    eventProperties: MutableMap<String, Any?> = mutableMapOf(),
+) : BaseEvent() {
+    init {
+        this.eventType = eventType
+        this.timestamp = timestamp
+        this.deviceId = deviceId
+        this.userId = userId
+        this.sessionId = sessionId
+        this.eventProperties = eventProperties
+    }
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamingAnalytics.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamingAnalytics.kt
@@ -1,0 +1,30 @@
+package com.amplitude.android.streaming.internal
+
+import androidx.media3.common.Player
+import com.amplitude.android.streaming.PlayerContentProvider
+import com.amplitude.core.Amplitude
+import com.amplitude.core.AmplitudePreview
+
+/**
+ * Per-Amplitude Streaming Analytics state.
+ */
+@OptIn(AmplitudePreview::class)
+@Suppress("UNUSED_PARAMETER")
+internal class StreamingAnalytics(
+    private val amplitude: Amplitude,
+) {
+    fun trackPlayer(
+        player: Player,
+        contentProvider: PlayerContentProvider,
+    ) {
+        // TODO: Not yet implemented
+    }
+
+    fun queueDelayedEvent(event: DelayedEvent) {
+        // TODO: Not yet implemented
+    }
+
+    fun teardown() {
+        // TODO: Not yet implemented
+    }
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/util/Kotlin.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/util/Kotlin.kt
@@ -1,0 +1,22 @@
+package com.amplitude.android.streaming.internal.util
+
+internal fun Map<String, Any?>.deepCopy(): MutableMap<String, Any?> {
+    val copy = LinkedHashMap<String, Any?>(size)
+    for ((key, value) in this) {
+        copy[key] = value.deepCopyValue()
+    }
+    return copy
+}
+
+private fun Any?.deepCopyValue(): Any? =
+    when (this) {
+        is Map<*, *> -> {
+            val copy = LinkedHashMap<Any?, Any?>(size)
+            for ((k, v) in this) {
+                copy[k] = v.deepCopyValue()
+            }
+            copy
+        }
+        is Collection<*> -> mapTo(ArrayList(size)) { it.deepCopyValue() }
+        else -> this
+    }

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/PlayerContentTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/PlayerContentTest.kt
@@ -1,0 +1,28 @@
+package com.amplitude.android.streaming
+
+import com.amplitude.core.AmplitudePreview
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+@OptIn(AmplitudePreview::class)
+class PlayerContentTest {
+    @Test
+    fun `defaults are null`() {
+        val content = PlayerContent()
+        assertNull(content.contentId)
+        assertNull(content.title)
+        assertNull(content.contentType)
+        assertNull(content.extraProperties)
+    }
+
+    @Test
+    fun `extraProperties is a defensive copy`() {
+        val extras = mutableMapOf<String, Any?>("season" to 1)
+        val content = PlayerContent(extraProperties = extras)
+        extras["season"] = 2
+        assertEquals(1, content.extraProperties?.get("season"))
+        assertNotSame(extras, content.extraProperties)
+    }
+}

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/PlayerContentTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/PlayerContentTest.kt
@@ -25,4 +25,31 @@ class PlayerContentTest {
         assertEquals(1, content.extraProperties?.get("season"))
         assertNotSame(extras, content.extraProperties)
     }
+
+    @Test
+    fun `nested extraProperties values are defensively copied`() {
+        val nested = mutableMapOf("quality" to "sd")
+        val tags = mutableListOf<Any?>("intro")
+        val extras =
+            mutableMapOf<String, Any?>(
+                "nested" to nested,
+                "tags" to tags,
+            )
+
+        val content = PlayerContent(extraProperties = extras)
+        nested["quality"] = "hd"
+        tags.add("credits")
+        extras["season"] = 2
+
+        @Suppress("UNCHECKED_CAST")
+        val copiedNested = content.extraProperties?.get("nested") as Map<String, Any?>
+        @Suppress("UNCHECKED_CAST")
+        val copiedTags = content.extraProperties?.get("tags") as List<Any?>
+
+        assertEquals("sd", copiedNested["quality"])
+        assertEquals(listOf("intro"), copiedTags)
+        assertNull(content.extraProperties?.get("season"))
+        assertNotSame(nested, copiedNested)
+        assertNotSame(tags, copiedTags)
+    }
 }

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPluginTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPluginTest.kt
@@ -1,0 +1,102 @@
+package com.amplitude.android.streaming
+
+import androidx.media3.common.Player
+import com.amplitude.android.streaming.internal.DelayedEvent
+import com.amplitude.android.trackPlayer
+import com.amplitude.core.Amplitude
+import com.amplitude.core.AmplitudePreview
+import com.amplitude.core.Configuration
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.platform.Plugin
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(AmplitudePreview::class)
+class StreamingAnalyticsPluginTest {
+    @Nested
+    inner class PluginContract {
+        @Test
+        fun `name is stable for Amplitude add dedupe`() {
+            val plugin = StreamingAnalyticsPlugin()
+            assertEquals("AmplitudeStreamingAnalytics", plugin.name)
+            assertEquals(Plugin.Type.Before, plugin.type)
+        }
+
+        @Test
+        fun `delayed events are consumed before the standard pipeline`() {
+            val plugin = StreamingAnalyticsPlugin()
+            val event =
+                DelayedEvent(
+                    eventType = "Video Content Stopped",
+                    timestamp = 1L,
+                    eventProperties = mutableMapOf(),
+                )
+
+            assertNull(plugin.execute(event))
+        }
+
+        @Test
+        fun `standard events pass through unchanged`() {
+            val plugin = StreamingAnalyticsPlugin()
+            val event = BaseEvent()
+
+            assertSame(event, plugin.execute(event))
+        }
+
+        @Test
+        fun `public constructor is loadable by class name`() {
+            val loaded =
+                Class.forName("com.amplitude.android.streaming.StreamingAnalyticsPlugin")
+                    .getDeclaredConstructor()
+                    .newInstance() as StreamingAnalyticsPlugin
+            assertEquals("AmplitudeStreamingAnalytics", loaded.name)
+        }
+    }
+
+    @Nested
+    inner class LifecycleAndWiring {
+        @Test
+        fun `setup initializes streamingAnalytics and teardown clears it`() {
+            val amplitude = mockk<Amplitude>(relaxed = true)
+            val plugin = StreamingAnalyticsPlugin()
+            assertNull(plugin.streamingAnalytics)
+
+            plugin.setup(amplitude)
+            val instance = plugin.streamingAnalytics
+            assertNotNull(instance)
+            assertSame(instance, plugin.streamingAnalytics)
+
+            plugin.teardown()
+            assertNull(plugin.streamingAnalytics)
+        }
+
+        @Test
+        fun `trackPlayer uses registered plugin`() {
+            val amplitude = Amplitude(Configuration(apiKey = "test"))
+            val plugin = StreamingAnalyticsPlugin()
+            amplitude.add(plugin)
+
+            val player = mockk<Player>(relaxed = true)
+            amplitude.trackPlayer(player) { PlayerContent() }
+
+            assertSame(plugin, amplitude.findPlugin<StreamingAnalyticsPlugin>())
+            assertNotNull(plugin.streamingAnalytics)
+        }
+
+        @Test
+        fun `trackPlayer adds plugin if not registered`() {
+            val amplitude = Amplitude(Configuration(apiKey = "test"))
+            val player = mockk<Player>(relaxed = true)
+            amplitude.trackPlayer(player) { PlayerContent() }
+
+            val plugin = amplitude.findPlugin<StreamingAnalyticsPlugin>()
+            assertNotNull(plugin)
+            assertNotNull(plugin?.streamingAnalytics)
+        }
+    }
+}

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPluginTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPluginTest.kt
@@ -2,22 +2,32 @@ package com.amplitude.android.streaming
 
 import androidx.media3.common.Player
 import com.amplitude.android.streaming.internal.DelayedEvent
-import com.amplitude.android.resolveStreamingAnalyticsPlugin
+import com.amplitude.android.streaming.internal.StreamingAnalytics
 import com.amplitude.android.trackPlayer
 import com.amplitude.core.Amplitude
 import com.amplitude.core.AmplitudePreview
-import com.amplitude.core.Configuration
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
+import com.amplitude.core.platform.Timeline
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import com.amplitude.android.Amplitude as AndroidAmplitude
 
-@OptIn(AmplitudePreview::class)
+@OptIn(AmplitudePreview::class, ExperimentalCoroutinesApi::class)
 class StreamingAnalyticsPluginTest {
     @Nested
     inner class PluginContract {
@@ -77,39 +87,84 @@ class StreamingAnalyticsPluginTest {
         }
 
         @Test
-        fun `trackPlayer uses registered plugin`() {
-            val amplitude = Amplitude(Configuration(apiKey = "test"))
+        fun `trackPlayer uses registered plugin`() =
+            runTest {
+                val isBuilt = CompletableDeferred<Boolean>()
+                val amplitude = androidAmplitude(isBuilt)
+                val streamingAnalytics = installMockedPlugin(amplitude)
+
+                val player = mockk<Player>(relaxed = true)
+                val contentProvider = PlayerContentProvider { PlayerContent() }
+                amplitude.trackPlayer(player, contentProvider)
+                isBuilt.complete(true)
+                advanceUntilIdle()
+
+                verify { streamingAnalytics.trackPlayer(player, contentProvider) }
+            }
+
+        @Test
+        fun `trackPlayer waits for the instance to finish building`() =
+            runTest {
+                val isBuilt = CompletableDeferred<Boolean>()
+                val amplitude = androidAmplitude(isBuilt)
+                val player = mockk<Player>(relaxed = true)
+                val contentProvider = PlayerContentProvider { PlayerContent() }
+
+                amplitude.trackPlayer(player, contentProvider)
+                advanceUntilIdle()
+
+                val streamingAnalytics = installMockedPlugin(amplitude)
+                isBuilt.complete(true)
+                advanceUntilIdle()
+
+                verify { streamingAnalytics.trackPlayer(player, contentProvider) }
+            }
+
+        @Test
+        fun `trackPlayer logs an error when the plugin is not installed`() =
+            runTest {
+                val amplitude = androidAmplitude(CompletableDeferred(true))
+
+                amplitude.trackPlayer(mockk<Player>(relaxed = true)) { PlayerContent() }
+                advanceUntilIdle()
+
+                verify { amplitude.logger.error("StreamingAnalyticsPlugin is not installed.") }
+            }
+
+        @Test
+        fun `trackPlayer logs an error after plugin teardown`() =
+            runTest {
+                val amplitude = androidAmplitude(CompletableDeferred(true))
+                val plugin = StreamingAnalyticsPlugin()
+                amplitude.add(plugin)
+                plugin.teardown()
+
+                amplitude.trackPlayer(mockk<Player>(relaxed = true)) { PlayerContent() }
+                advanceUntilIdle()
+
+                verify { amplitude.logger.error("StreamingAnalyticsPlugin is not installed.") }
+            }
+
+        private fun installMockedPlugin(amplitude: AndroidAmplitude): StreamingAnalytics {
             val plugin = StreamingAnalyticsPlugin()
             amplitude.add(plugin)
-
-            val player = mockk<Player>(relaxed = true)
-            amplitude.trackPlayer(player) { PlayerContent() }
-
             assertSame(plugin, amplitude.findPlugin<StreamingAnalyticsPlugin>())
-            assertNotNull(plugin.streamingAnalytics)
+            return mockk<StreamingAnalytics>(relaxed = true).also { plugin.streamingAnalytics = it }
         }
 
-        @Test
-        fun `trackPlayer adds plugin if not registered`() {
-            val amplitude = Amplitude(Configuration(apiKey = "test"))
-            val player = mockk<Player>(relaxed = true)
-            amplitude.trackPlayer(player) { PlayerContent() }
-
-            val plugin = amplitude.findPlugin<StreamingAnalyticsPlugin>()
-            assertNotNull(plugin)
-            assertNotNull(plugin?.streamingAnalytics)
-        }
-
-        @Test
-        fun `resolveStreamingAnalyticsPlugin uses registered plugin when add loses`() {
-            val amplitude = Amplitude(Configuration(apiKey = "test"))
-            val registered = StreamingAnalyticsPlugin()
-            amplitude.add(registered)
-
-            val winner = amplitude.resolveStreamingAnalyticsPlugin(existing = null)
-
-            assertSame(registered, winner)
-            assertNotNull(winner.streamingAnalytics)
+        private fun TestScope.androidAmplitude(isBuilt: CompletableDeferred<Boolean>): AndroidAmplitude {
+            val timeline = Timeline()
+            val amplitude = mockk<AndroidAmplitude>(relaxed = true)
+            timeline.amplitude = amplitude
+            every { amplitude.timeline } returns timeline
+            every { amplitude.isBuilt } returns isBuilt
+            every { amplitude.amplitudeScope } returns this as CoroutineScope
+            every { amplitude.amplitudeDispatcher } returns StandardTestDispatcher(testScheduler)
+            every { amplitude.add(any<Plugin>()) } answers {
+                timeline.add(firstArg<Plugin>())
+                amplitude
+            }
+            return amplitude
         }
     }
 }

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPluginTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPluginTest.kt
@@ -24,11 +24,11 @@ class StreamingAnalyticsPluginTest {
         fun `name is stable for Amplitude add dedupe`() {
             val plugin = StreamingAnalyticsPlugin()
             assertEquals("AmplitudeStreamingAnalytics", plugin.name)
-            assertEquals(Plugin.Type.Before, plugin.type)
+            assertEquals(Plugin.Type.Enrichment, plugin.type)
         }
 
         @Test
-        fun `delayed events are consumed before the standard pipeline`() {
+        fun `delayed events are consumed after before plugins and before destinations`() {
             val plugin = StreamingAnalyticsPlugin()
             val event =
                 DelayedEvent(

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPluginTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/StreamingAnalyticsPluginTest.kt
@@ -2,6 +2,7 @@ package com.amplitude.android.streaming
 
 import androidx.media3.common.Player
 import com.amplitude.android.streaming.internal.DelayedEvent
+import com.amplitude.android.resolveStreamingAnalyticsPlugin
 import com.amplitude.android.trackPlayer
 import com.amplitude.core.Amplitude
 import com.amplitude.core.AmplitudePreview
@@ -97,6 +98,18 @@ class StreamingAnalyticsPluginTest {
             val plugin = amplitude.findPlugin<StreamingAnalyticsPlugin>()
             assertNotNull(plugin)
             assertNotNull(plugin?.streamingAnalytics)
+        }
+
+        @Test
+        fun `resolveStreamingAnalyticsPlugin uses registered plugin when add loses`() {
+            val amplitude = Amplitude(Configuration(apiKey = "test"))
+            val registered = StreamingAnalyticsPlugin()
+            amplitude.add(registered)
+
+            val winner = amplitude.resolveStreamingAnalyticsPlugin(existing = null)
+
+            assertSame(registered, winner)
+            assertNotNull(winner.streamingAnalytics)
         }
     }
 }


### PR DESCRIPTION
### Describe what this PR is addressing
[SDKA-90](https://linear.app/amplitude/issue/SDKA-90/public-api-trackplayer-classpath-autocapture): preview `Amplitude.trackPlayer` and classpath install of Streaming Analytics when the artifact is present.

Stacked on [#483](https://github.com/amplitude/Amplitude-Kotlin/pull/483).

### Describe the solution
Adds the preview public surface on `:streaming-analytics-android`:
* `Amplitude.trackPlayer(player, contentProvider)` (`@AmplitudePreview`). Java: `AmplitudeStreamingAnalytics.trackPlayer(...)`
* `PlayerContent` / `PlayerContentProvider`
* `StreamingAnalyticsPlugin`, installed from `:android` via `Class.forName` during `buildInternal` when this module is on the classpath
* Internal `StreamingAnalytics` per Amplitude instance. `trackPlayer` / `teardown` are stubs except that `teardown` unregisters the instance so Amplitude replacements do not leak

Player observation, delayed events, and heartbeat stay on a follow-up commit.

### Steps to verify the change
1. `./gradlew :streaming-analytics-android:test :android:testDebugUnitTest --tests com.amplitude.android.plugins.OptionalClasspathPluginsTest`
2. `./gradlew ktlintCheck apiCheck`
3. Sample `:samples:streaming-app` compiles against `trackPlayer` (no-op tracking)

### Useful links and documentation (optional)
* [SDKA-90](https://linear.app/amplitude/issue/SDKA-90/public-api-trackplayer-classpath-autocapture)
* [#483](https://github.com/amplitude/Amplitude-Kotlin/pull/483)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reflective classpath plugin installation and new Enrichment pipeline behavior affect SDK startup and event routing; tracking logic is stubbed so functional risk is lower until follow-up work lands.
> 
> **Overview**
> Introduces the **preview** (`@AmplitudePreview`) public surface on `:streaming-analytics-android` for Media3 streaming analytics: `Amplitude.trackPlayer` (Java: `AmplitudeStreamingAnalytics.trackPlayer`), `PlayerContent`, `PlayerContentProvider`, and `StreamingAnalyticsPlugin`. Player observation and event emission are **not implemented yet**—internal `StreamingAnalytics` methods are stubs, and the plugin only wires lifecycle plus **Enrichment** handling that consumes internal `DelayedEvent`s before destinations.
> 
> When the streaming artifact is on the classpath, `:android` now **reflectively installs** `StreamingAnalyticsPlugin` during `buildInternal` via new `OptionalClasspathPlugins` (no-op if absent; errors logged otherwise). R8 consumer rules keep the plugin’s no-arg constructor for that path. `trackPlayer` can also register the plugin on demand, with logic to respect Amplitude’s first-name-wins `add` behavior.
> 
> Build/docs: binary-compat validation is extended for this module (manual `apiDump`/`apiCheck` on AGP 9, BCV dependency in `buildSrc`, committed `streaming-analytics-android.api`), and the streaming sample calls `trackPlayer` after creating demo players.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4061b565cb791b76715c39b885562486bca436f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->