### PR TITLE
feat: Streaming - Events

### DIFF
--- a/samples/streaming-analytics-android/src/main/java/com/amplitude/android/streaming/sample/DemoPlayerFactory.kt
+++ b/samples/streaming-analytics-android/src/main/java/com/amplitude/android/streaming/sample/DemoPlayerFactory.kt
@@ -28,7 +28,7 @@ internal class DemoPlayerFactory(
             PlayerContent(
                 contentId = item.id,
                 title = item.title,
-                contentType = item.contentType,
+                deliveryMode = item.deliveryMode,
             )
         }
         return player

--- a/samples/streaming-analytics-android/src/main/java/com/amplitude/android/streaming/sample/SampleMedia.kt
+++ b/samples/streaming-analytics-android/src/main/java/com/amplitude/android/streaming/sample/SampleMedia.kt
@@ -1,9 +1,13 @@
 package com.amplitude.android.streaming.sample
 
+import com.amplitude.android.streaming.PlayerContent
+import com.amplitude.core.AmplitudePreview
+
+@OptIn(AmplitudePreview::class)
 internal data class SampleMedia(
     val id: String,
     val title: String,
-    val contentType: String,
+    val deliveryMode: String,
     val uri: String,
 ) {
     companion object {
@@ -12,13 +16,13 @@ internal data class SampleMedia(
                 SampleMedia(
                     id = "big-buck-bunny",
                     title = "Big Buck Bunny (10 min)",
-                    contentType = "VoD",
+                    deliveryMode = PlayerContent.DELIVERY_MODE_ON_DEMAND,
                     uri = "https://storage.googleapis.com/exoplayer-test-media-0/BigBuckBunny_320x180.mp4",
                 ),
                 SampleMedia(
                     id = "frame-counter",
                     title = "Frame counter (1 hour)",
-                    contentType = "VoD",
+                    deliveryMode = PlayerContent.DELIVERY_MODE_ON_DEMAND,
                     uri = "https://storage.googleapis.com/exoplayer-test-media-1/mp4/frame-counter-one-hour.mp4",
                 ),
             )
@@ -28,13 +32,13 @@ internal data class SampleMedia(
                 SampleMedia(
                     id = "jazz-in-paris",
                     title = "Jazz in Paris",
-                    contentType = "VoD",
+                    deliveryMode = PlayerContent.DELIVERY_MODE_ON_DEMAND,
                     uri = "https://storage.googleapis.com/exoplayer-test-media-0/Jazz_In_Paris.mp3",
                 ),
                 SampleMedia(
                     id = "play-mp3",
                     title = "ExoPlayer test tone",
-                    contentType = "VoD",
+                    deliveryMode = PlayerContent.DELIVERY_MODE_ON_DEMAND,
                     uri = "https://storage.googleapis.com/exoplayer-test-media-0/play.mp3",
                 ),
             )

--- a/streaming-analytics-android/api/streaming-analytics-android.api
+++ b/streaming-analytics-android/api/streaming-analytics-android.api
@@ -3,10 +3,9 @@ public final class com/amplitude/android/AmplitudeStreamingAnalytics {
 }
 
 public final class com/amplitude/android/streaming/PlayerContent {
-	public static final field CONTENT_TYPE_AUDIO Ljava/lang/String;
-	public static final field CONTENT_TYPE_LIVE Ljava/lang/String;
-	public static final field CONTENT_TYPE_VOD Ljava/lang/String;
 	public static final field Companion Lcom/amplitude/android/streaming/PlayerContent$Companion;
+	public static final field DELIVERY_MODE_LIVE Ljava/lang/String;
+	public static final field DELIVERY_MODE_ON_DEMAND Ljava/lang/String;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
@@ -14,7 +13,7 @@ public final class com/amplitude/android/streaming/PlayerContent {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getContentId ()Ljava/lang/String;
-	public final fun getContentType ()Ljava/lang/String;
+	public final fun getDeliveryMode ()Ljava/lang/String;
 	public final fun getExtraProperties ()Ljava/util/Map;
 	public final fun getTitle ()Ljava/lang/String;
 }

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContent.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContent.kt
@@ -6,18 +6,18 @@ import com.amplitude.core.AmplitudePreview
  * App-supplied metadata for `trackPlayer`.
  *
  * The library infers position, duration, errors, and ended/buffering from the player.
- * Pass [contentId], [title], and [contentType] when the app already knows them.
+ * Pass [contentId], [title], and [deliveryMode] when the app already knows them.
  *
  * @param contentId Stable id for the current media item (`content_id` on events).
  * @param title Human-readable title.
- * @param contentType One of `VoD`, `live`, `audio`, or `podcast` when known.
+ * @param deliveryMode One of [DELIVERY_MODE_LIVE] or [DELIVERY_MODE_ON_DEMAND] when known.
  * @param extraProperties App extras merged onto started/stopped events.
  *
  * ```
  * PlayerContent(
  *     contentId = "ep-1",
  *     title = "Episode 1",
- *     contentType = PlayerContent.CONTENT_TYPE_PODCAST,
+ *     deliveryMode = PlayerContent.DELIVERY_MODE_ON_DEMAND,
  * )
  * ```
  */
@@ -25,7 +25,7 @@ import com.amplitude.core.AmplitudePreview
 public class PlayerContent @JvmOverloads constructor(
     public val contentId: String? = null,
     public val title: String? = null,
-    public val contentType: String? = null,
+    public val deliveryMode: String? = null,
     extraProperties: Map<String, Any?>? = null,
 ) {
     /**
@@ -34,8 +34,7 @@ public class PlayerContent @JvmOverloads constructor(
     public val extraProperties: Map<String, Any?>? = extraProperties?.toMap()
 
     public companion object {
-        public const val CONTENT_TYPE_VOD: String = "VoD"
-        public const val CONTENT_TYPE_LIVE: String = "Live"
-        public const val CONTENT_TYPE_AUDIO: String = "Audio"
+        public const val DELIVERY_MODE_LIVE: String = "live"
+        public const val DELIVERY_MODE_ON_DEMAND: String = "on_demand"
     }
 }

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContent.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/PlayerContent.kt
@@ -7,19 +7,18 @@ import com.amplitude.core.AmplitudePreview
  * App-supplied metadata for `trackPlayer`.
  *
  * The library infers position, duration, errors, and ended/buffering from the player.
- * Pass [contentId], [title], and [contentType] when the app already knows them.
+ * Pass [contentId], [title], and [deliveryMode] when the app already knows them.
  *
  * @param contentId Stable id for the current media item (`content_id` on events).
  * @param title Human-readable title.
- * @param contentType One of [CONTENT_TYPE_VOD], [CONTENT_TYPE_LIVE], or [CONTENT_TYPE_AUDIO]
- * when known.
+ * @param deliveryMode One of [DELIVERY_MODE_LIVE] or [DELIVERY_MODE_ON_DEMAND] when known.
  * @param extraProperties App extras merged onto started/stopped events.
  *
  * ```
  * PlayerContent(
  *     contentId = "ep-1",
  *     title = "Episode 1",
- *     contentType = PlayerContent.CONTENT_TYPE_AUDIO,
+ *     deliveryMode = PlayerContent.DELIVERY_MODE_ON_DEMAND,
  * )
  * ```
  */
@@ -27,7 +26,7 @@ import com.amplitude.core.AmplitudePreview
 public class PlayerContent @JvmOverloads constructor(
     public val contentId: String? = null,
     public val title: String? = null,
-    public val contentType: String? = null,
+    public val deliveryMode: String? = null,
     extraProperties: Map<String, Any?>? = null,
 ) {
     /**
@@ -37,8 +36,7 @@ public class PlayerContent @JvmOverloads constructor(
     public val extraProperties: Map<String, Any?>? = extraProperties?.deepCopy()
 
     public companion object {
-        public const val CONTENT_TYPE_VOD: String = "VoD"
-        public const val CONTENT_TYPE_LIVE: String = "Live"
-        public const val CONTENT_TYPE_AUDIO: String = "Audio"
+        public const val DELIVERY_MODE_LIVE: String = "live"
+        public const val DELIVERY_MODE_ON_DEMAND: String = "on_demand"
     }
 }

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamTracker.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamTracker.kt
@@ -7,13 +7,11 @@ import com.amplitude.android.streaming.internal.util.millisToSeconds
 import com.amplitude.core.Amplitude
 import com.amplitude.core.AmplitudePreview
 
-private const val AD_STARTED = "Ad Started"
-private const val AD_STOPPED = "Ad Stopped"
-private const val AD_SKIPPED = "Ad Skipped"
-private const val VIDEO_STARTED = "Video Content Started"
-private const val VIDEO_STOPPED = "Video Content Stopped"
-private const val AUDIO_STARTED = "Audio Content Started"
-private const val AUDIO_STOPPED = "Audio Content Stopped"
+private const val AD_STARTED = "[Amplitude] Ad Started"
+private const val AD_STOPPED = "[Amplitude] Ad Stopped"
+private const val AD_SKIPPED = "[Amplitude] Ad Skipped"
+private const val STREAM_STARTED = "[Amplitude] Stream Started"
+private const val STREAM_STOPPED = "[Amplitude] Stream Stopped"
 
 internal val StreamingDiGraph.streamTracker: StreamTracker by weak {
     StreamTracker(
@@ -28,34 +26,34 @@ internal class StreamTracker(
     fun trackAdStarted(
         options: PlayerContent,
         ad: AdContext,
-        viewSessionId: String,
+        streamSessionId: String,
     ) {
         amplitude.track(
             eventType = AD_STARTED,
-            eventProperties = adProperties(
-                options = options,
-                ad = ad,
-                viewSessionId = viewSessionId
-            ),
+            eventProperties =
+                adProperties(
+                    options = options,
+                    ad = ad,
+                    streamSessionId = streamSessionId,
+                ),
         )
     }
 
     fun trackAdStopped(
         options: PlayerContent,
         ad: AdContext,
-        viewSessionId: String,
-        watchDurationMillis: Long,
+        streamSessionId: String,
+        streamDurationMillis: Long,
         completed: Boolean,
     ) {
         amplitude.track(
             eventType = AD_STOPPED,
             eventProperties =
-                adProperties(options = options, ad = ad, viewSessionId = viewSessionId).apply {
-                    put("ad_watch_duration", watchDurationMillis.millisToSeconds())
+                adProperties(options = options, ad = ad, streamSessionId = streamSessionId).apply {
+                    put("ad_stream_duration", streamDurationMillis.millisToSeconds())
                     put("ad_completion_status", if (completed) "completed" else "abandoned")
                     ad.percentCompleted()?.let { percentage ->
                         put("ad_percent_completed", percentage)
-
                     }
                 },
         )
@@ -64,37 +62,39 @@ internal class StreamTracker(
     fun trackAdSkipped(
         options: PlayerContent,
         ad: AdContext,
-        viewSessionId: String,
+        streamSessionId: String,
     ) {
         amplitude.track(
             eventType = AD_SKIPPED,
-            eventProperties = adProperties(
-                options = options,
-                ad = ad,
-                viewSessionId = viewSessionId
-            ),
+            eventProperties =
+                adProperties(
+                    options = options,
+                    ad = ad,
+                    streamSessionId = streamSessionId,
+                ),
         )
     }
 
-    fun trackVideoStarted(
+    fun trackStreamStarted(
         options: PlayerContent,
         snapshot: PlayerMediaSnapshot,
-        viewSessionId: String,
+        mediaType: MediaType,
+        streamSessionId: String,
         timestamp: Long,
         insertId: String,
     ) {
         amplitude.track(
             event =
                 DelayedEvent(
-                    eventType = VIDEO_STARTED,
+                    eventType = STREAM_STARTED,
                     kind = DelayedEvent.Kind.INSTANT,
                     timestamp = timestamp,
                     eventProperties =
                         contentProperties(
                             options = options,
                             snapshot = snapshot,
-                            viewSessionId = viewSessionId,
-                            defaultContentType = PlayerContent.CONTENT_TYPE_VOD,
+                            mediaType = mediaType,
+                            streamSessionId = streamSessionId,
                         ).apply {
                             put("start_position", snapshot.positionMillis.millisToSeconds())
                         },
@@ -102,11 +102,12 @@ internal class StreamTracker(
         )
     }
 
-    fun trackVideoStopped(
+    fun trackStreamStopped(
         options: PlayerContent,
         snapshot: PlayerMediaSnapshot,
-        viewSessionId: String,
-        watchDurationMillis: Long,
+        mediaType: MediaType,
+        streamSessionId: String,
+        streamDurationMillis: Long,
         timestamp: Long,
         insertId: String,
         stopReason: StopReason? = null,
@@ -115,74 +116,18 @@ internal class StreamTracker(
         amplitude.track(
             event =
                 DelayedEvent(
-                    eventType = VIDEO_STOPPED,
+                    eventType = STREAM_STOPPED,
                     kind = DelayedEvent.Kind.DELAYED,
                     timestamp = timestamp,
                     eventProperties =
                         stoppedContentProperties(
                             options = options,
                             snapshot = snapshot,
-                            viewSessionId = viewSessionId,
-                            watchDurationMillis = watchDurationMillis,
+                            mediaType = mediaType,
+                            streamSessionId = streamSessionId,
+                            streamDurationMillis = streamDurationMillis,
                             stopReason = stopReason,
                             errorMessage = errorMessage,
-                            defaultContentType = PlayerContent.CONTENT_TYPE_VOD,
-                        ),
-                ).also { it.insertId = insertId },
-        )
-    }
-
-    fun trackAudioStarted(
-        options: PlayerContent,
-        snapshot: PlayerMediaSnapshot,
-        viewSessionId: String,
-        timestamp: Long,
-        insertId: String,
-    ) {
-        amplitude.track(
-            event =
-                DelayedEvent(
-                    eventType = AUDIO_STARTED,
-                    kind = DelayedEvent.Kind.INSTANT,
-                    timestamp = timestamp,
-                    eventProperties =
-                        contentProperties(
-                            options = options,
-                            snapshot = snapshot,
-                            viewSessionId = viewSessionId,
-                            defaultContentType = PlayerContent.CONTENT_TYPE_AUDIO,
-                        ).apply {
-                            put("start_position", snapshot.positionMillis.millisToSeconds())
-                        },
-                ).also { it.insertId = insertId },
-        )
-    }
-
-    fun trackAudioStopped(
-        options: PlayerContent,
-        snapshot: PlayerMediaSnapshot,
-        viewSessionId: String,
-        watchDurationMillis: Long,
-        timestamp: Long,
-        insertId: String,
-        stopReason: StopReason? = null,
-        errorMessage: String? = null,
-    ) {
-        amplitude.track(
-            event =
-                DelayedEvent(
-                    eventType = AUDIO_STOPPED,
-                    kind = DelayedEvent.Kind.DELAYED,
-                    timestamp = timestamp,
-                    eventProperties =
-                        stoppedContentProperties(
-                            options = options,
-                            snapshot = snapshot,
-                            viewSessionId = viewSessionId,
-                            watchDurationMillis = watchDurationMillis,
-                            stopReason = stopReason,
-                            errorMessage = errorMessage,
-                            defaultContentType = PlayerContent.CONTENT_TYPE_AUDIO,
                         ),
                 ).also { it.insertId = insertId },
         )
@@ -193,12 +138,12 @@ internal class StreamTracker(
 private fun adProperties(
     options: PlayerContent,
     ad: AdContext,
-    viewSessionId: String,
+    streamSessionId: String,
 ): MutableMap<String, Any?> =
     options.extraProperties.orEmpty().toMutableMap().apply {
         put("ad_id", ad.adId)
         put("content_id", options.contentId ?: ad.contentId)
-        put("view_session_id", viewSessionId)
+        put("stream_session_id", streamSessionId)
         put("ad_position", ad.contentPositionMillis.millisToSeconds())
         if (ad.durationMillis.isKnownDuration()) {
             put("ad_duration", ad.durationMillis.millisToSeconds())
@@ -209,18 +154,15 @@ private fun adProperties(
 private fun contentProperties(
     options: PlayerContent,
     snapshot: PlayerMediaSnapshot,
-    viewSessionId: String,
-    defaultContentType: String,
+    mediaType: MediaType,
+    streamSessionId: String,
 ): MutableMap<String, Any?> =
     options.extraProperties.orEmpty().toMutableMap().apply {
-        put("view_session_id", viewSessionId)
+        put("stream_session_id", streamSessionId)
+        put("media_type", mediaType.value)
         (options.contentId ?: snapshot.mediaId)?.let { put("content_id", it) }
         (options.title ?: snapshot.title)?.let { put("title", it) }
-        put(
-            "content_type",
-            options.contentType
-                ?: if (snapshot.isLive) PlayerContent.CONTENT_TYPE_LIVE else defaultContentType,
-        )
+        put("delivery_mode", deliveryMode(options = options, snapshot = snapshot))
         put("is_in_picture_in_picture", snapshot.isInPictureInPicture)
         put("is_in_background", snapshot.isInBackground)
         if (snapshot.hasKnownDuration()) {
@@ -232,25 +174,41 @@ private fun contentProperties(
 private fun stoppedContentProperties(
     options: PlayerContent,
     snapshot: PlayerMediaSnapshot,
-    viewSessionId: String,
-    watchDurationMillis: Long,
+    mediaType: MediaType,
+    streamSessionId: String,
+    streamDurationMillis: Long,
     stopReason: StopReason?,
     errorMessage: String?,
-    defaultContentType: String,
 ): MutableMap<String, Any?> =
     contentProperties(
         options = options,
         snapshot = snapshot,
-        viewSessionId = viewSessionId,
-        defaultContentType = defaultContentType,
+        mediaType = mediaType,
+        streamSessionId = streamSessionId,
     ).apply {
         put("current_time", snapshot.positionMillis.millisToSeconds())
-        put("watch_duration", watchDurationMillis.millisToSeconds())
+        put("stream_duration", streamDurationMillis.millisToSeconds())
         stopReason?.let { put("stop_reason", it.value) }
         errorMessage?.let { put("error_message", it) }
         snapshot.percentCompleted()?.let { percentage ->
             put("percent_completed", percentage)
         }
+    }
+
+@OptIn(AmplitudePreview::class)
+private fun deliveryMode(
+    options: PlayerContent,
+    snapshot: PlayerMediaSnapshot,
+): String =
+    when (options.deliveryMode) {
+        PlayerContent.DELIVERY_MODE_LIVE -> PlayerContent.DELIVERY_MODE_LIVE
+        PlayerContent.DELIVERY_MODE_ON_DEMAND -> PlayerContent.DELIVERY_MODE_ON_DEMAND
+        else ->
+            if (snapshot.isLive) {
+                PlayerContent.DELIVERY_MODE_LIVE
+            } else {
+                PlayerContent.DELIVERY_MODE_ON_DEMAND
+            }
     }
 
 private fun PlayerMediaSnapshot.hasKnownDuration(): Boolean =
@@ -295,6 +253,13 @@ internal data class PlayerMediaSnapshot(
     val isInPictureInPicture: Boolean = false,
     val isInBackground: Boolean = false,
 )
+
+internal enum class MediaType(
+    val value: String,
+) {
+    VIDEO("video"),
+    AUDIO("audio"),
+}
 
 internal enum class StopReason(
     val value: String,

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamTracker.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamTracker.kt
@@ -1,0 +1,308 @@
+package com.amplitude.android.streaming.internal
+
+import androidx.media3.common.C
+import com.amplitude.android.streaming.PlayerContent
+import com.amplitude.android.streaming.internal.util.DiGraph.Companion.weak
+import com.amplitude.android.streaming.internal.util.millisToSeconds
+import com.amplitude.core.Amplitude
+import com.amplitude.core.AmplitudePreview
+
+private const val AD_STARTED = "Ad Started"
+private const val AD_STOPPED = "Ad Stopped"
+private const val AD_SKIPPED = "Ad Skipped"
+private const val VIDEO_STARTED = "Video Content Started"
+private const val VIDEO_STOPPED = "Video Content Stopped"
+private const val AUDIO_STARTED = "Audio Content Started"
+private const val AUDIO_STOPPED = "Audio Content Stopped"
+
+internal val StreamingDiGraph.streamTracker: StreamTracker by weak {
+    StreamTracker(
+        amplitude = amplitude,
+    )
+}
+
+@OptIn(AmplitudePreview::class)
+internal class StreamTracker(
+    private val amplitude: Amplitude,
+) {
+    fun trackAdStarted(
+        options: PlayerContent,
+        ad: AdContext,
+        viewSessionId: String,
+    ) {
+        amplitude.track(
+            eventType = AD_STARTED,
+            eventProperties = adProperties(
+                options = options,
+                ad = ad,
+                viewSessionId = viewSessionId
+            ),
+        )
+    }
+
+    fun trackAdStopped(
+        options: PlayerContent,
+        ad: AdContext,
+        viewSessionId: String,
+        watchDurationMillis: Long,
+        completed: Boolean,
+    ) {
+        amplitude.track(
+            eventType = AD_STOPPED,
+            eventProperties =
+                adProperties(options = options, ad = ad, viewSessionId = viewSessionId).apply {
+                    put("ad_watch_duration", watchDurationMillis.millisToSeconds())
+                    put("ad_completion_status", if (completed) "completed" else "abandoned")
+                    ad.percentCompleted()?.let { percentage ->
+                        put("ad_percent_completed", percentage)
+
+                    }
+                },
+        )
+    }
+
+    fun trackAdSkipped(
+        options: PlayerContent,
+        ad: AdContext,
+        viewSessionId: String,
+    ) {
+        amplitude.track(
+            eventType = AD_SKIPPED,
+            eventProperties = adProperties(
+                options = options,
+                ad = ad,
+                viewSessionId = viewSessionId
+            ),
+        )
+    }
+
+    fun trackVideoStarted(
+        options: PlayerContent,
+        snapshot: PlayerMediaSnapshot,
+        viewSessionId: String,
+        timestamp: Long,
+        insertId: String,
+    ) {
+        amplitude.track(
+            event =
+                DelayedEvent(
+                    eventType = VIDEO_STARTED,
+                    kind = DelayedEvent.Kind.INSTANT,
+                    timestamp = timestamp,
+                    eventProperties =
+                        contentProperties(
+                            options = options,
+                            snapshot = snapshot,
+                            viewSessionId = viewSessionId,
+                            defaultContentType = PlayerContent.CONTENT_TYPE_VOD,
+                        ).apply {
+                            put("start_position", snapshot.positionMillis.millisToSeconds())
+                        },
+                ).also { it.insertId = insertId },
+        )
+    }
+
+    fun trackVideoStopped(
+        options: PlayerContent,
+        snapshot: PlayerMediaSnapshot,
+        viewSessionId: String,
+        watchDurationMillis: Long,
+        timestamp: Long,
+        insertId: String,
+        stopReason: StopReason? = null,
+        errorMessage: String? = null,
+    ) {
+        amplitude.track(
+            event =
+                DelayedEvent(
+                    eventType = VIDEO_STOPPED,
+                    kind = DelayedEvent.Kind.DELAYED,
+                    timestamp = timestamp,
+                    eventProperties =
+                        stoppedContentProperties(
+                            options = options,
+                            snapshot = snapshot,
+                            viewSessionId = viewSessionId,
+                            watchDurationMillis = watchDurationMillis,
+                            stopReason = stopReason,
+                            errorMessage = errorMessage,
+                            defaultContentType = PlayerContent.CONTENT_TYPE_VOD,
+                        ),
+                ).also { it.insertId = insertId },
+        )
+    }
+
+    fun trackAudioStarted(
+        options: PlayerContent,
+        snapshot: PlayerMediaSnapshot,
+        viewSessionId: String,
+        timestamp: Long,
+        insertId: String,
+    ) {
+        amplitude.track(
+            event =
+                DelayedEvent(
+                    eventType = AUDIO_STARTED,
+                    kind = DelayedEvent.Kind.INSTANT,
+                    timestamp = timestamp,
+                    eventProperties =
+                        contentProperties(
+                            options = options,
+                            snapshot = snapshot,
+                            viewSessionId = viewSessionId,
+                            defaultContentType = PlayerContent.CONTENT_TYPE_AUDIO,
+                        ).apply {
+                            put("start_position", snapshot.positionMillis.millisToSeconds())
+                        },
+                ).also { it.insertId = insertId },
+        )
+    }
+
+    fun trackAudioStopped(
+        options: PlayerContent,
+        snapshot: PlayerMediaSnapshot,
+        viewSessionId: String,
+        watchDurationMillis: Long,
+        timestamp: Long,
+        insertId: String,
+        stopReason: StopReason? = null,
+        errorMessage: String? = null,
+    ) {
+        amplitude.track(
+            event =
+                DelayedEvent(
+                    eventType = AUDIO_STOPPED,
+                    kind = DelayedEvent.Kind.DELAYED,
+                    timestamp = timestamp,
+                    eventProperties =
+                        stoppedContentProperties(
+                            options = options,
+                            snapshot = snapshot,
+                            viewSessionId = viewSessionId,
+                            watchDurationMillis = watchDurationMillis,
+                            stopReason = stopReason,
+                            errorMessage = errorMessage,
+                            defaultContentType = PlayerContent.CONTENT_TYPE_AUDIO,
+                        ),
+                ).also { it.insertId = insertId },
+        )
+    }
+}
+
+@OptIn(AmplitudePreview::class)
+private fun adProperties(
+    options: PlayerContent,
+    ad: AdContext,
+    viewSessionId: String,
+): MutableMap<String, Any?> =
+    options.extraProperties.orEmpty().toMutableMap().apply {
+        put("ad_id", ad.adId)
+        put("content_id", options.contentId ?: ad.contentId)
+        put("view_session_id", viewSessionId)
+        put("ad_position", ad.contentPositionMillis.millisToSeconds())
+        if (ad.durationMillis.isKnownDuration()) {
+            put("ad_duration", ad.durationMillis.millisToSeconds())
+        }
+    }
+
+@OptIn(AmplitudePreview::class)
+private fun contentProperties(
+    options: PlayerContent,
+    snapshot: PlayerMediaSnapshot,
+    viewSessionId: String,
+    defaultContentType: String,
+): MutableMap<String, Any?> =
+    options.extraProperties.orEmpty().toMutableMap().apply {
+        put("view_session_id", viewSessionId)
+        (options.contentId ?: snapshot.mediaId)?.let { put("content_id", it) }
+        (options.title ?: snapshot.title)?.let { put("title", it) }
+        put(
+            "content_type",
+            options.contentType
+                ?: if (snapshot.isLive) PlayerContent.CONTENT_TYPE_LIVE else defaultContentType,
+        )
+        put("is_in_picture_in_picture", snapshot.isInPictureInPicture)
+        put("is_in_background", snapshot.isInBackground)
+        if (snapshot.hasKnownDuration()) {
+            put("duration", snapshot.durationMillis.millisToSeconds())
+        }
+    }
+
+@OptIn(AmplitudePreview::class)
+private fun stoppedContentProperties(
+    options: PlayerContent,
+    snapshot: PlayerMediaSnapshot,
+    viewSessionId: String,
+    watchDurationMillis: Long,
+    stopReason: StopReason?,
+    errorMessage: String?,
+    defaultContentType: String,
+): MutableMap<String, Any?> =
+    contentProperties(
+        options = options,
+        snapshot = snapshot,
+        viewSessionId = viewSessionId,
+        defaultContentType = defaultContentType,
+    ).apply {
+        put("current_time", snapshot.positionMillis.millisToSeconds())
+        put("watch_duration", watchDurationMillis.millisToSeconds())
+        stopReason?.let { put("stop_reason", it.value) }
+        errorMessage?.let { put("error_message", it) }
+        snapshot.percentCompleted()?.let { percentage ->
+            put("percent_completed", percentage)
+        }
+    }
+
+private fun PlayerMediaSnapshot.hasKnownDuration(): Boolean =
+    !isLive && durationMillis.isKnownDuration()
+
+private fun Long.isKnownDuration(): Boolean = this != C.TIME_UNSET && this > 0
+
+private fun PlayerMediaSnapshot.percentCompleted(): Double? {
+    if (!hasKnownDuration()) {
+        return null
+    }
+    return (positionMillis.toDouble() / durationMillis.toDouble() * 100.0)
+        .coerceIn(0.0, 100.0)
+}
+
+internal data class AdContext(
+    val adGroupIndex: Int,
+    val adIndexInAdGroup: Int,
+    val positionMillis: Long,
+    val durationMillis: Long,
+    val contentPositionMillis: Long,
+    val contentId: String?,
+) {
+    val adId: String
+        get() = "${contentId.orEmpty()}:$adGroupIndex:$adIndexInAdGroup"
+}
+
+internal fun AdContext.percentCompleted(): Double? {
+    if (!durationMillis.isKnownDuration()) {
+        return null
+    }
+    return (100.0 * positionMillis.toDouble() / durationMillis)
+        .coerceIn(0.0, 100.0)
+}
+
+internal data class PlayerMediaSnapshot(
+    val positionMillis: Long,
+    val durationMillis: Long = C.TIME_UNSET,
+    val isLive: Boolean = false,
+    val mediaId: String? = null,
+    val title: String? = null,
+    val isInPictureInPicture: Boolean = false,
+    val isInBackground: Boolean = false,
+)
+
+internal enum class StopReason(
+    val value: String,
+) {
+    COMPLETED("completed"),
+    PAUSED("paused"),
+    SEEKING("seeking"),
+    WAITING("waiting"),
+    ERROR("error"),
+    UNSUBSCRIBED("unsubscribed"),
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamTracker.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamTracker.kt
@@ -80,6 +80,8 @@ internal class StreamTracker(
         snapshot: PlayerMediaSnapshot,
         mediaType: MediaType,
         streamSessionId: String,
+        playId: String,
+        startTimeMillis: Long,
         timestamp: Long,
         insertId: String,
     ) {
@@ -95,9 +97,9 @@ internal class StreamTracker(
                             snapshot = snapshot,
                             mediaType = mediaType,
                             streamSessionId = streamSessionId,
-                        ).apply {
-                            put("start_position", snapshot.positionMillis.millisToSeconds())
-                        },
+                            playId = playId,
+                            startTimeMillis = startTimeMillis,
+                        ),
                 ).also { it.insertId = insertId },
         )
     }
@@ -107,6 +109,8 @@ internal class StreamTracker(
         snapshot: PlayerMediaSnapshot,
         mediaType: MediaType,
         streamSessionId: String,
+        playId: String,
+        startTimeMillis: Long,
         streamDurationMillis: Long,
         timestamp: Long,
         insertId: String,
@@ -117,7 +121,7 @@ internal class StreamTracker(
             event =
                 DelayedEvent(
                     eventType = STREAM_STOPPED,
-                    kind = DelayedEvent.Kind.DELAYED,
+                    kind = stopReason.eventKind(),
                     timestamp = timestamp,
                     eventProperties =
                         stoppedContentProperties(
@@ -125,6 +129,8 @@ internal class StreamTracker(
                             snapshot = snapshot,
                             mediaType = mediaType,
                             streamSessionId = streamSessionId,
+                            playId = playId,
+                            startTimeMillis = startTimeMillis,
                             streamDurationMillis = streamDurationMillis,
                             stopReason = stopReason,
                             errorMessage = errorMessage,
@@ -156,9 +162,12 @@ private fun contentProperties(
     snapshot: PlayerMediaSnapshot,
     mediaType: MediaType,
     streamSessionId: String,
+    playId: String,
+    startTimeMillis: Long,
 ): MutableMap<String, Any?> =
     options.extraProperties.orEmpty().toMutableMap().apply {
         put("stream_session_id", streamSessionId)
+        put("play_id", playId)
         put("media_type", mediaType.value)
         (options.contentId ?: snapshot.mediaId)?.let { put("content_id", it) }
         (options.title ?: snapshot.title)?.let { put("title", it) }
@@ -168,6 +177,8 @@ private fun contentProperties(
         if (snapshot.hasKnownDuration()) {
             put("duration", snapshot.durationMillis.millisToSeconds())
         }
+        put("start_time", startTimeMillis.millisToSeconds())
+        put("position", snapshot.positionMillis.millisToSeconds())
     }
 
 @OptIn(AmplitudePreview::class)
@@ -176,6 +187,8 @@ private fun stoppedContentProperties(
     snapshot: PlayerMediaSnapshot,
     mediaType: MediaType,
     streamSessionId: String,
+    playId: String,
+    startTimeMillis: Long,
     streamDurationMillis: Long,
     stopReason: StopReason?,
     errorMessage: String?,
@@ -185,8 +198,9 @@ private fun stoppedContentProperties(
         snapshot = snapshot,
         mediaType = mediaType,
         streamSessionId = streamSessionId,
+        playId = playId,
+        startTimeMillis = startTimeMillis,
     ).apply {
-        put("current_time", snapshot.positionMillis.millisToSeconds())
         put("stream_duration", streamDurationMillis.millisToSeconds())
         stopReason?.let { put("stop_reason", it.value) }
         errorMessage?.let { put("error_message", it) }
@@ -214,11 +228,14 @@ private fun deliveryMode(
 private fun PlayerMediaSnapshot.hasKnownDuration(): Boolean =
     !isLive && durationMillis.isKnownDuration()
 
-private fun Long.isKnownDuration(): Boolean = this != C.TIME_UNSET && this > 0
+private fun Long.isKnownDuration(): Boolean = this != C.TIME_UNSET && this >= 0
 
 private fun PlayerMediaSnapshot.percentCompleted(): Double? {
     if (!hasKnownDuration()) {
         return null
+    }
+    if (durationMillis == 0L) {
+        return 0.0
     }
     return (positionMillis.toDouble() / durationMillis.toDouble() * 100.0)
         .coerceIn(0.0, 100.0)
@@ -239,6 +256,9 @@ internal data class AdContext(
 internal fun AdContext.percentCompleted(): Double? {
     if (!durationMillis.isKnownDuration()) {
         return null
+    }
+    if (durationMillis == 0L) {
+        return 0.0
     }
     return (100.0 * positionMillis.toDouble() / durationMillis)
         .coerceIn(0.0, 100.0)
@@ -264,10 +284,18 @@ internal enum class MediaType(
 internal enum class StopReason(
     val value: String,
 ) {
-    COMPLETED("completed"),
+    TIMEOUT("timeout"),
     PAUSED("paused"),
+    COMPLETED("completed"),
     SEEKING("seeking"),
     WAITING("waiting"),
     ERROR("error"),
-    UNSUBSCRIBED("unsubscribed"),
+    UNTRACKED("untracked"),
 }
+
+private fun StopReason?.eventKind(): DelayedEvent.Kind =
+    if (this == StopReason.TIMEOUT) {
+        DelayedEvent.Kind.DELAYED
+    } else {
+        DelayedEvent.Kind.INSTANT
+    }

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/util/Kotlin.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/util/Kotlin.kt
@@ -20,3 +20,5 @@ private fun Any?.deepCopyValue(): Any? =
         is Collection<*> -> mapTo(ArrayList(size)) { it.deepCopyValue() }
         else -> this
     }
+
+internal fun Long.millisToSeconds(): Double = this / 1_000.0

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/PlayerContentTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/PlayerContentTest.kt
@@ -13,7 +13,7 @@ class PlayerContentTest {
         val content = PlayerContent()
         assertNull(content.contentId)
         assertNull(content.title)
-        assertNull(content.contentType)
+        assertNull(content.deliveryMode)
         assertNull(content.extraProperties)
     }
 

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/StreamTrackerTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/StreamTrackerTest.kt
@@ -61,11 +61,12 @@ class StreamTrackerTest {
             )
 
         @Test
-        fun `trackVideoStarted sends Video Content Started delayed event with properties`() {
-            tracker.trackVideoStarted(
+        fun `trackStreamStarted sends Stream Started delayed event with properties`() {
+            tracker.trackStreamStarted(
                 options = options,
                 snapshot = snapshot,
-                viewSessionId = "view-1",
+                mediaType = MediaType.VIDEO,
+                streamSessionId = "stream-1",
                 timestamp = 1_000L,
                 insertId = "insert-start-1",
             )
@@ -73,15 +74,16 @@ class StreamTrackerTest {
             assertEquals(1, events.size)
             val event = events.first()
             assertTrue(event is DelayedEvent)
-            assertEquals("Video Content Started", event.eventType)
+            assertEquals("[Amplitude] Stream Started", event.eventType)
             assertEquals(1_000L, event.timestamp)
             assertEquals("insert-start-1", event.insertId)
 
             val props = event.eventProperties!!
-            assertEquals("view-1", props["view_session_id"])
+            assertEquals("stream-1", props["stream_session_id"])
+            assertEquals("video", props["media_type"])
             assertEquals("custom-id", props["content_id"])
             assertEquals("Custom Title", props["title"])
-            assertEquals(PlayerContent.CONTENT_TYPE_VOD, props["content_type"])
+            assertEquals("on_demand", props["delivery_mode"])
             assertEquals(15.0, props["start_position"])
             assertEquals(60.0, props["duration"])
             assertEquals(true, props["is_in_picture_in_picture"])
@@ -90,12 +92,13 @@ class StreamTrackerTest {
         }
 
         @Test
-        fun `trackVideoStopped sends Video Content Stopped delayed event with properties`() {
-            tracker.trackVideoStopped(
+        fun `trackStreamStopped sends Stream Stopped delayed event with properties`() {
+            tracker.trackStreamStopped(
                 options = options,
                 snapshot = snapshot,
-                viewSessionId = "view-1",
-                watchDurationMillis = 5_000L,
+                mediaType = MediaType.VIDEO,
+                streamSessionId = "stream-1",
+                streamDurationMillis = 5_000L,
                 timestamp = 6_000L,
                 insertId = "insert-stop-1",
                 stopReason = StopReason.PAUSED,
@@ -104,60 +107,66 @@ class StreamTrackerTest {
             assertEquals(1, events.size)
             val event = events.first()
             assertTrue(event is DelayedEvent)
-            assertEquals("Video Content Stopped", event.eventType)
+            assertEquals("[Amplitude] Stream Stopped", event.eventType)
             assertEquals(6_000L, event.timestamp)
             assertEquals("insert-stop-1", event.insertId)
 
             val props = event.eventProperties!!
-            assertEquals("view-1", props["view_session_id"])
+            assertEquals("stream-1", props["stream_session_id"])
+            assertEquals("video", props["media_type"])
             assertEquals(15.0, props["current_time"])
-            assertEquals(5.0, props["watch_duration"])
+            assertEquals(5.0, props["stream_duration"])
             assertEquals("paused", props["stop_reason"])
             assertEquals(25.0, props["percent_completed"])
         }
 
         @Test
-        fun `trackAudioStarted and trackAudioStopped default to audio content type`() {
-            tracker.trackAudioStarted(
+        fun `audio streams use media_type audio and on_demand delivery_mode`() {
+            tracker.trackStreamStarted(
                 options = PlayerContent(),
                 snapshot = snapshot,
-                viewSessionId = "view-audio",
+                mediaType = MediaType.AUDIO,
+                streamSessionId = "stream-audio",
                 timestamp = 2_000L,
                 insertId = "audio-start",
             )
-            tracker.trackAudioStopped(
+            tracker.trackStreamStopped(
                 options = PlayerContent(),
                 snapshot = snapshot,
-                viewSessionId = "view-audio",
-                watchDurationMillis = 3_000L,
+                mediaType = MediaType.AUDIO,
+                streamSessionId = "stream-audio",
+                streamDurationMillis = 3_000L,
                 timestamp = 5_000L,
                 insertId = "audio-stop",
             )
 
             assertEquals(2, events.size)
-            assertEquals("Audio Content Started", events[0].eventType)
-            assertEquals(PlayerContent.CONTENT_TYPE_AUDIO, events[0].eventProperties?.get("content_type"))
+            assertEquals("[Amplitude] Stream Started", events[0].eventType)
+            assertEquals("audio", events[0].eventProperties?.get("media_type"))
+            assertEquals("on_demand", events[0].eventProperties?.get("delivery_mode"))
             assertEquals("audio-start", events[0].insertId)
 
-            assertEquals("Audio Content Stopped", events[1].eventType)
-            assertEquals(PlayerContent.CONTENT_TYPE_AUDIO, events[1].eventProperties?.get("content_type"))
+            assertEquals("[Amplitude] Stream Stopped", events[1].eventType)
+            assertEquals("audio", events[1].eventProperties?.get("media_type"))
+            assertEquals("on_demand", events[1].eventProperties?.get("delivery_mode"))
             assertEquals("audio-stop", events[1].insertId)
         }
 
         @Test
         fun `live stream omits duration and percent_completed`() {
             val liveSnapshot = snapshot.copy(isLive = true)
-            tracker.trackVideoStopped(
+            tracker.trackStreamStopped(
                 options = PlayerContent(),
                 snapshot = liveSnapshot,
-                viewSessionId = "view-live",
-                watchDurationMillis = 10_000L,
+                mediaType = MediaType.VIDEO,
+                streamSessionId = "stream-live",
+                streamDurationMillis = 10_000L,
                 timestamp = 10_000L,
                 insertId = "stop-live",
             )
 
             val props = events.first().eventProperties!!
-            assertEquals(PlayerContent.CONTENT_TYPE_LIVE, props["content_type"])
+            assertEquals("live", props["delivery_mode"])
             assertFalse(props.containsKey("duration"))
             assertFalse(props.containsKey("percent_completed"))
         }
@@ -165,11 +174,12 @@ class StreamTrackerTest {
         @Test
         fun `unknown duration omits duration and percent_completed`() {
             val unknownDurationSnapshot = snapshot.copy(durationMillis = C.TIME_UNSET)
-            tracker.trackVideoStopped(
+            tracker.trackStreamStopped(
                 options = PlayerContent(),
                 snapshot = unknownDurationSnapshot,
-                viewSessionId = "view-unknown",
-                watchDurationMillis = 5_000L,
+                mediaType = MediaType.VIDEO,
+                streamSessionId = "stream-unknown",
+                streamDurationMillis = 5_000L,
                 timestamp = 5_000L,
                 insertId = "stop-unknown",
             )
@@ -198,16 +208,16 @@ class StreamTrackerTest {
             tracker.trackAdStarted(
                 options = options,
                 ad = ad,
-                viewSessionId = "view-ad-1",
+                streamSessionId = "stream-ad-1",
             )
 
             assertEquals(1, events.size)
             val event = events.first()
-            assertEquals("Ad Started", event.eventType)
+            assertEquals("[Amplitude] Ad Started", event.eventType)
             val props = event.eventProperties!!
             assertEquals("video-789:0:1", props["ad_id"])
             assertEquals("video-789", props["content_id"])
-            assertEquals("view-ad-1", props["view_session_id"])
+            assertEquals("stream-ad-1", props["stream_session_id"])
             assertEquals(45.0, props["ad_position"])
             assertEquals(30.0, props["ad_duration"])
             assertEquals("summer", props["ad_campaign"])
@@ -218,14 +228,14 @@ class StreamTrackerTest {
             tracker.trackAdStopped(
                 options = options,
                 ad = ad,
-                viewSessionId = "view-ad-1",
-                watchDurationMillis = 30_000L,
+                streamSessionId = "stream-ad-1",
+                streamDurationMillis = 30_000L,
                 completed = true,
             )
 
             val props = events.first().eventProperties!!
-            assertEquals("Ad Stopped", events.first().eventType)
-            assertEquals(30.0, props["ad_watch_duration"])
+            assertEquals("[Amplitude] Ad Stopped", events.first().eventType)
+            assertEquals(30.0, props["ad_stream_duration"])
             assertEquals("completed", props["ad_completion_status"])
             assertEquals(33.333, (props["ad_percent_completed"] as Double), 0.01)
         }
@@ -235,8 +245,8 @@ class StreamTrackerTest {
             tracker.trackAdStopped(
                 options = options,
                 ad = ad,
-                viewSessionId = "view-ad-1",
-                watchDurationMillis = 5_000L,
+                streamSessionId = "stream-ad-1",
+                streamDurationMillis = 5_000L,
                 completed = false,
             )
 
@@ -249,11 +259,11 @@ class StreamTrackerTest {
             tracker.trackAdSkipped(
                 options = options,
                 ad = ad,
-                viewSessionId = "view-ad-1",
+                streamSessionId = "stream-ad-1",
             )
 
             assertEquals(1, events.size)
-            assertEquals("Ad Skipped", events.first().eventType)
+            assertEquals("[Amplitude] Ad Skipped", events.first().eventType)
             assertEquals("video-789:0:1", events.first().eventProperties?.get("ad_id"))
         }
     }

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/StreamTrackerTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/StreamTrackerTest.kt
@@ -1,0 +1,260 @@
+package com.amplitude.android.streaming.internal
+
+import androidx.media3.common.C
+import com.amplitude.android.streaming.PlayerContent
+import com.amplitude.core.Amplitude
+import com.amplitude.core.AmplitudePreview
+import com.amplitude.core.events.BaseEvent
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(AmplitudePreview::class)
+class StreamTrackerTest {
+    private val events = mutableListOf<BaseEvent>()
+    private val amplitude = mockk<Amplitude>(relaxed = true)
+    private lateinit var tracker: StreamTracker
+
+    @BeforeEach
+    fun setUp() {
+        events.clear()
+        every { amplitude.track(any<BaseEvent>(), any(), any()) } answers {
+            events.add(firstArg())
+            amplitude
+        }
+        every { amplitude.track(any<String>(), any(), any()) } answers {
+            val eventType = firstArg<String>()
+            val props = secondArg<Map<String, Any?>?>()
+            events.add(
+                BaseEvent().apply {
+                    this.eventType = eventType
+                    this.eventProperties = props?.toMutableMap()
+                },
+            )
+            amplitude
+        }
+        tracker = StreamTracker(amplitude)
+    }
+
+    @Nested
+    inner class ContentEvents {
+        private val snapshot =
+            PlayerMediaSnapshot(
+                positionMillis = 15_000L,
+                durationMillis = 60_000L,
+                mediaId = "media-123",
+                title = "Test Video",
+                isInPictureInPicture = true,
+                isInBackground = false,
+            )
+        private val options =
+            PlayerContent(
+                contentId = "custom-id",
+                title = "Custom Title",
+                extraProperties = mapOf("channel" to "news"),
+            )
+
+        @Test
+        fun `trackVideoStarted sends Video Content Started delayed event with properties`() {
+            tracker.trackVideoStarted(
+                options = options,
+                snapshot = snapshot,
+                viewSessionId = "view-1",
+                timestamp = 1_000L,
+                insertId = "insert-start-1",
+            )
+
+            assertEquals(1, events.size)
+            val event = events.first()
+            assertTrue(event is DelayedEvent)
+            assertEquals("Video Content Started", event.eventType)
+            assertEquals(1_000L, event.timestamp)
+            assertEquals("insert-start-1", event.insertId)
+
+            val props = event.eventProperties!!
+            assertEquals("view-1", props["view_session_id"])
+            assertEquals("custom-id", props["content_id"])
+            assertEquals("Custom Title", props["title"])
+            assertEquals(PlayerContent.CONTENT_TYPE_VOD, props["content_type"])
+            assertEquals(15.0, props["start_position"])
+            assertEquals(60.0, props["duration"])
+            assertEquals(true, props["is_in_picture_in_picture"])
+            assertEquals(false, props["is_in_background"])
+            assertEquals("news", props["channel"])
+        }
+
+        @Test
+        fun `trackVideoStopped sends Video Content Stopped delayed event with properties`() {
+            tracker.trackVideoStopped(
+                options = options,
+                snapshot = snapshot,
+                viewSessionId = "view-1",
+                watchDurationMillis = 5_000L,
+                timestamp = 6_000L,
+                insertId = "insert-stop-1",
+                stopReason = StopReason.PAUSED,
+            )
+
+            assertEquals(1, events.size)
+            val event = events.first()
+            assertTrue(event is DelayedEvent)
+            assertEquals("Video Content Stopped", event.eventType)
+            assertEquals(6_000L, event.timestamp)
+            assertEquals("insert-stop-1", event.insertId)
+
+            val props = event.eventProperties!!
+            assertEquals("view-1", props["view_session_id"])
+            assertEquals(15.0, props["current_time"])
+            assertEquals(5.0, props["watch_duration"])
+            assertEquals("paused", props["stop_reason"])
+            assertEquals(25.0, props["percent_completed"])
+        }
+
+        @Test
+        fun `trackAudioStarted and trackAudioStopped default to audio content type`() {
+            tracker.trackAudioStarted(
+                options = PlayerContent(),
+                snapshot = snapshot,
+                viewSessionId = "view-audio",
+                timestamp = 2_000L,
+                insertId = "audio-start",
+            )
+            tracker.trackAudioStopped(
+                options = PlayerContent(),
+                snapshot = snapshot,
+                viewSessionId = "view-audio",
+                watchDurationMillis = 3_000L,
+                timestamp = 5_000L,
+                insertId = "audio-stop",
+            )
+
+            assertEquals(2, events.size)
+            assertEquals("Audio Content Started", events[0].eventType)
+            assertEquals(PlayerContent.CONTENT_TYPE_AUDIO, events[0].eventProperties?.get("content_type"))
+            assertEquals("audio-start", events[0].insertId)
+
+            assertEquals("Audio Content Stopped", events[1].eventType)
+            assertEquals(PlayerContent.CONTENT_TYPE_AUDIO, events[1].eventProperties?.get("content_type"))
+            assertEquals("audio-stop", events[1].insertId)
+        }
+
+        @Test
+        fun `live stream omits duration and percent_completed`() {
+            val liveSnapshot = snapshot.copy(isLive = true)
+            tracker.trackVideoStopped(
+                options = PlayerContent(),
+                snapshot = liveSnapshot,
+                viewSessionId = "view-live",
+                watchDurationMillis = 10_000L,
+                timestamp = 10_000L,
+                insertId = "stop-live",
+            )
+
+            val props = events.first().eventProperties!!
+            assertEquals(PlayerContent.CONTENT_TYPE_LIVE, props["content_type"])
+            assertFalse(props.containsKey("duration"))
+            assertFalse(props.containsKey("percent_completed"))
+        }
+
+        @Test
+        fun `unknown duration omits duration and percent_completed`() {
+            val unknownDurationSnapshot = snapshot.copy(durationMillis = C.TIME_UNSET)
+            tracker.trackVideoStopped(
+                options = PlayerContent(),
+                snapshot = unknownDurationSnapshot,
+                viewSessionId = "view-unknown",
+                watchDurationMillis = 5_000L,
+                timestamp = 5_000L,
+                insertId = "stop-unknown",
+            )
+
+            val props = events.first().eventProperties!!
+            assertFalse(props.containsKey("duration"))
+            assertFalse(props.containsKey("percent_completed"))
+        }
+    }
+
+    @Nested
+    inner class AdEvents {
+        private val ad =
+            AdContext(
+                adGroupIndex = 0,
+                adIndexInAdGroup = 1,
+                positionMillis = 10_000L,
+                durationMillis = 30_000L,
+                contentPositionMillis = 45_000L,
+                contentId = "video-789",
+            )
+        private val options = PlayerContent(extraProperties = mapOf("ad_campaign" to "summer"))
+
+        @Test
+        fun `trackAdStarted emits Ad Started with ad properties`() {
+            tracker.trackAdStarted(
+                options = options,
+                ad = ad,
+                viewSessionId = "view-ad-1",
+            )
+
+            assertEquals(1, events.size)
+            val event = events.first()
+            assertEquals("Ad Started", event.eventType)
+            val props = event.eventProperties!!
+            assertEquals("video-789:0:1", props["ad_id"])
+            assertEquals("video-789", props["content_id"])
+            assertEquals("view-ad-1", props["view_session_id"])
+            assertEquals(45.0, props["ad_position"])
+            assertEquals(30.0, props["ad_duration"])
+            assertEquals("summer", props["ad_campaign"])
+        }
+
+        @Test
+        fun `trackAdStopped records completion status and duration`() {
+            tracker.trackAdStopped(
+                options = options,
+                ad = ad,
+                viewSessionId = "view-ad-1",
+                watchDurationMillis = 30_000L,
+                completed = true,
+            )
+
+            val props = events.first().eventProperties!!
+            assertEquals("Ad Stopped", events.first().eventType)
+            assertEquals(30.0, props["ad_watch_duration"])
+            assertEquals("completed", props["ad_completion_status"])
+            assertEquals(33.333, (props["ad_percent_completed"] as Double), 0.01)
+        }
+
+        @Test
+        fun `trackAdStopped records abandoned status when not completed`() {
+            tracker.trackAdStopped(
+                options = options,
+                ad = ad,
+                viewSessionId = "view-ad-1",
+                watchDurationMillis = 5_000L,
+                completed = false,
+            )
+
+            val props = events.first().eventProperties!!
+            assertEquals("abandoned", props["ad_completion_status"])
+        }
+
+        @Test
+        fun `trackAdSkipped emits Ad Skipped`() {
+            tracker.trackAdSkipped(
+                options = options,
+                ad = ad,
+                viewSessionId = "view-ad-1",
+            )
+
+            assertEquals(1, events.size)
+            assertEquals("Ad Skipped", events.first().eventType)
+            assertEquals("video-789:0:1", events.first().eventProperties?.get("ad_id"))
+        }
+    }
+}

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/StreamTrackerTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/StreamTrackerTest.kt
@@ -9,8 +9,6 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -61,43 +59,52 @@ class StreamTrackerTest {
             )
 
         @Test
-        fun `trackStreamStarted sends Stream Started delayed event with properties`() {
+        fun `trackStreamStarted sends Stream Started with shared identity and position keys`() {
             tracker.trackStreamStarted(
                 options = options,
                 snapshot = snapshot,
                 mediaType = MediaType.VIDEO,
                 streamSessionId = "stream-1",
+                playId = "play-1",
+                startTimeMillis = 15_000L,
                 timestamp = 1_000L,
                 insertId = "insert-start-1",
             )
 
             assertEquals(1, events.size)
-            val event = events.first()
-            assertTrue(event is DelayedEvent)
+            val event = events.first() as DelayedEvent
             assertEquals("[Amplitude] Stream Started", event.eventType)
+            assertEquals(DelayedEvent.Kind.INSTANT, event.kind)
             assertEquals(1_000L, event.timestamp)
             assertEquals("insert-start-1", event.insertId)
 
             val props = event.eventProperties!!
             assertEquals("stream-1", props["stream_session_id"])
+            assertEquals("play-1", props["play_id"])
             assertEquals("video", props["media_type"])
             assertEquals("custom-id", props["content_id"])
             assertEquals("Custom Title", props["title"])
             assertEquals("on_demand", props["delivery_mode"])
-            assertEquals(15.0, props["start_position"])
+            assertEquals(15.0, props["start_time"])
+            assertEquals(15.0, props["position"])
             assertEquals(60.0, props["duration"])
             assertEquals(true, props["is_in_picture_in_picture"])
             assertEquals(false, props["is_in_background"])
             assertEquals("news", props["channel"])
+            assertFalse(props.containsKey("start_position"))
+            assertFalse(props.containsKey("stream_duration"))
+            assertFalse(props.containsKey("stop_reason"))
         }
 
         @Test
-        fun `trackStreamStopped sends Stream Stopped delayed event with properties`() {
+        fun `trackStreamStopped sends Stream Stopped with progress and reason`() {
             tracker.trackStreamStopped(
                 options = options,
                 snapshot = snapshot,
                 mediaType = MediaType.VIDEO,
                 streamSessionId = "stream-1",
+                playId = "play-1",
+                startTimeMillis = 10_000L,
                 streamDurationMillis = 5_000L,
                 timestamp = 6_000L,
                 insertId = "insert-stop-1",
@@ -105,19 +112,67 @@ class StreamTrackerTest {
             )
 
             assertEquals(1, events.size)
-            val event = events.first()
-            assertTrue(event is DelayedEvent)
+            val event = events.first() as DelayedEvent
             assertEquals("[Amplitude] Stream Stopped", event.eventType)
+            assertEquals(DelayedEvent.Kind.INSTANT, event.kind)
             assertEquals(6_000L, event.timestamp)
             assertEquals("insert-stop-1", event.insertId)
 
             val props = event.eventProperties!!
             assertEquals("stream-1", props["stream_session_id"])
+            assertEquals("play-1", props["play_id"])
             assertEquals("video", props["media_type"])
-            assertEquals(15.0, props["current_time"])
+            assertEquals(15.0, props["position"])
+            assertEquals(10.0, props["start_time"])
             assertEquals(5.0, props["stream_duration"])
             assertEquals("paused", props["stop_reason"])
             assertEquals(25.0, props["percent_completed"])
+            assertFalse(props.containsKey("current_time"))
+        }
+
+        @Test
+        fun `timeout is the only delayed stop`() {
+            tracker.trackStreamStopped(
+                options = options,
+                snapshot = snapshot,
+                mediaType = MediaType.VIDEO,
+                streamSessionId = "stream-1",
+                playId = "play-1",
+                startTimeMillis = 0L,
+                streamDurationMillis = 5_000L,
+                timestamp = 6_000L,
+                insertId = "timeout-stop",
+                stopReason = StopReason.TIMEOUT,
+            )
+            assertEquals(DelayedEvent.Kind.DELAYED, (events.last() as DelayedEvent).kind)
+            assertEquals("timeout", events.last().eventProperties?.get("stop_reason"))
+
+            val instantReasons =
+                listOf(
+                    StopReason.PAUSED,
+                    StopReason.COMPLETED,
+                    StopReason.SEEKING,
+                    StopReason.WAITING,
+                    StopReason.ERROR,
+                    StopReason.UNTRACKED,
+                )
+            for (reason in instantReasons) {
+                events.clear()
+                tracker.trackStreamStopped(
+                    options = options,
+                    snapshot = snapshot,
+                    mediaType = MediaType.VIDEO,
+                    streamSessionId = "stream-1",
+                    playId = "play-1",
+                    startTimeMillis = 0L,
+                    streamDurationMillis = 5_000L,
+                    timestamp = 6_000L,
+                    insertId = "stop-${reason.value}",
+                    stopReason = reason,
+                )
+                assertEquals(DelayedEvent.Kind.INSTANT, (events.last() as DelayedEvent).kind)
+                assertEquals(reason.value, events.last().eventProperties?.get("stop_reason"))
+            }
         }
 
         @Test
@@ -127,6 +182,8 @@ class StreamTrackerTest {
                 snapshot = snapshot,
                 mediaType = MediaType.AUDIO,
                 streamSessionId = "stream-audio",
+                playId = "play-audio",
+                startTimeMillis = 15_000L,
                 timestamp = 2_000L,
                 insertId = "audio-start",
             )
@@ -135,6 +192,8 @@ class StreamTrackerTest {
                 snapshot = snapshot,
                 mediaType = MediaType.AUDIO,
                 streamSessionId = "stream-audio",
+                playId = "play-audio",
+                startTimeMillis = 15_000L,
                 streamDurationMillis = 3_000L,
                 timestamp = 5_000L,
                 insertId = "audio-stop",
@@ -160,6 +219,8 @@ class StreamTrackerTest {
                 snapshot = liveSnapshot,
                 mediaType = MediaType.VIDEO,
                 streamSessionId = "stream-live",
+                playId = "play-live",
+                startTimeMillis = 15_000L,
                 streamDurationMillis = 10_000L,
                 timestamp = 10_000L,
                 insertId = "stop-live",
@@ -179,6 +240,8 @@ class StreamTrackerTest {
                 snapshot = unknownDurationSnapshot,
                 mediaType = MediaType.VIDEO,
                 streamSessionId = "stream-unknown",
+                playId = "play-unknown",
+                startTimeMillis = 15_000L,
                 streamDurationMillis = 5_000L,
                 timestamp = 5_000L,
                 insertId = "stop-unknown",
@@ -187,6 +250,27 @@ class StreamTrackerTest {
             val props = events.first().eventProperties!!
             assertFalse(props.containsKey("duration"))
             assertFalse(props.containsKey("percent_completed"))
+        }
+
+        @Test
+        fun `zero duration emits duration and zero percent_completed`() {
+            val zeroDurationSnapshot = snapshot.copy(durationMillis = 0L)
+            tracker.trackStreamStopped(
+                options = PlayerContent(),
+                snapshot = zeroDurationSnapshot,
+                mediaType = MediaType.VIDEO,
+                streamSessionId = "stream-zero",
+                playId = "play-zero",
+                startTimeMillis = 0L,
+                streamDurationMillis = 0L,
+                timestamp = 5_000L,
+                insertId = "stop-zero",
+                stopReason = StopReason.COMPLETED,
+            )
+
+            val props = events.first().eventProperties!!
+            assertEquals(0.0, props["duration"])
+            assertEquals(0.0, props["percent_completed"])
         }
     }
 


### PR DESCRIPTION
### Describe what this PR is addressing
[SDKA-89](https://linear.app/amplitude/issue/SDKA-89/video-content-startedstopped-events-and-properties): emit Video/Audio Content Started and Stopped (and ad events) with the shared property list.

Stacked on [#486](https://github.com/amplitude/Amplitude-Kotlin/pull/486).

### Describe the solution
Adds internal `StreamTracker` in `:streaming-analytics-android`:
* Video/audio started events go out as `DelayedEvent` with `Kind.INSTANT`; stopped events use `Kind.DELAYED`
* Properties match the cross-platform spec (`view_session_id`, `content_id`, `title`, `start_position`, `content_type`, `duration` when known, `percent_completed`, `current_time`, `stop_reason`, `watch_duration`, PiP/background, extras)
* Live / unknown duration omit `duration` and `percent_completed`
* Ad Started / Stopped / Skipped still use `amplitude.track` with ad properties

Player observation and delayed-event heartbeat stay on a follow-up.

### Steps to verify the change
1. `./gradlew :streaming-analytics-android:test --tests com.amplitude.android.streaming.internal.StreamTrackerTest`
2. `./gradlew ktlintCheck apiCheck`

### Useful links and documentation (optional)
* [SDKA-89](https://linear.app/amplitude/issue/SDKA-89/video-content-startedstopped-events-and-properties)
* [#486](https://github.com/amplitude/Amplitude-Kotlin/pull/486)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking `PlayerContent` API and new analytics event/property names affect integrators and downstream reporting; logic is largely isolated in internal `StreamTracker` with unit tests.
> 
> **Overview**
> Introduces internal **`StreamTracker`** to emit **`[Amplitude] Stream Started` / `Stream Stopped`** (via `DelayedEvent`) and **Ad Started / Stopped / Skipped** events, building a shared property map (`stream_session_id`, `play_id`, `media_type`, `delivery_mode`, timing in seconds, PiP/background, stop reason, progress when duration is known).
> 
> **Breaking change:** public **`PlayerContent`** drops **`contentType`** and the old `CONTENT_TYPE_*` constants in favor of **`deliveryMode`** with **`live`** / **`on_demand`** (inferred from the player snapshot when omitted). The Android sample and tests are updated accordingly.
> 
> Stream stop **`DelayedEvent`** timing is **`DELAYED` only for `timeout`**; other stop reasons stay instant. Live or unknown-duration content omits **`duration`** and **`percent_completed`** on events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e61e8273a1b8dd9610b0055ff97c8400d645e83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->