### PR TITLE
feat: Steaming - Storage

### DIFF
--- a/analytics-core/src/main/java/com/amplitude/core/utilities/JSONUtil.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/utilities/JSONUtil.kt
@@ -201,9 +201,11 @@ public fun JSONObject.toBaseEvent(): BaseEvent {
     event.revenue = if (this.has("revenue")) this.getDouble("revenue") else null
     event.productId = this.optionalString("productId", null)
     event.revenueType = this.optionalString("revenueType", null)
+    event.currency = this.optionalString("currency", null)
     event.locationLat = if (this.has("location_lat")) this.getDouble("location_lat") else null
     event.locationLng = if (this.has("location_lng")) this.getDouble("location_lng") else null
     event.ip = this.optionalString("ip", null)
+    event.versionName = this.optionalString("version_name", null)
     event.idfa = this.optionalString("idfa", null)
     event.idfv = this.optionalString("idfv", null)
     event.adid = this.optionalString("adid", null)

--- a/analytics-core/src/test/kotlin/com/amplitude/core/utilities/JSONUtilTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/utilities/JSONUtilTest.kt
@@ -1,0 +1,50 @@
+package com.amplitude.core.utilities
+
+import com.amplitude.core.events.BaseEvent
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class JSONUtilTest {
+    @Nested
+    inner class ToBaseEvent {
+        @Test
+        fun `restores version_name and currency from ingest json`() {
+            val json =
+                JSONObject()
+                    .put("event_type", "revenue")
+                    .put("version_name", "2.0.0-prod")
+                    .put("currency", "USD")
+
+            val event = json.toBaseEvent()
+
+            assertEquals("2.0.0-prod", event.versionName)
+            assertEquals("USD", event.currency)
+        }
+
+        @Test
+        fun `leaves version_name and currency null when absent`() {
+            val event = JSONObject().put("event_type", "click").toBaseEvent()
+
+            assertNull(event.versionName)
+            assertNull(event.currency)
+        }
+
+        @Test
+        fun `round trips versionName and currency through eventToString`() {
+            val original =
+                BaseEvent().apply {
+                    eventType = "revenue"
+                    versionName = "2.0.0-prod"
+                    currency = "USD"
+                }
+
+            val restored = JSONObject(JSONUtil.eventToString(original)).toBaseEvent()
+
+            assertEquals("2.0.0-prod", restored.versionName)
+            assertEquals("USD", restored.currency)
+        }
+    }
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/storage/DelayedEventEntity.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/storage/DelayedEventEntity.kt
@@ -1,0 +1,39 @@
+package com.amplitude.android.streaming.internal.storage
+
+import com.amplitude.android.streaming.internal.DelayedEvent
+import com.amplitude.core.utilities.JSONUtil
+import com.amplitude.core.utilities.toBaseEvent
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import org.json.JSONObject
+
+@Serializable(with = DelayedEventEntitySerializer::class)
+internal data class DelayedEventEntity(
+    val ingestJson: JsonObject,
+)
+
+internal fun DelayedEvent.toEntity(): DelayedEventEntity =
+    DelayedEventEntity(Json.parseToJsonElement(JSONUtil.eventToString(this)).jsonObject)
+
+internal fun DelayedEventEntity.toDelayedEvent(kind: DelayedEvent.Kind): DelayedEvent =
+    DelayedEvent(JSONObject(ingestJson.toString()).toBaseEvent(), kind)
+
+private object DelayedEventEntitySerializer : KSerializer<DelayedEventEntity> {
+    override val descriptor: SerialDescriptor = JsonObject.serializer().descriptor
+
+    override fun serialize(
+        encoder: Encoder,
+        value: DelayedEventEntity,
+    ) {
+        encoder.encodeSerializableValue(JsonObject.serializer(), value.ingestJson)
+    }
+
+    override fun deserialize(decoder: Decoder): DelayedEventEntity =
+        DelayedEventEntity(decoder.decodeSerializableValue(JsonObject.serializer()))
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/storage/DelayedEventStorage.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/storage/DelayedEventStorage.kt
@@ -1,0 +1,126 @@
+package com.amplitude.android.streaming.internal.storage
+
+import android.content.Context
+import com.amplitude.android.Configuration
+import com.amplitude.android.streaming.internal.StreamingDiGraph
+import com.amplitude.android.streaming.internal.util.DiGraph.Companion.weak
+import com.amplitude.android.streaming.internal.util.lazySuspend
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.UUID
+
+private const val STORAGE_DIR_NAME = "amplitude"
+private const val DELAYED_EVENTS_PATH = "analytics/streaming-delayed-events"
+
+internal val StreamingDiGraph.delayedEventStorage: DelayedEventStorage by weak {
+    DelayedEventStorage(
+        context = context,
+        configuration = configuration,
+        ioDispatcher = ioDispatcher,
+    )
+}
+
+/**
+ * Persists delayed-events request payloads as JSON files until they can be uploaded.
+ */
+internal class DelayedEventStorage(
+    private val context: Context,
+    private val configuration: Configuration,
+    private val ioDispatcher: CoroutineDispatcher,
+) {
+    private val directory =
+        lazySuspend {
+            withContext(ioDispatcher) {
+                File(
+                    context.getDir(STORAGE_DIR_NAME, Context.MODE_PRIVATE),
+                    "${context.packageName}/${configuration.instanceName}/$DELAYED_EVENTS_PATH",
+                )
+            }
+        }
+
+    suspend fun write(
+        key: String,
+        request: DelayedEventsRequestEntity,
+    ) {
+        withContext(ioDispatcher) {
+            val directory = directory()
+            check(directory.exists() || directory.mkdirs()) {
+                "Failed to create delayed-events queue directory"
+            }
+            val destination = File(directory, "$key.json")
+            val temporary = File(directory, "$key-${UUID.randomUUID()}.tmp")
+            try {
+                FileOutputStream(temporary).use { output ->
+                    val byteArray =
+                        delayedEventsStorageJson.encodeToString(request).toByteArray(Charsets.UTF_8)
+                    output.write(byteArray)
+                    output.fd.sync()
+                }
+                if (!temporary.renameTo(destination)) {
+                    throw IOException("Failed to commit delayed-events queue entry")
+                }
+            } finally {
+                temporary.delete()
+            }
+        }
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    suspend fun read(key: String): DelayedEventsRequestEntity =
+        withContext(ioDispatcher) {
+            File(directory(), "$key.json").inputStream().use { stream ->
+                delayedEventsStorageJson.decodeFromStream<DelayedEventsRequestEntity>(stream)
+            }
+        }
+
+    suspend fun findKey(idKey: String): String? =
+        withContext(ioDispatcher) {
+            val matches =
+                jsonFiles().filter { file ->
+                    file.name.endsWith("-$idKey.json")
+                }
+            val oldest = matches.minByOrNull { it.name } ?: return@withContext null
+            for (extra in matches) {
+                if (extra == oldest) continue
+                if (!extra.delete()) {
+                    throw IOException("Failed to remove duplicate delayed-events queue entry ${extra.name}")
+                }
+            }
+            oldest.nameWithoutExtension
+        }
+
+    suspend fun keys(): List<String> =
+        withContext(ioDispatcher) {
+            jsonFiles().map { it.nameWithoutExtension }
+        }
+
+    suspend fun delete(key: String) {
+        withContext(ioDispatcher) {
+            val file = File(directory(), "$key.json")
+            if (file.exists() && !file.delete()) {
+                throw IOException("Failed to remove delayed-events queue entry ${file.name}")
+            }
+        }
+    }
+
+    private suspend fun jsonFiles(): List<File> =
+        directory()
+            .listFiles { candidate ->
+                candidate.extension == "json"
+            }
+            .orEmpty()
+            .toList()
+}
+
+internal val delayedEventsStorageJson =
+    Json {
+        encodeDefaults = false
+        explicitNulls = false
+        ignoreUnknownKeys = true
+    }

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/storage/DelayedEventsRequestEntity.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/storage/DelayedEventsRequestEntity.kt
@@ -1,0 +1,35 @@
+package com.amplitude.android.streaming.internal.storage
+
+import com.amplitude.android.streaming.internal.DelayedEvent
+import com.amplitude.android.streaming.internal.network.DelayedEventsRequestDto
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+@Serializable
+internal data class DelayedEventsRequestEntity(
+    val id: String,
+    val timeoutMillis: Long,
+    val events: List<DelayedEventEntity>,
+    val instantEvents: List<DelayedEventEntity>? = null,
+    /**
+     * Filename of this entry in the delayed-events queue (`{sequence}-{sha256(id)}`).
+     * Not serialized: identity is the file name, not a field in the payload.
+     */
+    @Transient val queueKey: String? = null,
+)
+
+internal fun DelayedEventsRequestEntity.toDto(): DelayedEventsRequestDto =
+    DelayedEventsRequestDto(
+        id = id,
+        timeoutMillis = timeoutMillis,
+        events = events.map { it.toDelayedEvent(DelayedEvent.Kind.DELAYED) },
+        instantEvents = instantEvents?.map { it.toDelayedEvent(DelayedEvent.Kind.INSTANT) },
+    )
+
+internal fun DelayedEventsRequestDto.toRequest(): DelayedEventsRequestEntity =
+    DelayedEventsRequestEntity(
+        id = id,
+        timeoutMillis = timeoutMillis,
+        events = events.map { it.toEntity() },
+        instantEvents = instantEvents?.map { it.toEntity() },
+    )

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/util/LazySuspend.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/util/LazySuspend.kt
@@ -1,0 +1,66 @@
+package com.amplitude.android.streaming.internal.util
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Returns a [LazySuspend] that runs [initializer] the first time it is invoked.
+ *
+ * ```kotlin
+ * private val token = lazySuspend { fetchToken() }
+ *
+ * suspend fun useToken() {
+ *     val value = token()
+ * }
+ * ```
+ */
+internal fun <T> lazySuspend(initializer: suspend () -> T): LazySuspend<T> =
+    LazySuspendImpl(initializer)
+
+/**
+ * A value computed once by a suspending initializer, then reused.
+ *
+ * The first [invoke] runs the initializer and later calls return that result, including `null`.
+ * Concurrent callers wait on the same in-flight run. A thrown exception is not stored, so the
+ * next [invoke] runs the initializer again. The initializer uses the first caller's coroutine
+ * context.
+ */
+internal interface LazySuspend<T> {
+    /**
+     * Returns the cached value, running the initializer if this instance has none yet.
+     */
+    suspend operator fun invoke(): T
+}
+
+/**
+ * Suspend analog of [lazy]: the first [invoke] runs [initialize] and later calls reuse that
+ * result.
+ */
+private class LazySuspendImpl<T>(
+    private val initialize: suspend () -> T,
+) : LazySuspend<T> {
+    private val mutex = Mutex()
+
+    @Volatile
+    private var value: Any? = UNINITIALIZED
+    override suspend operator fun invoke(): T {
+        val current = value
+        if (current !== UNINITIALIZED) {
+            @Suppress("UNCHECKED_CAST")
+            return current as T
+        }
+        return mutex.withLock {
+            val locked = value
+            if (locked !== UNINITIALIZED) {
+                @Suppress("UNCHECKED_CAST")
+                locked as T
+            } else {
+                initialize().also { value = it }
+            }
+        }
+    }
+
+    private companion object {
+        val UNINITIALIZED = Any()
+    }
+}

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/DelayedEventsRequestSerializationTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/DelayedEventsRequestSerializationTest.kt
@@ -1,0 +1,122 @@
+package com.amplitude.android.streaming.internal
+
+import com.amplitude.android.streaming.internal.storage.DelayedEventsRequestEntity
+import com.amplitude.android.streaming.internal.storage.delayedEventsStorageJson
+import com.amplitude.android.streaming.internal.storage.toDelayedEvent
+import com.amplitude.android.streaming.internal.storage.toEntity
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class DelayedEventsRequestSerializationTest {
+    @Nested
+    inner class RoundTrip {
+        @Test
+        fun `should persist enriched BaseEvent fields as ingest json`() {
+            val delayed =
+                DelayedEvent(
+                    eventType = "video_stopped",
+                    kind = DelayedEvent.Kind.DELAYED,
+                    timestamp = 1_700_000_000_000L,
+                    deviceId = "device-1",
+                    userId = "user-1",
+                    sessionId = 42L,
+                    eventProperties =
+                        mutableMapOf(
+                            "video_id" to "v-100",
+                            "nested" to mapOf("quality" to "1080p"),
+                        ),
+                ).also { event ->
+                    event.insertId = "insert-1"
+                    event.library = "amplitude-android/1.0"
+                    event.osName = "android"
+                    event.osVersion = "14"
+                    event.deviceModel = "Pixel 8"
+                    event.platform = "Android"
+                    event.appVersion = "2.0.0"
+                    event.country = "US"
+                    event.language = "en"
+                    event.ip = "\$remote"
+                    event.userProperties = mutableMapOf("plan" to "pro")
+                }
+            val instant =
+                DelayedEvent(
+                    eventType = "video_started",
+                    kind = DelayedEvent.Kind.INSTANT,
+                    timestamp = 1_700_000_000_000L,
+                    eventProperties = mutableMapOf("video_id" to "v-100"),
+                )
+            val request =
+                DelayedEventsRequestEntity(
+                    id = "view-1",
+                    timeoutMillis = 5_000L,
+                    events = listOf(delayed.toEntity()),
+                    instantEvents = listOf(instant.toEntity()),
+                )
+
+            val decoded =
+                delayedEventsStorageJson.decodeFromString<DelayedEventsRequestEntity>(
+                    delayedEventsStorageJson.encodeToString(request),
+                )
+            val restored = decoded.events.single().toDelayedEvent(DelayedEvent.Kind.DELAYED)
+
+            assertEquals("view-1", decoded.id)
+            assertEquals("video_stopped", restored.eventType)
+            assertEquals("user-1", restored.userId)
+            assertEquals("device-1", restored.deviceId)
+            assertEquals(42L, restored.sessionId)
+            assertEquals("insert-1", restored.insertId)
+            assertEquals("amplitude-android/1.0", restored.library)
+            assertEquals("android", restored.osName)
+            assertEquals("14", restored.osVersion)
+            assertEquals("Pixel 8", restored.deviceModel)
+            assertEquals("Android", restored.platform)
+            assertEquals("2.0.0", restored.appVersion)
+            assertEquals("US", restored.country)
+            assertEquals("en", restored.language)
+            assertEquals("\$remote", restored.ip)
+            assertEquals("v-100", restored.eventProperties?.get("video_id"))
+            assertEquals("pro", restored.userProperties?.get("plan"))
+            assertEquals(
+                DelayedEvent.Kind.INSTANT,
+                decoded.instantEvents?.single()?.toDelayedEvent(DelayedEvent.Kind.INSTANT)?.kind,
+            )
+        }
+
+        @Test
+        fun `should store events as amplitude ingest json objects`() {
+            val request =
+                DelayedEventsRequestEntity(
+                    id = "view-2",
+                    timeoutMillis = 1_000L,
+                    events =
+                        listOf(
+                            DelayedEvent(
+                                eventType = "audio_stopped",
+                                kind = DelayedEvent.Kind.DELAYED,
+                                timestamp = 1L,
+                                eventProperties = mutableMapOf(),
+                            ).toEntity(),
+                        ),
+                    queueKey = "queue-key",
+                )
+
+            val json = delayedEventsStorageJson.encodeToString(request)
+            val body = JSONObject(json)
+            val event = body.getJSONArray("events").getJSONObject(0)
+
+            assertEquals("view-2", body.getString("id"))
+            assertEquals(1_000L, body.getLong("timeoutMillis"))
+            assertEquals("audio_stopped", event.getString("event_type"))
+            assertEquals(1L, event.getLong("time"))
+            assertFalse(event.has("eventType"))
+            assertFalse(body.has("queueKey"))
+            assertFalse(body.has("key"))
+            assertNull(delayedEventsStorageJson.decodeFromString<DelayedEventsRequestEntity>(json).instantEvents)
+            assertNull(delayedEventsStorageJson.decodeFromString<DelayedEventsRequestEntity>(json).queueKey)
+        }
+    }
+}

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/DelayedEventsRequestSerializationTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/DelayedEventsRequestSerializationTest.kt
@@ -37,6 +37,8 @@ class DelayedEventsRequestSerializationTest {
                     event.deviceModel = "Pixel 8"
                     event.platform = "Android"
                     event.appVersion = "2.0.0"
+                    event.versionName = "2.0.0-prod"
+                    event.currency = "USD"
                     event.country = "US"
                     event.language = "en"
                     event.ip = "\$remote"
@@ -75,6 +77,8 @@ class DelayedEventsRequestSerializationTest {
             assertEquals("Pixel 8", restored.deviceModel)
             assertEquals("Android", restored.platform)
             assertEquals("2.0.0", restored.appVersion)
+            assertEquals("2.0.0-prod", restored.versionName)
+            assertEquals("USD", restored.currency)
             assertEquals("US", restored.country)
             assertEquals("en", restored.language)
             assertEquals("\$remote", restored.ip)

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/storage/DelayedEventStorageTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/storage/DelayedEventStorageTest.kt
@@ -1,0 +1,243 @@
+package com.amplitude.android.streaming.internal.storage
+
+import android.content.Context
+import com.amplitude.android.Configuration
+import com.amplitude.android.streaming.internal.DelayedEvent
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.File
+import java.io.FileNotFoundException
+import java.util.UUID
+import kotlin.io.path.createTempDirectory
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DelayedEventStorageTest {
+    private lateinit var amplitudeDir: File
+    private lateinit var context: Context
+
+    @BeforeEach
+    fun setup() {
+        amplitudeDir = createTempDirectory("amplitude").toFile()
+        context =
+            mockk {
+                every { getDir("amplitude", Context.MODE_PRIVATE) } returns amplitudeDir
+                every { packageName } returns "com.example.app"
+            }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        amplitudeDir.deleteRecursively()
+    }
+
+    @Nested
+    inner class WriteAndRead {
+        @Test
+        fun `should create the queue directory and round trip a request`() =
+            runTest {
+                val instanceName = uniqueInstance()
+                val storage = storage(instanceName)
+                val request = request("view-1")
+
+                storage.write("0000000000000000001-abc", request)
+
+                assertTrue(queueDir(instanceName).isDirectory)
+                assertEquals(request, storage.read("0000000000000000001-abc"))
+            }
+
+        @Test
+        fun `should replace an existing file for the same key`() =
+            runTest {
+                val storage = storage()
+                storage.write("key-1", request("view-1", timeoutMillis = 1_000L))
+                storage.write("key-1", request("view-1", timeoutMillis = 9_000L))
+
+                assertEquals(9_000L, storage.read("key-1").timeoutMillis)
+                assertEquals(listOf("key-1"), storage.keys())
+            }
+
+        @Test
+        fun `should ignore leftover tmp files after a successful write`() =
+            runTest {
+                val instanceName = uniqueInstance()
+                val storage = storage(instanceName)
+                storage.write("key-1", request())
+
+                File(queueDir(instanceName), "key-1-leftover.tmp").writeText("{not-json")
+
+                assertEquals(listOf("key-1"), storage.keys())
+                assertEquals(request(), storage.read("key-1"))
+            }
+
+        @Test
+        fun `should ignore unknown json keys when reading`() =
+            runTest {
+                val instanceName = uniqueInstance()
+                val storage = storage(instanceName)
+                val stored = request("view-1")
+                storage.write("key-1", stored)
+
+                val file = File(queueDir(instanceName), "key-1.json")
+                val parsed = delayedEventsStorageJson.parseToJsonElement(file.readText()).jsonObject
+                file.writeText(
+                    JsonObject(
+                        parsed.toMutableMap().apply {
+                            put("schemaVersion", JsonPrimitive(2))
+                        },
+                    ).toString(),
+                )
+
+                assertEquals(stored, storage.read("key-1"))
+            }
+
+        @Test
+        fun `should throw when the file is missing`() =
+            runTest {
+                val storage = storage()
+                assertThrows<FileNotFoundException> { storage.read("missing") }
+            }
+    }
+
+    @Nested
+    inner class Keys {
+        @Test
+        fun `should return no keys when the directory is empty`() =
+            runTest {
+                val storage = storage()
+                assertEquals(emptyList<String>(), storage.keys())
+            }
+
+        @Test
+        fun `should return every stored key`() =
+            runTest {
+                val storage = storage()
+                storage.write("0000000000000000002-bbb", request("view-2"))
+                storage.write("0000000000000000001-aaa", request("view-1"))
+                storage.write("0000000000000000003-ccc", request("view-3"))
+
+                assertEquals(
+                    listOf(
+                        "0000000000000000001-aaa",
+                        "0000000000000000002-bbb",
+                        "0000000000000000003-ccc",
+                    ),
+                    storage.keys().sorted(),
+                )
+            }
+
+        @Test
+        fun `should isolate files by instance name`() =
+            runTest {
+                val first = uniqueInstance()
+                val second = uniqueInstance()
+                storage(first).write("key-1", request("view-1"))
+                storage(second).write("key-2", request("view-2"))
+
+                assertEquals(listOf("key-1"), storage(first).keys())
+                assertEquals(listOf("key-2"), storage(second).keys())
+            }
+    }
+
+    @Nested
+    inner class FindKey {
+        @Test
+        fun `should return null when no filename matches the hashed id`() =
+            runTest {
+                val storage = storage()
+                storage.write("0000000000000000001-aaa", request())
+                assertNull(storage.findKey("bbb"))
+            }
+
+        @Test
+        fun `should keep the oldest duplicate and delete the rest`() =
+            runTest {
+                val storage = storage()
+                storage.write("0000000000000000001-deadbeef", request("view-1", timeoutMillis = 1_000L))
+                storage.write("0000000000000000003-deadbeef", request("view-1", timeoutMillis = 3_000L))
+                storage.write("0000000000000000002-deadbeef", request("view-1", timeoutMillis = 2_000L))
+                storage.write("0000000000000000004-other", request("view-2"))
+
+                assertEquals("0000000000000000001-deadbeef", storage.findKey("deadbeef"))
+                assertEquals(
+                    setOf("0000000000000000001-deadbeef", "0000000000000000004-other"),
+                    storage.keys().toSet(),
+                )
+                assertEquals(1_000L, storage.read("0000000000000000001-deadbeef").timeoutMillis)
+            }
+    }
+
+    @Nested
+    inner class Delete {
+        @Test
+        fun `should remove a stored request`() =
+            runTest {
+                val storage = storage()
+                storage.write("key-1", request())
+                storage.delete("key-1")
+
+                assertEquals(emptyList<String>(), storage.keys())
+                assertThrows<FileNotFoundException> { storage.read("key-1") }
+            }
+
+        @Test
+        fun `should no-op when the key does not exist`() =
+            runTest {
+                val storage = storage()
+                storage.delete("missing")
+                assertEquals(emptyList<String>(), storage.keys())
+            }
+    }
+
+    private fun TestScope.storage(instanceName: String = uniqueInstance()): DelayedEventStorage =
+        DelayedEventStorage(
+            context = context,
+            configuration =
+                Configuration(
+                    apiKey = "test-api-key",
+                    context = context,
+                    instanceName = instanceName,
+                ),
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+    private fun uniqueInstance(): String = UUID.randomUUID().toString()
+
+    private fun queueDir(instanceName: String): File =
+        File(
+            amplitudeDir,
+            "com.example.app/$instanceName/analytics/streaming-delayed-events",
+        )
+
+    private fun request(
+        id: String = "view-1",
+        timeoutMillis: Long = 5_000L,
+    ): DelayedEventsRequestEntity =
+        DelayedEventsRequestEntity(
+            id = id,
+            timeoutMillis = timeoutMillis,
+            events =
+                listOf(
+                    DelayedEvent(
+                        eventType = "video_stopped",
+                        kind = DelayedEvent.Kind.DELAYED,
+                        timestamp = 1L,
+                        eventProperties = mutableMapOf("video_id" to "v-100"),
+                    ).toEntity(),
+                ),
+        )
+}


### PR DESCRIPTION
### Describe what this PR is addressing
[SDKA-111](https://linear.app/amplitude/issue/SDKA-111/delayed-events-local-persistence): persist delayed-event HTTP payloads on disk so they survive process death until upload.

Stacked on [#488](https://github.com/amplitude/Amplitude-Kotlin/pull/488).

### Describe the solution
Adds file-backed delayed-events storage in `:streaming-analytics-android` (`com.amplitude.android.streaming.internal.storage`):
* One JSON file per request under the Amplitude private directory, keyed per package/instance
* Atomic write (temp file + `fsync` + rename)
* Peek oldest / find by id / list / delete
* Disk DTOs (`DelayedEventEntity`, `DelayedEventsRequestEntity`) stay separate from the HTTP DTO (no `api_key` on disk)

Pipeline drain/upload stays on a follow-up.

### Steps to verify the change
1. `./gradlew :streaming-analytics-android:test --tests com.amplitude.android.streaming.internal.storage.DelayedEventStorageTest`
2. `./gradlew :streaming-analytics-android:test --tests com.amplitude.android.streaming.internal.DelayedEventsRequestSerializationTest`
3. `./gradlew ktlintCheck apiCheck`

### Useful links and documentation (optional)
* [SDKA-111](https://linear.app/amplitude/issue/SDKA-111/delayed-events-local-persistence)
* [#488](https://github.com/amplitude/Amplitude-Kotlin/pull/488)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New on-device queue logic can drop oldest delayed events under disk pressure; event field parsing changes in shared JSONUtil affect any ingest JSON round-trip paths.
> 
> **Overview**
> Adds **file-backed persistence** for streaming delayed-event HTTP payloads so they survive process death until a later upload PR wires the drain path.
> 
> **`DelayedEventStorage`** writes one JSON file per queued request under the Amplitude private app dir (scoped by package + instance), using temp file + `fsync` + rename, with list/read/delete and **`findKey`** by hashed id suffix (deduping duplicate filenames). A **25 MB cap** on the queue directory drops oldest entries (or rejects oversized single payloads) so a stuck uploader cannot exhaust disk; **`StreamingDiGraph`** exposes `maxStorageBytes` for tests/overrides.
> 
> Disk models (**`DelayedEventsRequestEntity`**, **`DelayedEventEntity`**) serialize events as Amplitude **ingest JSON** (not HTTP DTOs—no `api_key` on disk), with mappers to/from network DTOs. **`lazySuspend`** supports one-time async directory initialization.
> 
> In **`analytics-core`**, **`JSONObject.toBaseEvent()`** now restores **`currency`** and **`version_name`** so round-trips through persisted ingest JSON match **`JSONUtil.eventToString`**, with new unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b368eb6e3f470b1571df76f93be04f4e4dbba595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->