### PR TITLE
feat: Streaming - Player Observer

### DIFF
--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamTracker.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/StreamTracker.kt
@@ -2,6 +2,8 @@ package com.amplitude.android.streaming.internal
 
 import androidx.media3.common.C
 import com.amplitude.android.streaming.PlayerContent
+import com.amplitude.android.streaming.internal.player.PlayerMediaSnapshot
+import com.amplitude.android.streaming.internal.player.PlayerState
 import com.amplitude.android.streaming.internal.util.DiGraph.Companion.weak
 import com.amplitude.android.streaming.internal.util.millisToSeconds
 import com.amplitude.core.Amplitude
@@ -78,6 +80,7 @@ internal class StreamTracker(
     fun trackStreamStarted(
         options: PlayerContent,
         snapshot: PlayerMediaSnapshot,
+        playerState: PlayerState,
         mediaType: MediaType,
         streamSessionId: String,
         timestamp: Long,
@@ -93,6 +96,7 @@ internal class StreamTracker(
                         contentProperties(
                             options = options,
                             snapshot = snapshot,
+                            playerState = playerState,
                             mediaType = mediaType,
                             streamSessionId = streamSessionId,
                         ).apply {
@@ -105,6 +109,7 @@ internal class StreamTracker(
     fun trackStreamStopped(
         options: PlayerContent,
         snapshot: PlayerMediaSnapshot,
+        playerState: PlayerState,
         mediaType: MediaType,
         streamSessionId: String,
         streamDurationMillis: Long,
@@ -123,6 +128,7 @@ internal class StreamTracker(
                         stoppedContentProperties(
                             options = options,
                             snapshot = snapshot,
+                            playerState = playerState,
                             mediaType = mediaType,
                             streamSessionId = streamSessionId,
                             streamDurationMillis = streamDurationMillis,
@@ -154,6 +160,7 @@ private fun adProperties(
 private fun contentProperties(
     options: PlayerContent,
     snapshot: PlayerMediaSnapshot,
+    playerState: PlayerState,
     mediaType: MediaType,
     streamSessionId: String,
 ): MutableMap<String, Any?> =
@@ -163,8 +170,8 @@ private fun contentProperties(
         (options.contentId ?: snapshot.mediaId)?.let { put("content_id", it) }
         (options.title ?: snapshot.title)?.let { put("title", it) }
         put("delivery_mode", deliveryMode(options = options, snapshot = snapshot))
-        put("is_in_picture_in_picture", snapshot.isInPictureInPicture)
-        put("is_in_background", snapshot.isInBackground)
+        put("is_in_picture_in_picture", playerState.isInPictureInPicture)
+        put("is_in_background", playerState.isInBackground)
         if (snapshot.hasKnownDuration()) {
             put("duration", snapshot.durationMillis.millisToSeconds())
         }
@@ -174,6 +181,7 @@ private fun contentProperties(
 private fun stoppedContentProperties(
     options: PlayerContent,
     snapshot: PlayerMediaSnapshot,
+    playerState: PlayerState,
     mediaType: MediaType,
     streamSessionId: String,
     streamDurationMillis: Long,
@@ -183,6 +191,7 @@ private fun stoppedContentProperties(
     contentProperties(
         options = options,
         snapshot = snapshot,
+        playerState = playerState,
         mediaType = mediaType,
         streamSessionId = streamSessionId,
     ).apply {
@@ -243,16 +252,6 @@ internal fun AdContext.percentCompleted(): Double? {
     return (100.0 * positionMillis.toDouble() / durationMillis)
         .coerceIn(0.0, 100.0)
 }
-
-internal data class PlayerMediaSnapshot(
-    val positionMillis: Long,
-    val durationMillis: Long = C.TIME_UNSET,
-    val isLive: Boolean = false,
-    val mediaId: String? = null,
-    val title: String? = null,
-    val isInPictureInPicture: Boolean = false,
-    val isInBackground: Boolean = false,
-)
 
 internal enum class MediaType(
     val value: String,

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/Media3PlayerObserver.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/Media3PlayerObserver.kt
@@ -1,0 +1,281 @@
+package com.amplitude.android.streaming.internal.player
+
+import android.os.Handler
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.Tracks
+import com.amplitude.android.streaming.internal.AdContext
+import com.amplitude.android.streaming.internal.MediaType
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.android.asCoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration.Companion.milliseconds
+
+private const val BUFFERING_DEBOUNCE_MILLIS = 500L
+private const val EVENT_BUFFER_CAPACITY = 64
+
+internal class Media3PlayerObserver(
+    private val player: Player,
+    private val scope: CoroutineScope,
+    private val playerDispatcher: CoroutineDispatcher = player.createPlayerDispatcher(),
+) : Player.Listener,
+    PlayerObserver {
+    private val _eventFlow =
+        MutableSharedFlow<PlayerEvent>(extraBufferCapacity = EVENT_BUFFER_CAPACITY)
+    override val eventFlow: SharedFlow<PlayerEvent> = _eventFlow.asSharedFlow()
+    private val mutex = Mutex()
+    private var bufferingJob: Job? = null
+    private var observing = false
+    private var activeAd: AdContext? = null
+
+    init {
+        scope.launch {
+            try {
+                _eventFlow.subscriptionCount
+                    .map { it > 0 }
+                    .distinctUntilChanged()
+                    .collect { subscribed ->
+                        if (subscribed) attach() else detach()
+                    }
+            } finally {
+                withContext(NonCancellable) {
+                    detach()
+                }
+            }
+        }
+    }
+
+    override suspend fun snapshot(): PlayerMediaSnapshot =
+        withContext(playerDispatcher) {
+            val item = player.currentMediaItem
+            val metadata = item?.mediaMetadata
+            PlayerMediaSnapshot(
+                positionMillis = player.currentPosition.coerceAtLeast(0L),
+                durationMillis = player.duration,
+                isLive = player.isCurrentMediaItemLive,
+                mediaId = item?.mediaId?.takeIf { it.isNotEmpty() },
+                title = metadata?.title?.toString() ?: metadata?.displayTitle?.toString(),
+                mediaType = player.mediaType(),
+            )
+        }
+
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        if (isPlaying) {
+            emit(PlayerEvent.Playing)
+        } else if (player.playWhenReady && player.playbackState == Player.STATE_READY) {
+            // Suppression (audio focus, unsuitable output, scrubbing): still READY and
+            // intending to play, but isPlaying flipped false with no pause callback.
+            emit(PlayerEvent.Buffering)
+        }
+    }
+
+    override fun onPlayWhenReadyChanged(
+        playWhenReady: Boolean,
+        reason: Int,
+    ) {
+        if (!playWhenReady && player.playbackState != Player.STATE_ENDED) {
+            cancelBuffering()
+            emit(PlayerEvent.Paused)
+        }
+    }
+
+    override fun onPlaybackStateChanged(playbackState: Int) {
+        when (playbackState) {
+            Player.STATE_BUFFERING -> startBufferingDebounce()
+            Player.STATE_READY -> {
+                cancelBuffering()
+                emit(PlayerEvent.Ready)
+            }
+            Player.STATE_ENDED -> {
+                cancelBuffering()
+                if (activeAd != null) {
+                    finishAdForTransition(
+                        completed = true,
+                        positionMillis = player.currentPosition.coerceAtLeast(0),
+                    )
+                }
+                emit(PlayerEvent.Ended)
+            }
+            Player.STATE_IDLE -> {
+                cancelBuffering()
+                // Player.stop() / reset go idle without changing playWhenReady, so pause never fires.
+                if (player.playWhenReady) {
+                    emit(PlayerEvent.Paused)
+                }
+            }
+        }
+    }
+
+    override fun onPlayerError(error: PlaybackException) {
+        cancelBuffering()
+        emit(PlayerEvent.Error(error.message))
+    }
+
+    override fun onPositionDiscontinuity(
+        oldPosition: Player.PositionInfo,
+        newPosition: Player.PositionInfo,
+        reason: Int,
+    ) {
+        if (reason == Player.DISCONTINUITY_REASON_SEEK) {
+            emit(PlayerEvent.Seeking)
+        }
+        if (oldPosition.adGroupIndex != C.INDEX_UNSET &&
+            (
+                newPosition.adGroupIndex == C.INDEX_UNSET ||
+                    oldPosition.adGroupIndex != newPosition.adGroupIndex ||
+                    oldPosition.adIndexInAdGroup != newPosition.adIndexInAdGroup ||
+                    oldPosition.mediaItemIndex != newPosition.mediaItemIndex
+            )
+        ) {
+            finishAdForTransition(
+                completed = reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION,
+                positionMillis = oldPosition.positionMs,
+            )
+        }
+    }
+
+    override fun onMediaItemTransition(
+        mediaItem: MediaItem?,
+        reason: Int,
+    ) {
+        emit(PlayerEvent.MediaChanged(mediaItem))
+    }
+
+    override fun onEvents(
+        player: Player,
+        events: Player.Events,
+    ) {
+        detectAdTransition()
+    }
+
+    internal fun detectAdTransition() {
+        if (player.playbackState == Player.STATE_ENDED) {
+            if (activeAd != null) {
+                finishAdForTransition(
+                    completed = true,
+                    positionMillis = player.currentPosition.coerceAtLeast(0),
+                )
+            }
+            return
+        }
+        if (player.isPlayingAd) {
+            val current = adContextFromPlayer()
+            val previous = activeAd
+            if (previous != null && !previous.isSameAdAs(current)) {
+                finishAdForTransition(completed = false)
+            }
+            if (activeAd == null) {
+                activeAd = current
+                emit(PlayerEvent.AdStarted(current))
+            }
+        } else if (activeAd != null) {
+            finishAdForTransition(completed = false)
+        }
+    }
+
+    internal fun finishAdForTransition(
+        completed: Boolean,
+        positionMillis: Long? = null,
+    ) {
+        val ad = activeAd ?: return
+        activeAd = null
+        val finalAd = positionMillis?.let { ad.copy(positionMillis = it) } ?: ad
+        if (completed) {
+            emit(PlayerEvent.AdStopped(finalAd, completed = true))
+        } else {
+            emit(PlayerEvent.AdSkipped(finalAd))
+        }
+    }
+
+    private suspend fun attach() {
+        withContext(playerDispatcher) {
+            mutex.withLock {
+                if (observing) return@withLock
+                observing = true
+                player.addListener(this@Media3PlayerObserver)
+                if (player.isPlaying) {
+                    emit(PlayerEvent.Playing)
+                }
+                onPlaybackStateChanged(player.playbackState)
+                detectAdTransition()
+            }
+        }
+    }
+
+    private suspend fun detach() {
+        withContext(playerDispatcher) {
+            mutex.withLock {
+                if (observing) {
+                    observing = false
+                    player.removeListener(this@Media3PlayerObserver)
+                }
+                activeAd = null
+                cancelBuffering()
+            }
+        }
+    }
+
+    private fun emit(event: PlayerEvent) {
+        _eventFlow.tryEmit(event)
+    }
+
+    private fun startBufferingDebounce() {
+        if (!player.playWhenReady || bufferingJob?.isActive == true) return
+        bufferingJob =
+            scope.launch {
+                delay(BUFFERING_DEBOUNCE_MILLIS.milliseconds)
+                emit(PlayerEvent.Buffering)
+            }
+    }
+
+    private fun cancelBuffering() {
+        bufferingJob?.cancel()
+        bufferingJob = null
+    }
+
+    private fun adContextFromPlayer(): AdContext =
+        AdContext(
+            adGroupIndex = player.currentAdGroupIndex,
+            adIndexInAdGroup = player.currentAdIndexInAdGroup,
+            positionMillis = player.currentPosition.coerceAtLeast(0),
+            durationMillis = player.duration,
+            contentPositionMillis = player.contentPosition.coerceAtLeast(0),
+            contentId = player.currentMediaItem?.mediaId?.takeIf { it.isNotEmpty() },
+        )
+}
+
+private fun AdContext.isSameAdAs(other: AdContext): Boolean =
+    adGroupIndex == other.adGroupIndex &&
+        adIndexInAdGroup == other.adIndexInAdGroup &&
+        contentId == other.contentId
+
+internal fun Player.createPlayerDispatcher(): CoroutineDispatcher {
+    return Handler(applicationLooper).asCoroutineDispatcher()
+}
+
+private fun Player.mediaType(): MediaType {
+    val groups = currentTracks.groups
+    val hasVideo = groups.any { it.isType(C.TRACK_TYPE_VIDEO) }
+    val hasAudio = groups.any { it.isType(C.TRACK_TYPE_AUDIO) }
+    return when {
+        hasVideo -> MediaType.VIDEO
+        hasAudio -> MediaType.AUDIO
+        else -> MediaType.VIDEO
+    }
+}
+
+private fun Tracks.Group.isType(trackType: Int): Boolean = type == trackType

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerEvent.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerEvent.kt
@@ -1,0 +1,39 @@
+package com.amplitude.android.streaming.internal.player
+
+import androidx.media3.common.MediaItem
+import com.amplitude.android.streaming.internal.AdContext
+
+internal sealed interface PlayerEvent {
+    data object Playing : PlayerEvent
+
+    data object Paused : PlayerEvent
+
+    data object Buffering : PlayerEvent
+
+    data object Ready : PlayerEvent
+
+    data object Ended : PlayerEvent
+
+    data object Seeking : PlayerEvent
+
+    data class Error(
+        val message: String?,
+    ) : PlayerEvent
+
+    data class MediaChanged(
+        val mediaItem: MediaItem?,
+    ) : PlayerEvent
+
+    data class AdStarted(
+        val ad: AdContext,
+    ) : PlayerEvent
+
+    data class AdStopped(
+        val ad: AdContext,
+        val completed: Boolean,
+    ) : PlayerEvent
+
+    data class AdSkipped(
+        val ad: AdContext,
+    ) : PlayerEvent
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerMediaSnapshot.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerMediaSnapshot.kt
@@ -1,0 +1,13 @@
+package com.amplitude.android.streaming.internal.player
+
+import androidx.media3.common.C
+import com.amplitude.android.streaming.internal.MediaType
+
+internal data class PlayerMediaSnapshot(
+    val positionMillis: Long,
+    val durationMillis: Long = C.TIME_UNSET,
+    val isLive: Boolean = false,
+    val mediaId: String? = null,
+    val title: String? = null,
+    val mediaType: MediaType,
+)

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerObserver.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerObserver.kt
@@ -1,0 +1,9 @@
+package com.amplitude.android.streaming.internal.player
+
+import kotlinx.coroutines.flow.SharedFlow
+
+internal interface PlayerObserver {
+    val eventFlow: SharedFlow<PlayerEvent>
+
+    suspend fun snapshot(): PlayerMediaSnapshot
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerObserverFactory.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerObserverFactory.kt
@@ -1,0 +1,22 @@
+package com.amplitude.android.streaming.internal.player
+
+import androidx.media3.common.Player
+import com.amplitude.android.streaming.internal.StreamingDiGraph
+import com.amplitude.android.streaming.internal.util.DiGraph.Companion.weak
+import kotlinx.coroutines.CoroutineScope
+
+internal val StreamingDiGraph.playerObserverFactory: PlayerObserverFactory by weak {
+    PlayerObserverFactory { player, parentScope ->
+        Media3PlayerObserver(
+            player = player,
+            scope = parentScope,
+        )
+    }
+}
+
+internal fun interface PlayerObserverFactory {
+    fun create(
+        player: Player,
+        parentScope: CoroutineScope,
+    ): PlayerObserver
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerState.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerState.kt
@@ -1,0 +1,6 @@
+package com.amplitude.android.streaming.internal.player
+
+internal data class PlayerState(
+    val isInPictureInPicture: Boolean = false,
+    val isInBackground: Boolean = false,
+)

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/StreamTrackerTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/StreamTrackerTest.kt
@@ -2,6 +2,8 @@ package com.amplitude.android.streaming.internal
 
 import androidx.media3.common.C
 import com.amplitude.android.streaming.PlayerContent
+import com.amplitude.android.streaming.internal.player.PlayerMediaSnapshot
+import com.amplitude.android.streaming.internal.player.PlayerState
 import com.amplitude.core.Amplitude
 import com.amplitude.core.AmplitudePreview
 import com.amplitude.core.events.BaseEvent
@@ -50,6 +52,10 @@ class StreamTrackerTest {
                 durationMillis = 60_000L,
                 mediaId = "media-123",
                 title = "Test Video",
+                mediaType = MediaType.VIDEO,
+            )
+        private val playerState =
+            PlayerState(
                 isInPictureInPicture = true,
                 isInBackground = false,
             )
@@ -65,6 +71,7 @@ class StreamTrackerTest {
             tracker.trackStreamStarted(
                 options = options,
                 snapshot = snapshot,
+                playerState = playerState,
                 mediaType = MediaType.VIDEO,
                 streamSessionId = "stream-1",
                 timestamp = 1_000L,
@@ -96,6 +103,7 @@ class StreamTrackerTest {
             tracker.trackStreamStopped(
                 options = options,
                 snapshot = snapshot,
+                playerState = playerState,
                 mediaType = MediaType.VIDEO,
                 streamSessionId = "stream-1",
                 streamDurationMillis = 5_000L,
@@ -125,6 +133,7 @@ class StreamTrackerTest {
             tracker.trackStreamStarted(
                 options = PlayerContent(),
                 snapshot = snapshot,
+                playerState = playerState,
                 mediaType = MediaType.AUDIO,
                 streamSessionId = "stream-audio",
                 timestamp = 2_000L,
@@ -133,6 +142,7 @@ class StreamTrackerTest {
             tracker.trackStreamStopped(
                 options = PlayerContent(),
                 snapshot = snapshot,
+                playerState = playerState,
                 mediaType = MediaType.AUDIO,
                 streamSessionId = "stream-audio",
                 streamDurationMillis = 3_000L,
@@ -158,6 +168,7 @@ class StreamTrackerTest {
             tracker.trackStreamStopped(
                 options = PlayerContent(),
                 snapshot = liveSnapshot,
+                playerState = playerState,
                 mediaType = MediaType.VIDEO,
                 streamSessionId = "stream-live",
                 streamDurationMillis = 10_000L,
@@ -177,6 +188,7 @@ class StreamTrackerTest {
             tracker.trackStreamStopped(
                 options = PlayerContent(),
                 snapshot = unknownDurationSnapshot,
+                playerState = playerState,
                 mediaType = MediaType.VIDEO,
                 streamSessionId = "stream-unknown",
                 streamDurationMillis = 5_000L,

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/Media3PlayerObserverTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/Media3PlayerObserverTest.kt
@@ -1,0 +1,440 @@
+package com.amplitude.android.streaming.internal.player
+
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Tracks
+import com.amplitude.android.streaming.internal.MediaType
+import com.google.common.collect.ImmutableList
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class Media3PlayerObserverTest {
+    @Test
+    fun `should add the listener once while subscribers are present and remove it when they leave`() =
+        runTest {
+            val player = mockk<Player>(relaxed = true)
+            val observer =
+                Media3PlayerObserver(
+                    player = player,
+                    scope = backgroundScope,
+                    playerDispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+
+            val first = launch { observer.eventFlow.collect {} }
+            runCurrent()
+            verify(exactly = 1) { player.addListener(observer) }
+
+            val second = launch { observer.eventFlow.collect {} }
+            runCurrent()
+            verify(exactly = 1) { player.addListener(observer) }
+
+            first.cancel()
+            runCurrent()
+            verify(exactly = 0) { player.removeListener(observer) }
+
+            second.cancel()
+            runCurrent()
+            verify(exactly = 1) { player.removeListener(observer) }
+        }
+
+    @Test
+    fun `should not emit Paused when playback ends`() =
+        runTest {
+            val player = mockk<Player>(relaxed = true)
+            every { player.playbackState } returns Player.STATE_ENDED
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.onPlaybackStateChanged(Player.STATE_ENDED)
+            observer.onIsPlayingChanged(false)
+            runCurrent()
+
+            assertTrue(events.any { it is PlayerEvent.Ended })
+            assertTrue(events.none { it is PlayerEvent.Paused })
+        }
+
+    @Test
+    fun `should emit Paused when playback stops in STATE_READY`() =
+        runTest {
+            val player = mockk<Player>(relaxed = true)
+            every { player.playbackState } returns Player.STATE_READY
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.onPlayWhenReadyChanged(false, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+            runCurrent()
+
+            assertTrue(events.any { it is PlayerEvent.Paused })
+        }
+
+    @Test
+    fun `should emit Paused when playWhenReady becomes false while buffering`() =
+        runTest {
+            val player = mockk<Player>(relaxed = true)
+            every { player.playbackState } returns Player.STATE_BUFFERING
+            every { player.isPlaying } returns false
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.onIsPlayingChanged(false)
+            observer.onPlayWhenReadyChanged(false, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+            observer.onPlaybackStateChanged(Player.STATE_READY)
+            runCurrent()
+
+            assertTrue(events.any { it is PlayerEvent.Paused })
+        }
+
+    @Test
+    fun `should not emit Buffering after a pause while still buffering`() =
+        runTest {
+            val player = mockk<Player>(relaxed = true)
+            every { player.playbackState } returns Player.STATE_BUFFERING
+            every { player.playWhenReady } returns true
+            every { player.isPlaying } returns false
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.onPlaybackStateChanged(Player.STATE_BUFFERING)
+            every { player.playWhenReady } returns false
+            observer.onPlayWhenReadyChanged(false, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+            observer.onPlaybackStateChanged(Player.STATE_BUFFERING)
+            advanceTimeBy(500)
+            runCurrent()
+
+            assertTrue(events.any { it is PlayerEvent.Paused })
+            assertTrue(events.none { it is PlayerEvent.Buffering })
+        }
+
+    @Test
+    fun `should emit Paused when playback becomes idle while playWhenReady is true`() =
+        runTest {
+            val player = mockk<Player>(relaxed = true)
+            every { player.playWhenReady } returns true
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.onPlaybackStateChanged(Player.STATE_IDLE)
+            runCurrent()
+
+            assertTrue(events.any { it is PlayerEvent.Paused })
+            assertTrue(events.none { it is PlayerEvent.Ended })
+        }
+
+    @Test
+    fun `should not emit Paused when playback becomes idle after a user pause`() =
+        runTest {
+            val player = mockk<Player>(relaxed = true)
+            every { player.playWhenReady } returns false
+            every { player.playbackState } returns Player.STATE_READY
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.onPlayWhenReadyChanged(false, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+            every { player.playbackState } returns Player.STATE_IDLE
+            observer.onPlaybackStateChanged(Player.STATE_IDLE)
+            runCurrent()
+
+            assertEquals(1, events.filterIsInstance<PlayerEvent.Paused>().size)
+        }
+
+    @Test
+    fun `should emit Buffering when playback is suppressed while ready`() =
+        runTest {
+            val player = mockk<Player>(relaxed = true)
+            every { player.playWhenReady } returns true
+            every { player.playbackState } returns Player.STATE_READY
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.onIsPlayingChanged(false)
+            runCurrent()
+
+            assertTrue(events.any { it is PlayerEvent.Buffering })
+            assertTrue(events.none { it is PlayerEvent.Paused })
+        }
+
+    @Test
+    fun `should not emit Buffering when isPlaying becomes false because the player paused`() =
+        runTest {
+            val player = mockk<Player>(relaxed = true)
+            every { player.playWhenReady } returns false
+            every { player.playbackState } returns Player.STATE_READY
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.onIsPlayingChanged(false)
+            observer.onPlayWhenReadyChanged(false, Player.PLAY_WHEN_READY_CHANGE_REASON_USER_REQUEST)
+            runCurrent()
+
+            assertTrue(events.none { it is PlayerEvent.Buffering })
+            assertTrue(events.any { it is PlayerEvent.Paused })
+        }
+
+    @Test
+    fun `should snapshot video mediaType when a video track is present`() =
+        runTest {
+            val observer =
+                Media3PlayerObserver(
+                    player = playerWithTrackType(C.TRACK_TYPE_VIDEO),
+                    scope = backgroundScope,
+                    playerDispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+
+            assertEquals(MediaType.VIDEO, observer.snapshot().mediaType)
+        }
+
+    @Test
+    fun `should snapshot audio mediaType when only an audio track is present`() =
+        runTest {
+            val observer =
+                Media3PlayerObserver(
+                    player = playerWithTrackType(C.TRACK_TYPE_AUDIO),
+                    scope = backgroundScope,
+                    playerDispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+
+            assertEquals(MediaType.AUDIO, observer.snapshot().mediaType)
+        }
+
+    @Test
+    fun `should emit AdStarted on attach when an ad is already playing`() =
+        runTest {
+            val player = playingAdPlayer(adGroupIndex = 0, adIndexInAdGroup = 2)
+            val (_, events) = observerCollectingEvents(player)
+
+            val started = events.filterIsInstance<PlayerEvent.AdStarted>()
+            assertEquals(1, started.size)
+            assertEquals(2, started.first().ad.adIndexInAdGroup)
+        }
+
+    @Test
+    fun `should not skip an ad that ended while detached`() =
+        runTest {
+            val player = playingAdPlayer(adGroupIndex = 0, adIndexInAdGroup = 0)
+            val events = mutableListOf<PlayerEvent>()
+            val observer =
+                Media3PlayerObserver(
+                    player = player,
+                    scope = backgroundScope,
+                    playerDispatcher = UnconfinedTestDispatcher(testScheduler),
+                )
+            val first =
+                backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                    observer.eventFlow.collect { events.add(it) }
+                }
+            runCurrent()
+            assertEquals(1, events.filterIsInstance<PlayerEvent.AdStarted>().size)
+
+            first.cancel()
+            runCurrent()
+            events.clear()
+            every { player.isPlayingAd } returns false
+
+            val second =
+                backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                    observer.eventFlow.collect { events.add(it) }
+                }
+            runCurrent()
+            assertTrue(events.none { it is PlayerEvent.AdSkipped || it is PlayerEvent.AdStopped })
+            second.cancel()
+            runCurrent()
+        }
+
+    @Test
+    fun `should start each ad in a pod while isPlayingAd stays true`() =
+        runTest {
+            val player = playingAdPlayer(adGroupIndex = 0, adIndexInAdGroup = 0)
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.detectAdTransition()
+            every { player.currentAdIndexInAdGroup } returns 1
+            observer.detectAdTransition()
+            runCurrent()
+
+            val started = events.filterIsInstance<PlayerEvent.AdStarted>()
+            assertEquals(listOf(0, 1), started.map { it.ad.adIndexInAdGroup })
+            assertTrue(events.any { it is PlayerEvent.AdSkipped })
+        }
+
+    @Test
+    fun `should complete the previous ad on auto-transition to the next ad`() =
+        runTest {
+            val player = playingAdPlayer(adGroupIndex = 0, adIndexInAdGroup = 0)
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.detectAdTransition()
+            runCurrent()
+            observer.onPositionDiscontinuity(
+                oldPosition = adPosition(adGroupIndex = 0, adIndexInAdGroup = 0, positionMs = 1_500L),
+                newPosition = adPosition(adGroupIndex = 0, adIndexInAdGroup = 1, positionMs = 0L),
+                reason = Player.DISCONTINUITY_REASON_AUTO_TRANSITION,
+            )
+            every { player.currentAdIndexInAdGroup } returns 1
+            observer.detectAdTransition()
+            runCurrent()
+
+            val stopped = events.filterIsInstance<PlayerEvent.AdStopped>()
+            assertEquals(1, stopped.size)
+            assertEquals(0, stopped.first().ad.adIndexInAdGroup)
+            assertEquals(1_500L, stopped.first().ad.positionMillis)
+            assertTrue(stopped.first().completed)
+            assertEquals(
+                listOf(0, 1),
+                events.filterIsInstance<PlayerEvent.AdStarted>().map { it.ad.adIndexInAdGroup },
+            )
+        }
+
+    @Test
+    fun `should treat ads with the same indices on different media items as distinct`() =
+        runTest {
+            val player = playingAdPlayer(adGroupIndex = 0, adIndexInAdGroup = 0, mediaId = "item-a")
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.detectAdTransition()
+            every { player.currentMediaItem } returns mediaItem("item-b")
+            observer.detectAdTransition()
+            runCurrent()
+
+            assertEquals(
+                listOf("item-a", "item-b"),
+                events.filterIsInstance<PlayerEvent.AdStarted>().map { it.ad.contentId },
+            )
+            assertTrue(events.any { it is PlayerEvent.AdSkipped })
+        }
+
+    @Test
+    fun `should complete the previous ad on auto-transition to the next media item's ad`() =
+        runTest {
+            val player = playingAdPlayer(adGroupIndex = 0, adIndexInAdGroup = 0, mediaId = "item-a")
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.detectAdTransition()
+            runCurrent()
+            observer.onPositionDiscontinuity(
+                oldPosition =
+                    adPosition(
+                        adGroupIndex = 0,
+                        adIndexInAdGroup = 0,
+                        positionMs = 2_000L,
+                        mediaItemIndex = 0,
+                        mediaItem = mediaItem("item-a"),
+                    ),
+                newPosition =
+                    adPosition(
+                        adGroupIndex = 0,
+                        adIndexInAdGroup = 0,
+                        positionMs = 0L,
+                        mediaItemIndex = 1,
+                        mediaItem = mediaItem("item-b"),
+                    ),
+                reason = Player.DISCONTINUITY_REASON_AUTO_TRANSITION,
+            )
+            every { player.currentMediaItem } returns mediaItem("item-b")
+            observer.detectAdTransition()
+            runCurrent()
+
+            val stopped = events.filterIsInstance<PlayerEvent.AdStopped>()
+            assertEquals(1, stopped.size)
+            assertEquals("item-a", stopped.first().ad.contentId)
+            assertEquals(2_000L, stopped.first().ad.positionMillis)
+            assertTrue(stopped.first().completed)
+            assertEquals(
+                listOf("item-a", "item-b"),
+                events.filterIsInstance<PlayerEvent.AdStarted>().map { it.ad.contentId },
+            )
+        }
+
+    @Test
+    fun `should complete an active ad when playback ends`() =
+        runTest {
+            val player = playingAdPlayer(adGroupIndex = 0, adIndexInAdGroup = 0)
+            every { player.currentPosition } returns 15_000L
+            val (observer, events) = observerCollectingEvents(player)
+
+            observer.onPlaybackStateChanged(Player.STATE_ENDED)
+            every { player.playbackState } returns Player.STATE_ENDED
+            observer.detectAdTransition()
+            runCurrent()
+
+            val stopped = events.filterIsInstance<PlayerEvent.AdStopped>()
+            assertEquals(1, stopped.size)
+            assertTrue(stopped.first().completed)
+            assertEquals(15_000L, stopped.first().ad.positionMillis)
+            assertTrue(events.any { it is PlayerEvent.Ended })
+            assertTrue(events.none { it is PlayerEvent.AdSkipped })
+            assertEquals(1, events.filterIsInstance<PlayerEvent.AdStarted>().size)
+        }
+
+    private fun TestScope.observerCollectingEvents(
+        player: Player,
+    ): Pair<Media3PlayerObserver, MutableList<PlayerEvent>> {
+        val events = mutableListOf<PlayerEvent>()
+        val observer =
+            Media3PlayerObserver(
+                player = player,
+                scope = backgroundScope,
+                playerDispatcher = UnconfinedTestDispatcher(testScheduler),
+            )
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            observer.eventFlow.collect { events.add(it) }
+        }
+        runCurrent()
+        return observer to events
+    }
+}
+
+private fun playerWithTrackType(trackType: Int): Player {
+    val group = mockk<Tracks.Group>()
+    every { group.type } returns trackType
+    val tracks = mockk<Tracks>()
+    every { tracks.groups } returns ImmutableList.of(group)
+    val player = mockk<Player>(relaxed = true)
+    every { player.currentTracks } returns tracks
+    return player
+}
+
+private fun playingAdPlayer(
+    adGroupIndex: Int,
+    adIndexInAdGroup: Int,
+    mediaId: String? = null,
+): Player {
+    val player = mockk<Player>(relaxed = true)
+    every { player.isPlayingAd } returns true
+    every { player.currentAdGroupIndex } returns adGroupIndex
+    every { player.currentAdIndexInAdGroup } returns adIndexInAdGroup
+    every { player.currentPosition } returns 0L
+    every { player.duration } returns 15_000L
+    every { player.contentPosition } returns 30_000L
+    every { player.currentMediaItem } returns mediaId?.let { mediaItem(it) }
+    return player
+}
+
+private fun mediaItem(mediaId: String): MediaItem =
+    MediaItem.Builder()
+        .setMediaId(mediaId)
+        .setUri("https://example.com/$mediaId")
+        .build()
+
+private fun adPosition(
+    adGroupIndex: Int,
+    adIndexInAdGroup: Int,
+    positionMs: Long,
+    mediaItemIndex: Int = 0,
+    mediaItem: MediaItem? = null,
+): Player.PositionInfo =
+    Player.PositionInfo(
+        /* windowUid= */ null,
+        mediaItemIndex,
+        mediaItem,
+        /* periodUid= */ null,
+        /* periodIndex= */ 0,
+        positionMs,
+        positionMs,
+        adGroupIndex,
+        adIndexInAdGroup,
+    )


### PR DESCRIPTION
### Describe what this PR is addressing
[SDKA-92](https://linear.app/amplitude/issue/SDKA-92): Media3 player observation for streaming analytics.

Stacked on [#490](https://github.com/amplitude/Amplitude-Kotlin/pull/490).

### Describe the solution
Adds `com.amplitude.android.streaming.internal.player`:
* `PlayerObserver` exposes a `SharedFlow<PlayerEvent>` and an on-demand `snapshot()` of Media3-owned fields
* `Media3PlayerObserver` attaches when there are subscribers, hops to the player looper, and emits play/pause/buffer/seek/error/media/ad events
* Ad pods emit `AdStarted` per ad; auto-transition completes the previous ad; attach seeds `AdStarted` if an ad is already playing; detach drops in-flight ad state without a spurious skip
* `PlayerState` (PiP/background) is passed into `StreamTracker` separately from `PlayerMediaSnapshot`

Heartbeat and `trackPlayer` wiring stay on a follow-up commit.

### Steps to verify the change
1. `./gradlew :streaming-analytics-android:test --tests com.amplitude.android.streaming.internal.player.Media3PlayerObserverTest`
2. `./gradlew :streaming-analytics-android:test --tests com.amplitude.android.streaming.internal.StreamTrackerTest`
3. `./gradlew build -x test test ktlintCheck apiCheck`

### Useful links and documentation (optional)
* [SDKA-92](https://linear.app/amplitude/issue/SDKA-92)
* [#490](https://github.com/amplitude/Amplitude-Kotlin/pull/490)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Media3 listener and coroutine logic drives future stream/ad analytics events, and StreamTracker’s stream APIs changed internally—incorrect pause/buffer/ad edge handling could skew telemetry once wired up.
> 
> **Overview**
> Introduces an internal **Media3 player observation** layer under `internal.player`: `PlayerObserver` exposes a `SharedFlow` of `PlayerEvent` (play/pause/buffer/seek/error/media/ad) plus a thread-safe `snapshot()` of playback metadata, implemented by **`Media3PlayerObserver`** with subscribe-driven attach/detach, player-looper dispatch, debounced buffering, and ad-pod lifecycle handling (per-ad `AdStarted`, completed vs skipped transitions, no spurious skip on detach).
> 
> **`StreamTracker`** is updated to take a separate **`PlayerState`** for PiP/background on stream start/stop (instead of reading those flags from the media snapshot), and **`PlayerMediaSnapshot`** moves into the player package with a required **`mediaType`** field derived from track types in snapshots.
> 
> DI adds **`PlayerObserverFactory`** for creating observers; heartbeat / public `trackPlayer` wiring is explicitly out of scope for this PR. Coverage includes extensive **`Media3PlayerObserverTest`** and updated **`StreamTrackerTest`** call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d87276c14fce632d4929ac7afe06a776cd1bd85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->