### PR TITLE
feat: Streaming - Heartbeat

### DIFF
--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/Heartbeat.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/Heartbeat.kt
@@ -1,0 +1,64 @@
+package com.amplitude.android.streaming.internal.player
+
+import com.amplitude.android.streaming.internal.util.Time
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
+
+private const val HEARTBEAT_INTERVAL_MILLIS = 1_000L
+
+internal class Heartbeat internal constructor(
+    private val scope: CoroutineScope,
+    private val stoppedEvent: suspend (timestamp: Long) -> Unit,
+    private val time: Time,
+) {
+    private val sendMutex = Mutex()
+    private var job: Job? = null
+    private val stopped = AtomicBoolean(false)
+
+    fun start() {
+        if (job != null || stopped.get()) return
+        job =
+            scope.launch {
+                while (true) {
+                    try {
+                        sendHeartbeat()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        // Keep upserting; a single snapshot/track failure must not end the play.
+                    }
+                    delay(HEARTBEAT_INTERVAL_MILLIS.milliseconds)
+                }
+            }
+    }
+
+    suspend fun cancel() {
+        if (!stopped.compareAndSet(false, true)) return
+        job?.cancelAndJoin()
+        job = null
+    }
+
+    suspend fun stop() {
+        if (!stopped.compareAndSet(false, true)) return
+        job?.cancelAndJoin()
+        job = null
+        sendMutex.withLock {
+            stoppedEvent(time.nowMillis())
+        }
+    }
+
+    private suspend fun sendHeartbeat() {
+        sendMutex.withLock {
+            if (stopped.get()) return
+            stoppedEvent(time.nowMillis())
+        }
+    }
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/HeartbeatFactory.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/HeartbeatFactory.kt
@@ -1,0 +1,27 @@
+package com.amplitude.android.streaming.internal.player
+
+import com.amplitude.android.streaming.internal.StreamingDiGraph
+import com.amplitude.android.streaming.internal.util.DiGraph.Companion.weak
+import com.amplitude.android.streaming.internal.util.Time
+import com.amplitude.android.streaming.internal.util.time
+import kotlinx.coroutines.CoroutineScope
+
+internal val StreamingDiGraph.heartbeatFactory: HeartbeatFactory by weak {
+    HeartbeatFactory(
+        time = time,
+    )
+}
+
+internal class HeartbeatFactory(
+    private val time: Time,
+) {
+    fun create(
+        scope: CoroutineScope,
+        stoppedEvent: suspend (timestamp: Long) -> Unit,
+    ): Heartbeat =
+        Heartbeat(
+            scope = scope,
+            stoppedEvent = stoppedEvent,
+            time = time,
+        )
+}

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerBinding.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerBinding.kt
@@ -28,6 +28,7 @@ internal class PlayerBinding internal constructor(
     private val contentProvider: PlayerContentProvider,
     playerObserverFactory: PlayerObserverFactory,
     private val streamTracker: StreamTracker,
+    private val heartbeatFactory: HeartbeatFactory,
     private val time: Time,
     parentScope: CoroutineScope,
 ) {
@@ -125,8 +126,10 @@ internal class PlayerBinding internal constructor(
             StreamSession(
                 streamSessionId = id,
                 startedInsertId = UUID.randomUUID().toString(),
+                stoppedInsertId = UUID.randomUUID().toString(),
                 options = options,
                 mediaType = snapshot.mediaType,
+                snapshot = snapshot,
                 time = time,
             ).also { it.resumeWatch() }
         streamTracker.trackStreamStarted(
@@ -142,20 +145,20 @@ internal class PlayerBinding internal constructor(
             PlaybackState.Content(
                 viewSessionId = id,
                 segment = segment,
+                heartbeat = createHeartbeat(segment),
                 phase = ContentPhase.PLAYING,
             )
-        // TODO: heartbeat a delayed Stream Stopped event while this segment stays active.
     }
 
-    private fun onPaused() {
+    private suspend fun onPaused() {
         when (val state = playback) {
             is PlaybackState.Content -> {
-                finishSegment(state.segment, StopReason.PAUSED)
-                playback = PlaybackState.Idle(state.viewSessionId)
+                finishSegment(state.segment, state.heartbeat, StopReason.PAUSED)
+                playback = PlaybackState.Idle(state.viewSessionId, state.segment)
             }
             is PlaybackState.Suspended -> {
-                finishSegment(state.segment, StopReason.PAUSED)
-                playback = PlaybackState.Idle(state.viewSessionId)
+                finishSegment(state.segment, heartbeat = null, reason = StopReason.PAUSED)
+                playback = PlaybackState.Idle(state.viewSessionId, state.segment)
             }
             is PlaybackState.Ad -> {
                 state.content?.segment?.apply {
@@ -218,7 +221,7 @@ internal class PlayerBinding internal constructor(
         }
     }
 
-    private fun finishSession(
+    private suspend fun finishSession(
         reason: StopReason?,
         errorMessage: String? = null,
     ) {
@@ -235,6 +238,7 @@ internal class PlayerBinding internal constructor(
             when (current) {
                 is PlaybackState.Content -> {
                     current.segment.pauseWatch()
+                    current.heartbeat.cancel()
                     PlaybackState.Suspended(
                         viewSessionId = current.viewSessionId,
                         segment = current.segment,
@@ -288,8 +292,8 @@ internal class PlayerBinding internal constructor(
             return
         }
         if (state.paused) {
-            finishSegment(content.segment, StopReason.PAUSED)
-            playback = PlaybackState.Idle(state.viewSessionId)
+            finishSegment(content.segment, heartbeat = null, reason = StopReason.PAUSED)
+            playback = PlaybackState.Idle(state.viewSessionId, content.segment)
             return
         }
         playback = content
@@ -304,33 +308,117 @@ internal class PlayerBinding internal constructor(
             PlaybackState.Content(
                 viewSessionId = state.viewSessionId,
                 segment = state.segment,
+                heartbeat = createHeartbeat(state.segment),
                 phase = ContentPhase.PLAYING,
             )
     }
 
-    private fun finishPlayback(
+    private fun createHeartbeat(segment: StreamSession): Heartbeat =
+        heartbeatFactory
+            .create(
+                scope = scope,
+                stoppedEvent = { timestamp ->
+                    sendStreamStopped(segment, timestamp)
+                },
+            ).also { it.start() }
+
+    private suspend fun finishPlayback(
         reason: StopReason?,
         errorMessage: String? = null,
     ) {
         when (val state = playback) {
-            is PlaybackState.Content -> finishSegment(state.segment, reason, errorMessage)
-            is PlaybackState.Suspended -> finishSegment(state.segment, reason, errorMessage)
+            is PlaybackState.Content -> {
+                finishSegment(state.segment, state.heartbeat, reason, errorMessage)
+            }
+            is PlaybackState.Suspended -> {
+                finishSegment(
+                    segment = state.segment,
+                    heartbeat = null,
+                    reason = reason,
+                    errorMessage = errorMessage,
+                )
+            }
             is PlaybackState.Ad -> {
                 trackAdFinished(state, state.ad, completed = false)
-                state.content?.let { finishSegment(it.segment, reason, errorMessage) }
+                state.content?.let {
+                    finishSegment(
+                        segment = it.segment,
+                        heartbeat = null,
+                        reason = reason,
+                        errorMessage = errorMessage,
+                    )
+                }
             }
-            is PlaybackState.Idle -> Unit
+            is PlaybackState.Idle -> {
+                if (reason == StopReason.UNSUBSCRIBED) {
+                    state.lastSegment?.let {
+                        it.stopReason = reason
+                        it.errorMessage = errorMessage
+                        sendStreamStopped(it, time.nowMillis())
+                    }
+                }
+            }
         }
     }
 
-    private fun finishSegment(
+    private suspend fun finishSegment(
         segment: StreamSession,
+        heartbeat: Heartbeat?,
         reason: StopReason?,
         errorMessage: String? = null,
     ) {
         segment.pauseWatch()
         segment.stopReason = reason
         segment.errorMessage = errorMessage
+        freezeSegment(segment)
+        if (heartbeat == null) {
+            sendFinalStreamStopped(segment)
+        } else {
+            try {
+                heartbeat.stop()
+            } catch (_: Exception) {
+                // The segment is frozen and the heartbeat job is stopped.
+            }
+        }
+    }
+
+    private suspend fun sendFinalStreamStopped(segment: StreamSession) {
+        try {
+            sendStreamStopped(segment, time.nowMillis())
+        } catch (_: Exception) {
+            // A final upsert failure must not prevent the state transition.
+        }
+    }
+
+    private suspend fun freezeSegment(segment: StreamSession) {
+        try {
+            segment.freeze(snapshot())
+        } catch (_: Exception) {
+            segment.freeze(segment.snapshot)
+        }
+    }
+
+    private suspend fun sendStreamStopped(
+        segment: StreamSession,
+        timestamp: Long,
+    ) {
+        streamTracker.trackStreamStopped(
+            options = segment.options,
+            snapshot =
+                if (segment.frozen) {
+                    segment.snapshot
+                } else {
+                    snapshot().also { segment.updateSnapshot(it) }
+                },
+            playerState = playerState,
+            mediaType = segment.mediaType,
+            streamSessionId = segment.streamSessionId,
+            streamDurationMillis = segment.durationMillis(),
+            timestamp = timestamp,
+            insertId = segment.stoppedInsertId,
+            stopReason = segment.stopReason,
+            errorMessage = segment.errorMessage,
+        )
     }
 
     private suspend fun snapshot(): PlayerMediaSnapshot = observer.snapshot()
@@ -355,11 +443,13 @@ internal class PlayerBinding internal constructor(
 
         data class Idle(
             override val viewSessionId: String? = null,
+            val lastSegment: StreamSession? = null,
         ) : PlaybackState
 
         data class Content(
             override val viewSessionId: String,
             val segment: StreamSession,
+            val heartbeat: Heartbeat,
             val phase: ContentPhase,
         ) : PlaybackState
 

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingFactory.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingFactory.kt
@@ -16,6 +16,7 @@ internal val StreamingDiGraph.playerBindingFactory: PlayerBindingFactory by DiGr
     PlayerBindingFactory(
         playerObserverFactory = playerObserverFactory,
         streamTracker = streamTracker,
+        heartbeatFactory = heartbeatFactory,
         time = time,
         scope = scope,
     )
@@ -25,6 +26,7 @@ internal val StreamingDiGraph.playerBindingFactory: PlayerBindingFactory by DiGr
 internal class PlayerBindingFactory(
     private val playerObserverFactory: PlayerObserverFactory,
     private val streamTracker: StreamTracker,
+    private val heartbeatFactory: HeartbeatFactory,
     private val time: Time,
     private val scope: CoroutineScope,
 ) {
@@ -43,6 +45,7 @@ internal class PlayerBindingFactory(
                     contentProvider = contentProvider,
                     playerObserverFactory = playerObserverFactory,
                     streamTracker = streamTracker,
+                    heartbeatFactory = heartbeatFactory,
                     time = time,
                     parentScope = scope,
                 )

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/StreamSession.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/StreamSession.kt
@@ -10,29 +10,65 @@ import com.amplitude.core.AmplitudePreview
 internal class StreamSession(
     val streamSessionId: String,
     val startedInsertId: String,
+    val stoppedInsertId: String,
     val options: PlayerContent,
     val mediaType: MediaType,
+    snapshot: PlayerMediaSnapshot,
     private val time: Time,
 ) {
+    @Volatile
+    var snapshot: PlayerMediaSnapshot = snapshot
+        private set
+
+    @Volatile
     var stopReason: StopReason? = null
+
+    @Volatile
     var errorMessage: String? = null
 
+    @Volatile
+    var frozen: Boolean = false
+        private set
+
+    private var frozenDurationMillis = 0L
     private var watchDurationMillis = 0L
     private var watchStartedAt: Long? = null
 
+    @Synchronized
     fun resumeWatch() {
+        if (frozen) return
         if (watchStartedAt == null) {
             watchStartedAt = time.elapsedRealtime()
         }
     }
 
+    @Synchronized
     fun pauseWatch() {
         val startedAt = watchStartedAt ?: return
         watchDurationMillis += (time.elapsedRealtime() - startedAt).coerceAtLeast(0)
         watchStartedAt = null
     }
 
-    fun durationMillis(): Long = watchDurationMillis + currentWatchSegment()
+    @Synchronized
+    fun durationMillis(): Long {
+        if (frozen) return frozenDurationMillis
+        return watchDurationMillis + currentWatchSegment()
+    }
+
+    @Synchronized
+    fun updateSnapshot(snapshot: PlayerMediaSnapshot) {
+        if (frozen) return
+        this.snapshot = snapshot
+    }
+
+    @Synchronized
+    fun freeze(snapshot: PlayerMediaSnapshot) {
+        if (frozen) return
+        pauseWatch()
+        this.snapshot = snapshot
+        frozenDurationMillis = durationMillis()
+        frozen = true
+    }
 
     private fun currentWatchSegment(): Long =
         watchStartedAt?.let { (time.elapsedRealtime() - it).coerceAtLeast(0) } ?: 0

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/HeartbeatTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/HeartbeatTest.kt
@@ -1,0 +1,133 @@
+package com.amplitude.android.streaming.internal.player
+
+import com.amplitude.android.streaming.internal.util.Time
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HeartbeatTest {
+    @Test
+    fun `should send immediately and again on the interval`() =
+        runTest {
+            val timestamps = mutableListOf<Long>()
+            var now = 10_000L
+            val heartbeat =
+                Heartbeat(
+                    scope = this,
+                    stoppedEvent = { timestamps.add(it) },
+                    time = time { now },
+                )
+
+            heartbeat.start()
+            runCurrent()
+            assertEquals(listOf(10_000L), timestamps)
+
+            now = 11_000L
+            advanceTimeBy(1_000)
+            runCurrent()
+            assertEquals(listOf(10_000L, 11_000L), timestamps)
+
+            heartbeat.stop()
+        }
+
+    @Test
+    fun `should timestamp stop with now rather than the last tick`() =
+        runTest {
+            val timestamps = mutableListOf<Long>()
+            var now = 10_000L
+            val heartbeat =
+                Heartbeat(
+                    scope = this,
+                    stoppedEvent = { timestamps.add(it) },
+                    time = time { now },
+                )
+
+            heartbeat.start()
+            runCurrent()
+            now = 10_500L
+            heartbeat.stop()
+            runCurrent()
+
+            assertEquals(10_500L, timestamps.last())
+        }
+
+    @Test
+    fun `should keep sending after a failed heartbeat`() =
+        runTest {
+            var calls = 0
+            val heartbeat =
+                Heartbeat(
+                    scope = this,
+                    stoppedEvent = {
+                        calls++
+                        if (calls == 1) error("snapshot failed")
+                    },
+                    time = time { 0L },
+                )
+
+            heartbeat.start()
+            runCurrent()
+            advanceTimeBy(1_000)
+            runCurrent()
+
+            assertEquals(2, calls)
+            heartbeat.stop()
+        }
+
+    @Test
+    fun `should not start after stop`() =
+        runTest {
+            val timestamps = mutableListOf<Long>()
+            val heartbeat =
+                Heartbeat(
+                    scope = this,
+                    stoppedEvent = { timestamps.add(it) },
+                    time = time { 0L },
+                )
+
+            heartbeat.start()
+            runCurrent()
+            heartbeat.stop()
+            runCurrent()
+            val sent = timestamps.size
+            heartbeat.start()
+            advanceTimeBy(2_000)
+            runCurrent()
+
+            assertEquals(sent, timestamps.size)
+        }
+
+    @Test
+    fun `should not send on cancel`() =
+        runTest {
+            val timestamps = mutableListOf<Long>()
+            var now = 10_000L
+            val heartbeat =
+                Heartbeat(
+                    scope = this,
+                    stoppedEvent = { timestamps.add(it) },
+                    time = time { now },
+                )
+
+            heartbeat.start()
+            runCurrent()
+            assertEquals(1, timestamps.size)
+            now = 10_500L
+            heartbeat.cancel()
+            runCurrent()
+
+            assertEquals(1, timestamps.size)
+        }
+}
+
+private fun time(nowMillis: () -> Long): Time =
+    mockk<Time>().also { time ->
+        every { time.nowMillis() } answers { nowMillis() }
+        every { time.elapsedRealtime() } answers { nowMillis() }
+    }

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingInsertIdTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingInsertIdTest.kt
@@ -1,0 +1,83 @@
+package com.amplitude.android.streaming.internal.player
+
+import com.amplitude.android.streaming.PlayerContent
+import com.amplitude.android.streaming.internal.StreamTracker
+import com.amplitude.android.streaming.internal.util.Time
+import com.amplitude.core.Amplitude
+import com.amplitude.core.AmplitudePreview
+import com.amplitude.core.events.BaseEvent
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@OptIn(AmplitudePreview::class, ExperimentalCoroutinesApi::class)
+class PlayerBindingInsertIdTest {
+    @Nested
+    inner class PerPlay {
+        @Test
+        fun `pause then play uses new insert ids and the same view session`() =
+            runTest {
+                val events = mutableListOf<BaseEvent>()
+                val amplitude = mockk<Amplitude>(relaxed = true)
+                every { amplitude.track(any<BaseEvent>(), any(), any()) } answers {
+                    events.add(firstArg())
+                    amplitude
+                }
+                val observer = TestPlayerObserver()
+                val binding =
+                    PlayerBinding(
+                        player = mockk(relaxed = true),
+                        contentProvider = { PlayerContent() },
+                        playerObserverFactory = PlayerObserverFactory { _, _ -> observer },
+                        streamTracker = StreamTracker(amplitude),
+                        heartbeatFactory = HeartbeatFactory(time = Time()),
+                        time = Time(),
+                        parentScope = this,
+                    )
+                binding.start()
+                try {
+                    runCurrent()
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    advanceTimeBy(1_000)
+                    runCurrent()
+
+                    observer.emit(PlayerEvent.Paused)
+                    runCurrent()
+
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+
+                    val started = events.filter { it.eventType == "[Amplitude] Stream Started" }
+                    val stopped = events.filter { it.eventType == "[Amplitude] Stream Stopped" }
+                    assertEquals(2, started.size)
+                    assertTrue(stopped.size >= 3)
+
+                    val firstStoppedInsertId = stopped.first().insertId
+                    val firstPlayStops = stopped.takeWhile { it.insertId == firstStoppedInsertId }
+                    assertTrue(firstPlayStops.size >= 2)
+                    assertTrue(stopped.any { it.insertId != firstStoppedInsertId })
+
+                    assertNotEquals(started[0].insertId, firstStoppedInsertId)
+                    assertNotEquals(started[0].insertId, started[1].insertId)
+                    assertNotEquals(firstStoppedInsertId, stopped.last().insertId)
+                    assertNotEquals(started[1].insertId, stopped.last().insertId)
+
+                    val streamSessionId = started[0].eventProperties?.get("stream_session_id")
+                    assertEquals(streamSessionId, started[1].eventProperties?.get("stream_session_id"))
+                    assertTrue(stopped.all { it.eventProperties?.get("stream_session_id") == streamSessionId })
+                } finally {
+                    binding.stop()
+                    runCurrent()
+                }
+            }
+    }
+}

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingTest.kt
@@ -15,14 +15,17 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 private const val STREAM_STARTED = "[Amplitude] Stream Started"
+private const val STREAM_STOPPED = "[Amplitude] Stream Stopped"
 private const val AD_STARTED = "[Amplitude] Ad Started"
 private const val AD_SKIPPED = "[Amplitude] Ad Skipped"
 private const val AD_STOPPED = "[Amplitude] Ad Stopped"
@@ -128,21 +131,124 @@ class PlayerBindingTest {
                     )
                 }
             }
+    }
+
+    @Nested
+    inner class Heartbeat {
+        @Test
+        fun `should keep accumulated watch duration on the terminal Stream Stopped`() =
+            runTest {
+                var elapsed = 0L
+                val time = mockk<Time>()
+                every { time.elapsedRealtime() } answers { elapsed }
+                every { time.nowMillis() } answers { elapsed }
+
+                withBinding(time = time) {
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    elapsed = 5_000L
+                    observer.emit(PlayerEvent.Ended)
+                    runCurrent()
+
+                    val stopped = tracked.filter { it.eventType == STREAM_STOPPED }
+                    assertEquals(5.0, stopped.last().eventProperties?.get("stream_duration"))
+                    assertEquals("completed", stopped.last().eventProperties?.get("stop_reason"))
+                }
+            }
 
         @Test
-        fun `should not restart the stream while buffering and seeking`() =
+        fun `should not let a stale heartbeat overwrite the resumed Stream Stopped`() =
+            runTest {
+                var elapsed = 0L
+                val time = mockk<Time>()
+                every { time.elapsedRealtime() } answers { elapsed }
+                every { time.nowMillis() } answers { elapsed }
+
+                withBinding(time = time) {
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    elapsed = 5_000L
+                    observer.emit(PlayerEvent.Paused)
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    elapsed = 15_000L
+                    advanceTimeBy(1_000)
+                    runCurrent()
+
+                    val stopped = tracked.filter { it.eventType == STREAM_STOPPED }
+                    val firstInsertId = stopped.first().insertId
+                    val firstPlayStops = stopped.filter { it.insertId == firstInsertId }
+                    assertEquals(5.0, firstPlayStops.last().eventProperties?.get("stream_duration"))
+                    assertEquals("paused", firstPlayStops.last().eventProperties?.get("stop_reason"))
+                    assertTrue(
+                        stopped.any {
+                            it.insertId != firstInsertId &&
+                                (it.eventProperties?.get("stream_duration") as Double) > 5.0
+                        },
+                    )
+                }
+            }
+
+        @Test
+        fun `should stop the heartbeat job even if freeze snapshot fails`() =
             runTest {
                 withBinding {
                     observer.emit(PlayerEvent.Playing)
                     runCurrent()
-                    observer.emit(PlayerEvent.Buffering)
+                    observer.snapshotError = IllegalStateException("snapshot failed")
+                    observer.emit(PlayerEvent.Paused)
+                    runCurrent()
+                    val stoppedAfterPause = tracked.count { it.eventType == STREAM_STOPPED }
+                    observer.snapshotError = null
+
+                    advanceTimeBy(2_000)
+                    runCurrent()
+
+                    assertEquals(stoppedAfterPause, tracked.count { it.eventType == STREAM_STOPPED })
+                    assertTrue(stoppedAfterPause >= 1)
+
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    val started = startedEvents()
+                    assertEquals(2, started.size)
+                    assertNotEquals(started[0].insertId, started[1].insertId)
+                }
+            }
+
+        @Test
+        fun `should freeze the last heartbeat snapshot if freeze snapshot fails`() =
+            runTest {
+                withBinding {
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    observer.positionMillis = 5_000L
+                    advanceTimeBy(1_000)
+                    runCurrent()
+                    observer.snapshotError = IllegalStateException("snapshot failed")
+                    observer.emit(PlayerEvent.Paused)
+                    runCurrent()
+
+                    val stopped = tracked.filter { it.eventType == STREAM_STOPPED }
+                    assertEquals(5.0, stopped.last().eventProperties?.get("current_time"))
+                }
+            }
+
+        @Test
+        fun `should not keep stop_reason seeking on heartbeats after playback is ready`() =
+            runTest {
+                withBinding {
+                    observer.emit(PlayerEvent.Playing)
                     runCurrent()
                     observer.emit(PlayerEvent.Seeking)
                     runCurrent()
                     observer.emit(PlayerEvent.Ready)
                     runCurrent()
+                    advanceTimeBy(1_000)
+                    runCurrent()
 
-                    assertEquals(1, startedEvents().size)
+                    val afterReady =
+                        tracked.filter { it.eventType == STREAM_STOPPED }.last()
+                    assertEquals(null, afterReady.eventProperties?.get("stop_reason"))
                 }
             }
     }
@@ -158,6 +264,7 @@ class PlayerBindingTest {
                         contentProvider = { PlayerContent() },
                         playerObserverFactory = PlayerObserverFactory { _, _ -> observer },
                         streamTracker = StreamTracker(amplitude),
+                        heartbeatFactory = HeartbeatFactory(time = Time()),
                         time = Time(),
                         parentScope = this,
                     )
@@ -185,19 +292,68 @@ class PlayerBindingTest {
                         contentProvider = { PlayerContent() },
                         playerObserverFactory = PlayerObserverFactory { _, _ -> observer },
                         streamTracker = StreamTracker(amplitude),
+                        heartbeatFactory = HeartbeatFactory(time = Time()),
                         time = Time(),
                         parentScope = CoroutineScope(coroutineContext + parentJob),
                     )
                 binding.start()
                 runCurrent()
                 try {
-                    observer.emit(PlayerEvent.AdStarted(testAd()))
+                    observer.emit(
+                        PlayerEvent.AdStarted(
+                            AdContext(
+                                adGroupIndex = 0,
+                                adIndexInAdGroup = 0,
+                                positionMillis = 0L,
+                                durationMillis = 15_000L,
+                                contentPositionMillis = 1_000L,
+                                contentId = "media-1",
+                            ),
+                        ),
+                    )
                     runCurrent()
                     binding.stop()
                     parentJob.cancel()
                     runCurrent()
 
                     assertEquals(1, tracked.count { it.eventType == AD_STOPPED })
+                } finally {
+                    binding.stop()
+                    runCurrent()
+                }
+            }
+
+        @Test
+        fun `should upsert delayed Stream Stopped as unsubscribed after pause`() =
+            runTest {
+                val binding =
+                    PlayerBinding(
+                        player = mockk(relaxed = true),
+                        contentProvider = { PlayerContent() },
+                        playerObserverFactory = PlayerObserverFactory { _, _ -> observer },
+                        streamTracker = StreamTracker(amplitude),
+                        heartbeatFactory = HeartbeatFactory(time = Time()),
+                        time = Time(),
+                        parentScope = this,
+                    )
+                binding.start()
+                runCurrent()
+                try {
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    observer.emit(PlayerEvent.Paused)
+                    runCurrent()
+
+                    val paused = tracked.filter { it.eventType == STREAM_STOPPED }
+                    assertTrue(paused.isNotEmpty())
+                    assertEquals("paused", paused.last().eventProperties?.get("stop_reason"))
+                    val insertId = paused.last().insertId
+
+                    binding.stop()
+                    runCurrent()
+
+                    val samePlay = tracked.filter { it.eventType == STREAM_STOPPED && it.insertId == insertId }
+                    assertEquals("unsubscribed", samePlay.last().eventProperties?.get("stop_reason"))
                 } finally {
                     binding.stop()
                     runCurrent()
@@ -247,6 +403,89 @@ class PlayerBindingTest {
             }
 
         @Test
+        fun `should not upsert content Stream Stopped as paused during an ad`() =
+            runTest {
+                val player = mockk<Player>(relaxed = true)
+                every { player.isPlaying } returns true
+                withBinding(player) {
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    observer.emit(PlayerEvent.AdStarted(testAd()))
+                    runCurrent()
+                    val stoppedBeforePause = tracked.count { it.eventType == STREAM_STOPPED }
+                    observer.emit(PlayerEvent.Paused)
+                    runCurrent()
+
+                    assertEquals(stoppedBeforePause, tracked.count { it.eventType == STREAM_STOPPED })
+                    assertTrue(
+                        tracked.none {
+                            it.eventType == STREAM_STOPPED &&
+                                it.eventProperties?.get("stop_reason") == "paused"
+                        },
+                    )
+                }
+            }
+
+        @Test
+        fun `should finish a suspended content segment when an ad ends paused`() =
+            runTest {
+                val player = mockk<Player>(relaxed = true)
+                every { player.isPlaying } returns true
+                withBinding(player) {
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    observer.emit(PlayerEvent.AdStarted(testAd()))
+                    runCurrent()
+                    observer.emit(PlayerEvent.Paused)
+                    runCurrent()
+                    every { player.isPlaying } returns false
+                    observer.emit(PlayerEvent.AdStopped(testAd(), completed = true))
+                    runCurrent()
+
+                    val firstStart = startedEvents().single()
+                    val pausedStop =
+                        tracked
+                            .filter { it.eventType == STREAM_STOPPED }
+                            .last()
+                    assertEquals("paused", pausedStop.eventProperties?.get("stop_reason"))
+
+                    every { player.isPlaying } returns true
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+
+                    val starts = startedEvents()
+                    assertEquals(2, starts.size)
+                    assertNotEquals(firstStart.insertId, starts.last().insertId)
+                    assertEquals(
+                        firstStart.eventProperties?.get(STREAM_SESSION_ID),
+                        starts.last().eventProperties?.get(STREAM_SESSION_ID),
+                    )
+                }
+            }
+
+        @Test
+        fun `should finish the ad and suspended content when playback ends`() =
+            runTest {
+                val player = mockk<Player>(relaxed = true)
+                every { player.isPlaying } returns true
+                withBinding(player) {
+                    observer.emit(PlayerEvent.Playing)
+                    runCurrent()
+                    observer.emit(PlayerEvent.AdStarted(testAd()))
+                    runCurrent()
+                    observer.emit(PlayerEvent.Ended)
+                    runCurrent()
+
+                    assertEquals(1, tracked.count { it.eventType == AD_STOPPED })
+                    val stopped =
+                        tracked
+                            .filter { it.eventType == STREAM_STOPPED }
+                            .last()
+                    assertEquals("completed", stopped.eventProperties?.get("stop_reason"))
+                }
+            }
+
+        @Test
         fun `should not start a new content stream after a mid-roll ad`() =
             runTest {
                 val player = mockk<Player>(relaxed = true)
@@ -264,31 +503,28 @@ class PlayerBindingTest {
             }
 
         @Test
-        fun `should start a new stream segment when an ad ends paused`() =
+        fun `should not count ad time toward content stream duration`() =
             runTest {
+                var elapsed = 0L
+                val time = mockk<Time>()
+                every { time.elapsedRealtime() } answers { elapsed }
+                every { time.nowMillis() } answers { elapsed }
                 val player = mockk<Player>(relaxed = true)
                 every { player.isPlaying } returns true
-                withBinding(player) {
+                withBinding(player, time) {
                     observer.emit(PlayerEvent.Playing)
                     runCurrent()
+                    elapsed = 5_000L
                     observer.emit(PlayerEvent.AdStarted(testAd()))
                     runCurrent()
-                    observer.emit(PlayerEvent.Paused)
-                    runCurrent()
-                    every { player.isPlaying } returns false
+                    elapsed = 15_000L
                     observer.emit(PlayerEvent.AdStopped(testAd(), completed = true))
                     runCurrent()
-                    every { player.isPlaying } returns true
-                    observer.emit(PlayerEvent.Playing)
+                    observer.emit(PlayerEvent.Ended)
                     runCurrent()
 
-                    val started = startedEvents()
-                    assertEquals(2, started.size)
-                    assertNotEquals(started[0].insertId, started[1].insertId)
-                    assertEquals(
-                        started[0].eventProperties?.get(STREAM_SESSION_ID),
-                        started[1].eventProperties?.get(STREAM_SESSION_ID),
-                    )
+                    val stopped = tracked.filter { it.eventType == STREAM_STOPPED }
+                    assertEquals(5.0, stopped.last().eventProperties?.get("stream_duration"))
                 }
             }
 
@@ -345,6 +581,7 @@ class PlayerBindingTest {
 
     private fun TestScope.withBinding(
         player: Player = mockk(relaxed = true),
+        time: Time = Time(),
         contentProvider: (MediaItem?) -> PlayerContent = { PlayerContent() },
         block: () -> Unit,
     ) {
@@ -354,7 +591,8 @@ class PlayerBindingTest {
                 contentProvider = contentProvider,
                 playerObserverFactory = PlayerObserverFactory { _, _ -> observer },
                 streamTracker = StreamTracker(amplitude),
-                time = Time(),
+                heartbeatFactory = HeartbeatFactory(time = time),
+                time = time,
                 parentScope = this,
             )
         binding.start()

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/TestPlayerObserver.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/TestPlayerObserver.kt
@@ -16,12 +16,17 @@ internal class TestPlayerObserver : PlayerObserver {
         check(events.tryEmit(event))
     }
 
-    override suspend fun snapshot(): PlayerMediaSnapshot =
-        PlayerMediaSnapshot(
-            positionMillis = POSITION_MILLIS,
+    var snapshotError: Throwable? = null
+    var positionMillis: Long = POSITION_MILLIS
+
+    override suspend fun snapshot(): PlayerMediaSnapshot {
+        snapshotError?.let { throw it }
+        return PlayerMediaSnapshot(
+            positionMillis = positionMillis,
             durationMillis = DURATION_MILLIS,
             mediaType = MediaType.VIDEO,
         )
+    }
 
     private companion object {
         const val EVENT_BUFFER_CAPACITY = 16


### PR DESCRIPTION
### Describe what this PR is addressing
Upsert delayed Stream Stopped events while content is playing so a crash still leaves a last-write-wins stop on the server.

Stacked on [#492](https://github.com/amplitude/Amplitude-Kotlin/pull/492).

### Describe the solution
Each content segment owns a `Heartbeat` ticker:
* Upserts Stream Stopped on a fixed interval under a stable insert id
* Remembers the latest snapshot so a failed freeze still uses live position metadata
* `cancelAndJoin` waits for an in-flight send; `stop()` sends one final upsert after freeze

### Steps to verify the change
1. `./gradlew :streaming-analytics-android:test --tests com.amplitude.android.streaming.internal.player.HeartbeatTest`
2. `./gradlew :streaming-analytics-android:test --tests com.amplitude.android.streaming.internal.player.PlayerBindingTest`
3. `./gradlew build -x test test ktlintCheck apiCheck`

### Useful links and documentation (optional)
* [#492](https://github.com/amplitude/Amplitude-Kotlin/pull/492)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how Stream Stopped events are emitted (repeated upserts and new insert-id rules), which affects streaming analytics semantics; mitigated by broad tests and defensive freeze/heartbeat teardown.
> 
> **Overview**
> Adds a **periodic heartbeat** while content is playing so **Stream Stopped** is upserted on a fixed interval under a stable **`stoppedInsertId`**, giving last-write-wins stop metadata if the app crashes before a normal finish.
> 
> Each play segment now owns **`playId`**, start position, and a mutable **snapshot** that heartbeats refresh; finishing a segment **freezes** watch duration and snapshot (with fallbacks when snapshot reads fail), then **`heartbeat.stop()`** sends a final upsert. Heartbeats are **cancelled during ads** (content suspended) and **restarted on resume**; pause keeps the last segment in **Idle** so teardown can upsert **`untracked`**. **PlayerBinding** paths for pause, ads, seeking/buffering, and binding stop were updated to route stops through **`sendStreamStopped`** instead of only emitting a single terminal event.
> 
> New **`HeartbeatTest`**, **`PlayerBindingInsertIdTest`**, and expanded **`PlayerBindingTest`** cover interval sends, insert-id rotation across pause/play, stale heartbeat isolation, and ad duration exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8e5af409e9370f0c5142a5021bb01fbcc449c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->