### PR TITLE
fix: Streaming - Weak Player

### DIFF
--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/Media3PlayerObserver.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/Media3PlayerObserver.kt
@@ -23,17 +23,19 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.lang.ref.WeakReference
 import kotlin.time.Duration.Companion.milliseconds
 
 private const val BUFFERING_DEBOUNCE_MILLIS = 500L
 private const val EVENT_BUFFER_CAPACITY = 64
 
 internal class Media3PlayerObserver(
-    private val player: Player,
+    player: Player,
     private val scope: CoroutineScope,
     private val playerDispatcher: CoroutineDispatcher = player.createPlayerDispatcher(),
 ) : Player.Listener,
     PlayerObserver {
+    private val playerReference = WeakReference(player)
     private val _eventFlow =
         MutableSharedFlow<PlayerEvent>(extraBufferCapacity = EVENT_BUFFER_CAPACITY)
     override val eventFlow: SharedFlow<PlayerEvent> = _eventFlow.asSharedFlow()
@@ -41,6 +43,11 @@ internal class Media3PlayerObserver(
     private var bufferingJob: Job? = null
     private var observing = false
     private var activeAd: AdContext? = null
+    private var lastSnapshot =
+        PlayerMediaSnapshot(
+            positionMillis = 0L,
+            mediaType = MediaType.VIDEO,
+        )
 
     init {
         scope.launch {
@@ -61,6 +68,7 @@ internal class Media3PlayerObserver(
 
     override suspend fun snapshot(): PlayerMediaSnapshot =
         withContext(playerDispatcher) {
+            val player = playerReference.get() ?: return@withContext lastSnapshot
             val item = player.currentMediaItem
             val metadata = item?.mediaMetadata
             PlayerMediaSnapshot(
@@ -70,10 +78,11 @@ internal class Media3PlayerObserver(
                 mediaId = item?.mediaId?.takeIf { it.isNotEmpty() },
                 title = metadata?.title?.toString() ?: metadata?.displayTitle?.toString(),
                 mediaType = player.mediaType(),
-            )
+            ).also { lastSnapshot = it }
         }
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {
+        val player = playerReference.get() ?: return
         if (isPlaying) {
             emit(PlayerEvent.Playing)
         } else if (player.playWhenReady && player.playbackState == Player.STATE_READY) {
@@ -87,6 +96,7 @@ internal class Media3PlayerObserver(
         playWhenReady: Boolean,
         reason: Int,
     ) {
+        val player = playerReference.get() ?: return
         if (!playWhenReady && player.playbackState != Player.STATE_ENDED) {
             cancelBuffering()
             emit(PlayerEvent.Paused)
@@ -94,6 +104,7 @@ internal class Media3PlayerObserver(
     }
 
     override fun onPlaybackStateChanged(playbackState: Int) {
+        val player = playerReference.get() ?: return
         when (playbackState) {
             Player.STATE_BUFFERING -> startBufferingDebounce()
             Player.STATE_READY -> {
@@ -163,6 +174,7 @@ internal class Media3PlayerObserver(
     }
 
     internal fun detectAdTransition() {
+        val player = playerReference.get() ?: return
         if (player.playbackState == Player.STATE_ENDED) {
             if (activeAd != null) {
                 finishAdForTransition(
@@ -173,7 +185,7 @@ internal class Media3PlayerObserver(
             return
         }
         if (player.isPlayingAd) {
-            val current = adContextFromPlayer()
+            val current = adContextFromPlayer(player)
             val previous = activeAd
             if (previous != null && !previous.isSameAdAs(current)) {
                 finishAdForTransition(completed = false)
@@ -205,6 +217,7 @@ internal class Media3PlayerObserver(
         withContext(playerDispatcher) {
             mutex.withLock {
                 if (observing) return@withLock
+                val player = playerReference.get() ?: return@withLock
                 observing = true
                 player.addListener(this@Media3PlayerObserver)
                 if (player.isPlaying) {
@@ -221,7 +234,7 @@ internal class Media3PlayerObserver(
             mutex.withLock {
                 if (observing) {
                     observing = false
-                    player.removeListener(this@Media3PlayerObserver)
+                    playerReference.get()?.removeListener(this@Media3PlayerObserver)
                 }
                 activeAd = null
                 cancelBuffering()
@@ -234,6 +247,7 @@ internal class Media3PlayerObserver(
     }
 
     private fun startBufferingDebounce() {
+        val player = playerReference.get() ?: return
         if (!player.playWhenReady || bufferingJob?.isActive == true) return
         bufferingJob =
             scope.launch {
@@ -247,7 +261,7 @@ internal class Media3PlayerObserver(
         bufferingJob = null
     }
 
-    private fun adContextFromPlayer(): AdContext =
+    private fun adContextFromPlayer(player: Player): AdContext =
         AdContext(
             adGroupIndex = player.currentAdGroupIndex,
             adIndexInAdGroup = player.currentAdIndexInAdGroup,

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerBinding.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerBinding.kt
@@ -13,25 +13,32 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.lang.ref.WeakReference
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
+
+private const val ORPHAN_CHECK_MILLIS = 1_000L
 
 /**
  * Turns player events into stream sessions, Stream Started, and ad events.
  */
 @OptIn(AmplitudePreview::class)
 internal class PlayerBinding internal constructor(
-    val player: Player,
+    player: Player,
     private val contentProvider: PlayerContentProvider,
     playerObserverFactory: PlayerObserverFactory,
     private val streamTracker: StreamTracker,
     private val heartbeatFactory: HeartbeatFactory,
     private val time: Time,
     parentScope: CoroutineScope,
+    private val onStopped: (PlayerBinding) -> Unit = {},
 ) {
+    private val playerReference = WeakReference(player)
     private val scope =
         CoroutineScope(
             parentScope.coroutineContext +
@@ -54,7 +61,7 @@ internal class PlayerBinding internal constructor(
 
     fun start() {
         if (eventJob != null) return
-        options = resolveOptions(player.currentMediaItem)
+        options = resolveOptions(playerReference.get()?.currentMediaItem)
         eventJob =
             scope.launch {
                 observer.eventFlow.collect { event ->
@@ -65,6 +72,12 @@ internal class PlayerBinding internal constructor(
                     }
                 }
             }
+        scope.launch {
+            while (!stopped.get()) {
+                delay(ORPHAN_CHECK_MILLIS.milliseconds)
+                if (isOrphaned()) stop()
+            }
+        }
     }
 
     fun stop() {
@@ -81,11 +94,16 @@ internal class PlayerBinding internal constructor(
             } finally {
                 this@PlayerBinding.scope.cancel()
                 cleanupScope.cancel()
+                onStopped(this@PlayerBinding)
             }
         }
     }
 
     private suspend fun handlePlayerEvent(event: PlayerEvent) {
+        if (isOrphaned()) {
+            stop()
+            return
+        }
         when (event) {
             PlayerEvent.Playing -> onPlaying()
             PlayerEvent.Paused -> onPaused()
@@ -105,7 +123,7 @@ internal class PlayerBinding internal constructor(
     }
 
     private suspend fun onPlaying() {
-        if (player.isPlayingAd || playback is PlaybackState.Ad) return
+        if (playerReference.get()?.isPlayingAd == true || playback is PlaybackState.Ad) return
         when (val state = playback) {
             is PlaybackState.Content -> {
                 state.segment.resumeWatch()
@@ -288,7 +306,7 @@ internal class PlayerBinding internal constructor(
         val content = state.content
         if (content == null) {
             playback = PlaybackState.Idle(state.viewSessionId)
-            if (player.isPlaying) startContent(state.viewSessionId)
+            if (playerReference.get()?.isPlaying == true) startContent(state.viewSessionId)
             return
         }
         if (state.paused) {
@@ -297,7 +315,7 @@ internal class PlayerBinding internal constructor(
             return
         }
         playback = content
-        if (player.isPlaying) resumeContent(content)
+        if (playerReference.get()?.isPlaying == true) resumeContent(content)
     }
 
     private fun resumeContent(state: PlaybackState.Suspended) {
@@ -405,7 +423,8 @@ internal class PlayerBinding internal constructor(
         streamTracker.trackStreamStopped(
             options = segment.options,
             snapshot =
-                if (segment.frozen) {
+                if (segment.frozen || isOrphaned()) {
+                    if (!segment.frozen) segment.freeze(segment.snapshot)
                     segment.snapshot
                 } else {
                     snapshot().also { segment.updateSnapshot(it) }
@@ -422,6 +441,10 @@ internal class PlayerBinding internal constructor(
     }
 
     private suspend fun snapshot(): PlayerMediaSnapshot = observer.snapshot()
+
+    internal fun isBoundTo(player: Player): Boolean = playerReference.get() === player
+
+    internal fun isOrphaned(): Boolean = playerReference.get() == null
 
     private fun newViewSessionId(): String = UUID.randomUUID().toString()
 

--- a/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingFactory.kt
+++ b/streaming-analytics-android/src/main/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingFactory.kt
@@ -10,7 +10,6 @@ import com.amplitude.android.streaming.internal.util.Time
 import com.amplitude.android.streaming.internal.util.time
 import com.amplitude.core.AmplitudePreview
 import kotlinx.coroutines.CoroutineScope
-import java.util.IdentityHashMap
 
 internal val StreamingDiGraph.playerBindingFactory: PlayerBindingFactory by DiGraph.singleton {
     PlayerBindingFactory(
@@ -31,35 +30,46 @@ internal class PlayerBindingFactory(
     private val scope: CoroutineScope,
 ) {
     private val lock = Any()
-    private val bindingRegistry = IdentityHashMap<Player, PlayerBinding>()
+    private val bindingRegistry = mutableListOf<PlayerBinding>()
 
     fun getOrCreate(
         player: Player,
         contentProvider: PlayerContentProvider,
     ): PlayerBinding {
+        val orphaned: List<PlayerBinding>
+        val binding: PlayerBinding
         synchronized(lock) {
-            bindingRegistry[player]?.let { return it }
-            val binding =
-                PlayerBinding(
-                    player = player,
-                    contentProvider = contentProvider,
-                    playerObserverFactory = playerObserverFactory,
-                    streamTracker = streamTracker,
-                    heartbeatFactory = heartbeatFactory,
-                    time = time,
-                    parentScope = scope,
-                )
-            bindingRegistry[player] = binding
-            binding.start()
-            return binding
+            orphaned = bindingRegistry.filter { it.isOrphaned() }
+            bindingRegistry.removeAll(orphaned.toSet())
+            binding =
+                bindingRegistry.firstOrNull { it.isBoundTo(player) }
+                    ?: PlayerBinding(
+                        player = player,
+                        contentProvider = contentProvider,
+                        playerObserverFactory = playerObserverFactory,
+                        streamTracker = streamTracker,
+                        heartbeatFactory = heartbeatFactory,
+                        time = time,
+                        parentScope = scope,
+                        onStopped = ::unregister,
+                    ).also { bindingRegistry.add(it) }
         }
+        orphaned.forEach { it.stop() }
+        binding.start()
+        return binding
     }
 
     fun detachAll() {
         synchronized(lock) {
-            val toFlush = bindingRegistry.values.toList()
+            val toFlush = bindingRegistry.toList()
             bindingRegistry.clear()
             toFlush
         }.forEach { it.stop() }
+    }
+
+    private fun unregister(binding: PlayerBinding) {
+        synchronized(lock) {
+            bindingRegistry.remove(binding)
+        }
     }
 }

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/Media3PlayerObserverTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/Media3PlayerObserverTest.kt
@@ -9,6 +9,8 @@ import com.google.common.collect.ImmutableList
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
@@ -18,10 +20,41 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
+import java.lang.ref.WeakReference
+import java.lang.reflect.Proxy
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class Media3PlayerObserverTest {
+    @Test
+    fun `should not retain the player`() =
+        runTest {
+            val (observer, playerReference) =
+                observerWithAbandonedPlayer(
+                    backgroundScope,
+                    UnconfinedTestDispatcher(testScheduler),
+                )
+
+            awaitCollected(playerReference)
+
+            assertTrue(observer.eventFlow.replayCache.isEmpty())
+        }
+
+    @Test
+    fun `should return the last snapshot after the player is collected`() =
+        runTest {
+            val (observer, playerReference) =
+                observerWithAbandonedPlayer(
+                    backgroundScope,
+                    UnconfinedTestDispatcher(testScheduler),
+                )
+
+            awaitCollected(playerReference)
+
+            assertEquals(0L, observer.snapshot().positionMillis)
+        }
+
     @Test
     fun `should add the listener once while subscribers are present and remove it when they leave`() =
         runTest {
@@ -385,6 +418,31 @@ class Media3PlayerObserverTest {
         }
         runCurrent()
         return observer to events
+    }
+
+    private fun observerWithAbandonedPlayer(
+        scope: CoroutineScope,
+        dispatcher: CoroutineDispatcher,
+    ): Pair<Media3PlayerObserver, WeakReference<Player>> {
+        val player =
+            Proxy.newProxyInstance(
+                Player::class.java.classLoader,
+                arrayOf(Player::class.java),
+            ) { _, _, _ -> null } as Player
+        return Media3PlayerObserver(
+            player = player,
+            scope = scope,
+            playerDispatcher = dispatcher,
+        ) to WeakReference(player)
+    }
+
+    private fun awaitCollected(reference: WeakReference<*>) {
+        repeat(100) {
+            if (reference.get() == null) return
+            System.gc()
+            Thread.sleep(10)
+        }
+        fail<Unit>("Player was not garbage collected")
     }
 }
 

--- a/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingFactoryTest.kt
+++ b/streaming-analytics-android/src/test/kotlin/com/amplitude/android/streaming/internal/player/PlayerBindingFactoryTest.kt
@@ -1,0 +1,130 @@
+package com.amplitude.android.streaming.internal.player
+
+import androidx.media3.common.Player
+import com.amplitude.android.streaming.PlayerContent
+import com.amplitude.android.streaming.internal.StreamTracker
+import com.amplitude.android.streaming.internal.util.Time
+import com.amplitude.core.Amplitude
+import com.amplitude.core.AmplitudePreview
+import com.amplitude.core.events.BaseEvent
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import java.lang.ref.WeakReference
+import java.lang.reflect.Proxy
+
+@OptIn(AmplitudePreview::class, ExperimentalCoroutinesApi::class)
+class PlayerBindingFactoryTest {
+    @Test
+    fun `getOrCreate stops bindings whose player was collected`() =
+        runTest {
+            val amplitude = mockk<Amplitude>(relaxed = true)
+            val observers = mutableListOf<TestPlayerObserver>()
+            val factory =
+                PlayerBindingFactory(
+                    playerObserverFactory =
+                        PlayerObserverFactory { _, _ ->
+                            TestPlayerObserver().also { observers.add(it) }
+                        },
+                    streamTracker = StreamTracker(amplitude),
+                    heartbeatFactory = HeartbeatFactory(Time()),
+                    time = Time(),
+                    scope = backgroundScope,
+                )
+            val (abandonedBinding, playerReference) = factory.createAbandonedBinding()
+            runCurrent()
+
+            awaitCollected(playerReference)
+            factory.getOrCreate(playerProxy()) { PlayerContent() }
+            runCurrent()
+            observers.first().emit(PlayerEvent.Playing)
+            runCurrent()
+
+            assertTrue(abandonedBinding.isOrphaned())
+            verify(exactly = 0) { amplitude.track(any<BaseEvent>(), any(), any()) }
+        }
+
+    @Test
+    fun `stops a binding when its player is collected without another getOrCreate`() =
+        runTest {
+            val events = mutableListOf<BaseEvent>()
+            val amplitude =
+                mockk<Amplitude>(relaxed = true).also { amplitude ->
+                    every { amplitude.track(any<BaseEvent>(), any(), any()) } answers {
+                        events.add(firstArg())
+                        amplitude
+                    }
+                    every { amplitude.track(any<String>(), any(), any()) } answers {
+                        events.add(
+                            BaseEvent().apply {
+                                eventType = firstArg()
+                                eventProperties = secondArg<Map<String, Any?>?>()?.toMutableMap()
+                            },
+                        )
+                        amplitude
+                    }
+                }
+            val observers = mutableListOf<TestPlayerObserver>()
+            val factory =
+                PlayerBindingFactory(
+                    playerObserverFactory =
+                        PlayerObserverFactory { _, _ ->
+                            TestPlayerObserver().also { observers.add(it) }
+                        },
+                    streamTracker = StreamTracker(amplitude),
+                    heartbeatFactory = HeartbeatFactory(Time()),
+                    time = Time(),
+                    scope = this,
+                )
+            val playerReference = factory.createAbandonedBinding().second
+            runCurrent()
+            observers.first().emit(PlayerEvent.Playing)
+            runCurrent()
+
+            awaitCollected(playerReference)
+            advanceTimeBy(1_000)
+            runCurrent()
+
+            assertTrue(events.any { it.eventType == "[Amplitude] Stream Started" })
+            assertTrue(
+                events.any {
+                    it.eventType == "[Amplitude] Stream Stopped" &&
+                        it.eventProperties?.get("stop_reason") == "unsubscribed"
+                },
+            )
+        }
+
+    private fun PlayerBindingFactory.createAbandonedBinding(): Pair<PlayerBinding, WeakReference<Player>> {
+        val player = playerProxy()
+        return getOrCreate(player) { PlayerContent() } to WeakReference(player)
+    }
+
+    private fun playerProxy(): Player =
+        Proxy.newProxyInstance(
+            Player::class.java.classLoader,
+            arrayOf(Player::class.java),
+        ) { _, method, _ ->
+            when (method.returnType) {
+                java.lang.Boolean.TYPE -> false
+                java.lang.Integer.TYPE -> 0
+                java.lang.Long.TYPE -> 0L
+                else -> null
+            }
+        } as Player
+
+    private fun awaitCollected(reference: WeakReference<*>) {
+        repeat(100) {
+            if (reference.get() == null) return
+            System.gc()
+            Thread.sleep(10)
+        }
+        fail<Unit>("Player was not garbage collected")
+    }
+}


### PR DESCRIPTION
### Describe what this PR is addressing
`PlayerBinding` and `Media3PlayerObserver` held Media3 `Player` instances strongly, so a released player could not be collected. After GC, a live session could keep heartbeating without a final Stream Stopped.

Stacked on [#493](https://github.com/amplitude/Amplitude-Kotlin/pull/493).

### Describe the solution
Hold the player in a `WeakReference` in the observer, binding, and registry:
* Orphaned bindings `stop()` as `unsubscribed` within about one second, using the last snapshot instead of throwing
* `stop()` unregisters the binding; `getOrCreate()` still sweeps leftovers

### Steps to verify the change
1. `./gradlew :streaming-analytics-android:testDebugUnitTest --tests '*Media3PlayerObserverTest'`
2. `./gradlew :streaming-analytics-android:testDebugUnitTest --tests '*PlayerBindingFactoryTest'`
3. `./gradlew :streaming-analytics-android:testDebugUnitTest --tests '*PlayerBindingTest'`

### Useful links and documentation (optional)
* [#493](https://github.com/amplitude/Amplitude-Kotlin/pull/493)

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle and analytics teardown for active streams; mis-detecting orphans could stop sessions early or leave stale bindings, but the scope is isolated to player binding/observer code.
> 
> **Overview**
> Fixes a leak where **`PlayerBinding`** and **`Media3PlayerObserver`** kept a strong reference to Media3 **`Player`**, so released players could not be GC’d and analytics could keep heartbeating without emitting **Stream Stopped**.
> 
> **`Media3PlayerObserver`** now stores the player in a **`WeakReference`**, caches **`lastSnapshot`**, and no-ops listener paths when the player is gone; **`snapshot()`** returns the last snapshot instead of touching a collected player.
> 
> **`PlayerBinding`** uses the same weak hold, polls every ~1s for **`isOrphaned()`**, stops with **`StopReason.UNTRACKED`**, and uses the frozen/last snapshot when sending **Stream Stopped** after orphaning. **`PlayerBindingFactory`** tracks bindings in a list (not a player-keyed map), sweeps orphaned entries on **`getOrCreate`**, and unregisters via **`onStopped`** when a binding stops.
> 
> Unit tests cover non-retention of the player, last-snapshot behavior, orphan cleanup on **`getOrCreate`**, and automatic stop with **`stop_reason: untracked`** after GC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd4f60d3eb383e349d37c643a3e1684f64b55ad1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->