### PR TITLE
feat: add core interface change signals (SDKA-10)

### DIFF
--- a/analytics-core/api/analytics-core.api
+++ b/analytics-core/api/analytics-core.api
@@ -842,6 +842,14 @@ public abstract interface class com/amplitude/core/platform/EventPlugin : com/am
 	public fun track (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;
 }
 
+public abstract interface class com/amplitude/core/platform/InterfaceChangeSignal : com/amplitude/core/platform/Signal {
+	public abstract fun getTimestampMillis ()J
+}
+
+public abstract interface class com/amplitude/core/platform/InterfaceSignalProvider : com/amplitude/core/platform/Plugin, com/amplitude/core/platform/SignalProvider {
+	public abstract fun isProviding ()Z
+}
+
 public abstract class com/amplitude/core/platform/ObservePlugin : com/amplitude/core/platform/Plugin {
 	public fun <init> ()V
 	public final fun execute (Lcom/amplitude/core/events/BaseEvent;)Lcom/amplitude/core/events/BaseEvent;

--- a/analytics-core/src/main/java/com/amplitude/core/platform/InterfaceSignal.kt
+++ b/analytics-core/src/main/java/com/amplitude/core/platform/InterfaceSignal.kt
@@ -1,0 +1,28 @@
+package com.amplitude.core.platform
+
+import com.amplitude.core.RestrictedAmplitudeFeature
+
+/**
+ * A timestamped interface change observed by an [InterfaceSignalProvider].
+ *
+ * [timestampMillis] uses Unix epoch milliseconds so consumers can compare it with interaction
+ * timestamps. The signal is evidence that rendering changed, not proof that a specific interaction
+ * caused the change.
+ */
+@RestrictedAmplitudeFeature
+public interface InterfaceChangeSignal : Signal {
+    /** Unix epoch time at which the interface change was observed. */
+    public val timestampMillis: Long
+}
+
+/**
+ * An Amplitude plugin that can report interface changes while [isProviding] is true.
+ *
+ * Availability is explicit because an absent signal can mean either that the interface did not
+ * change or that observation is currently unavailable.
+ */
+@RestrictedAmplitudeFeature
+public interface InterfaceSignalProvider : Plugin, SignalProvider {
+    /** Whether this plugin is currently able to emit [InterfaceChangeSignal]s. */
+    public val isProviding: Boolean
+}

--- a/analytics-core/src/test/kotlin/com/amplitude/core/platform/SignalProviderTest.kt
+++ b/analytics-core/src/test/kotlin/com/amplitude/core/platform/SignalProviderTest.kt
@@ -2,7 +2,7 @@ package com.amplitude.core.platform
 
 import com.amplitude.core.Amplitude
 import com.amplitude.core.Configuration
-import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.RestrictedAmplitudeFeature
 import com.amplitude.core.utils.FakeAmplitude
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collectLatest
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test
 import java.util.Date
 
 @ExperimentalCoroutinesApi
+@OptIn(RestrictedAmplitudeFeature::class)
 class SignalProviderTest {
     private val testDispatcher = StandardTestDispatcher()
     private val amplitude =
@@ -72,6 +73,25 @@ class SignalProviderTest {
 
             // Clean up
             collectionJob.cancel()
+        }
+
+    @Test
+    fun `interface signal provider is discoverable while registered`() =
+        runTest(testDispatcher) {
+            amplitude.isBuilt.await()
+
+            amplitude.add(signalProviderPlugin)
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(signalProviderPlugin),
+                amplitude.plugins(InterfaceSignalProvider::class.java),
+            )
+
+            amplitude.remove(signalProviderPlugin)
+            advanceUntilIdle()
+
+            assertTrue(amplitude.plugins(InterfaceSignalProvider::class.java).isEmpty())
         }
 
     @Test
@@ -202,13 +222,18 @@ class SignalProviderTest {
             collectionJob.cancel()
         }
 
-    private class TestSignal(val timestamp: Date) : Signal
+    private class TestSignal(val timestamp: Date) : InterfaceChangeSignal {
+        override val timestampMillis: Long
+            get() = timestamp.time
+    }
 
     /**
      * Test plugin that extends SignalProvider to emit TestSignal
      */
-    private class TestSignalProviderPlugin : SignalProvider, EventPlugin {
+    private class TestSignalProviderPlugin : InterfaceSignalProvider {
         override var active: Boolean = false
+        override val isProviding: Boolean
+            get() = active
         override val type: Plugin.Type = Plugin.Type.Before
         override lateinit var amplitude: Amplitude
 
@@ -219,8 +244,6 @@ class SignalProviderTest {
             super.setup(amplitude)
             activate()
         }
-
-        override fun track(payload: BaseEvent): BaseEvent = payload
 
         override fun teardown() {
             deactivate()

--- a/android/api/android.api
+++ b/android/api/android.api
@@ -862,13 +862,14 @@ public final class com/amplitude/android/plugins/AndroidNetworkConnectivityCheck
 	public final fun getDisabled ()Ljava/lang/Void;
 }
 
-public final class com/amplitude/android/signals/UiChangeSignal : com/amplitude/core/platform/Signal {
+public final class com/amplitude/android/signals/UiChangeSignal : com/amplitude/core/platform/InterfaceChangeSignal {
 	public fun <init> (Ljava/util/Date;)V
 	public final fun component1 ()Ljava/util/Date;
 	public final fun copy (Ljava/util/Date;)Lcom/amplitude/android/signals/UiChangeSignal;
 	public static synthetic fun copy$default (Lcom/amplitude/android/signals/UiChangeSignal;Ljava/util/Date;ILjava/lang/Object;)Lcom/amplitude/android/signals/UiChangeSignal;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTimestamp ()Ljava/util/Date;
+	public fun getTimestampMillis ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1114,4 +1115,3 @@ public final class com/amplitude/common/android/LogcatLogger : com/amplitude/com
 public final class com/amplitude/common/android/LogcatLogger$Companion {
 	public final fun getLogger ()Lcom/amplitude/common/android/LogcatLogger;
 }
-

--- a/android/src/main/java/com/amplitude/android/FrustrationInteractionsDetector.kt
+++ b/android/src/main/java/com/amplitude/android/FrustrationInteractionsDetector.kt
@@ -23,12 +23,10 @@ import com.amplitude.core.platform.InterfaceSignalProvider
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import java.util.ArrayDeque
-import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Core frustration interactions detector that handles rage click and dead click detection.
@@ -61,14 +59,13 @@ public class FrustrationInteractionsDetector(
     // Convert pt to pixels for density-independent behavior
     private val rageClickDistanceThresholdPx: Float = RAGE_CLICK_DISTANCE_THRESHOLD * density
 
-    @Volatile
     private var started = false
-    private val stateMutex = Mutex()
+    private val stateLock = Any()
     private var lifecycleGeneration = 0L
     private var uiChangeCollectionJob: Job? = null
 
     // Rage click detection
-    private val pendingRageClicks = ConcurrentHashMap<String, RageClickSession>()
+    private val pendingRageClicks = mutableMapOf<String, RageClickSession>()
 
     // Dead click detection
     private val pendingDeadClicks = mutableMapOf<String, DeadClickSession>()
@@ -79,44 +76,52 @@ public class FrustrationInteractionsDetector(
      * This is required for proper dead click detection.
      */
     public fun start() {
-        amplitude.amplitudeScope.launch(
-            amplitude.amplitudeDispatcher,
-            start = CoroutineStart.UNDISPATCHED,
-        ) {
-            val didStart =
-                stateMutex.withLock {
-                    if (started) return@withLock false
-
+        val startGeneration =
+            synchronized(stateLock) {
+                if (started) return
+                lifecycleGeneration
+            }
+        val collectionJob = startUiChangeCollection(startGeneration)
+        val didStart =
+            synchronized(stateLock) {
+                if (started || lifecycleGeneration != startGeneration || !collectionJob.isActive) {
+                    false
+                } else {
                     started = true
-                    startUiChangeCollection()
+                    uiChangeCollectionJob = collectionJob
                     true
                 }
-            if (didStart) {
-                logger.debug("FrustrationInteractionsDetector started - UI change collection is now active")
             }
+
+        if (!didStart) {
+            collectionJob.cancel()
+            return
         }
+
+        logger.debug("FrustrationInteractionsDetector started - UI change collection is now active")
     }
 
     public fun stop() {
-        amplitude.amplitudeScope.launch(
-            amplitude.amplitudeDispatcher,
-            start = CoroutineStart.UNDISPATCHED,
-        ) {
-            val jobsToCancel =
-                stateMutex.withLock {
-                    val pendingJobs = pendingDeadClicks.values.mapNotNull { it.job }
-                    started = false
-                    lifecycleGeneration++
-                    pendingDeadClicks.clear()
-                    recentUiChangeTimes.clear()
-                    pendingRageClicks.clear()
-                    uiChangeCollectionJob?.cancel()
-                    uiChangeCollectionJob = null
-                    pendingJobs
-                }
-            jobsToCancel.forEach { it.cancel() }
-            logger.debug("FrustrationInteractionsDetector stopped - UI change collection is now inactive")
-        }
+        val jobsToCancel =
+            synchronized(stateLock) {
+                val pendingJobs =
+                    buildList {
+                        addAll(pendingDeadClicks.values.mapNotNull { it.job })
+                        uiChangeCollectionJob?.let(::add)
+                    }
+
+                started = false
+                lifecycleGeneration++
+                pendingDeadClicks.clear()
+                recentUiChangeTimes.clear()
+                pendingRageClicks.clear()
+                uiChangeCollectionJob = null
+
+                pendingJobs
+            }
+
+        jobsToCancel.forEach { it.cancel() }
+        logger.debug("FrustrationInteractionsDetector stopped - UI change collection is now inactive")
     }
 
     /**
@@ -163,38 +168,38 @@ public class FrustrationInteractionsDetector(
     ) {
         val locationKey = generateLocationKey(clickInfo, targetInfo)
 
-        val existingSession = pendingRageClicks[locationKey]
-        if (existingSession != null) {
-            // Check if this click is within the time window
-            if (clickTime - existingSession.firstClickTime <= RAGE_CLICK_TIME_WINDOW) {
-                // Check if this click is within the distance threshold
-                if (isWithinDistanceThreshold(
+        val completedSession =
+            synchronized(stateLock) {
+                val existingSession = pendingRageClicks[locationKey]
+                if (existingSession == null ||
+                    clickTime - existingSession.firstClickTime > RAGE_CLICK_TIME_WINDOW ||
+                    !isWithinDistanceThreshold(
                         clickInfo.x,
                         clickInfo.y,
                         existingSession.firstClickX,
                         existingSession.firstClickY,
                     )
                 ) {
-                    existingSession.clickCount++
-                    existingSession.lastClickTime = clickTime
-                    existingSession.clicks.add(clickInfo.copy(timestamp = clickTime))
-
-                    // Check if we've reached the rage click threshold (4+ clicks in 1s to match iOS)
-                    if (existingSession.clickCount >= RAGE_CLICK_THRESHOLD) {
-                        trackRageClick(existingSession, target, activityName)
-                        pendingRageClicks.remove(locationKey)
-                    }
-                } else {
-                    // Click is outside distance threshold, start new session
                     startNewRageClickSession(locationKey, clickInfo, targetInfo, clickTime)
+                    null
+                } else {
+                    existingSession.apply {
+                        clickCount++
+                        lastClickTime = clickTime
+                        clicks.add(clickInfo.copy(timestamp = clickTime))
+                    }
+
+                    if (existingSession.clickCount >= RAGE_CLICK_THRESHOLD) {
+                        pendingRageClicks.remove(locationKey)
+                        existingSession
+                    } else {
+                        null
+                    }
                 }
-            } else {
-                // Click is outside time window, start new session
-                startNewRageClickSession(locationKey, clickInfo, targetInfo, clickTime)
             }
-        } else {
-            // First click in this location
-            startNewRageClickSession(locationKey, clickInfo, targetInfo, clickTime)
+
+        if (completedSession != null) {
+            trackRageClick(completedSession, target, activityName)
         }
     }
 
@@ -206,87 +211,105 @@ public class FrustrationInteractionsDetector(
         clickTime: Long,
         clickId: String,
     ) {
-        if (!started) {
+        val clickLifecycleGeneration =
+            synchronized(stateLock) {
+                lifecycleGeneration.takeIf { started }
+            }
+        if (clickLifecycleGeneration == null) {
             logger.error("Dead click detection is disabled - call start() to enable.")
             return
         }
 
+        if (!hasActiveSignalProvider()) {
+            logger.error("Dead click detection is disabled - no UI change signal provider is active.")
+            return
+        }
+
+        val deadClickSession =
+            DeadClickSession(
+                target = target,
+                activityName = activityName,
+                clickInfo = clickInfo.copy(timestamp = clickTime),
+                targetInfo = targetInfo,
+                lifecycleGeneration = clickLifecycleGeneration,
+            )
+        val job = createDeadClickJob(clickId, deadClickSession)
+        deadClickSession.job = job
+
+        var previousJob: Job? = null
+        val didRegister =
+            synchronized(stateLock) {
+                if (!started || lifecycleGeneration != clickLifecycleGeneration) {
+                    false
+                } else {
+                    deadClickSession.uiChanged =
+                        recentUiChangeTimes.any { timestampMillis ->
+                            timestampMillis >= clickTime
+                        }
+                    previousJob = pendingDeadClicks.put(clickId, deadClickSession)?.job
+                    true
+                }
+            }
+
+        if (!didRegister) {
+            job.cancel()
+            return
+        }
+
+        previousJob?.cancel()
+        job.start()
+    }
+
+    private fun createDeadClickJob(
+        clickId: String,
+        deadClickSession: DeadClickSession,
+    ): Job =
+        amplitude.amplitudeScope.launch(
+            amplitude.amplitudeDispatcher,
+            start = CoroutineStart.LAZY,
+        ) {
+            delay(DEAD_CLICK_TIMEOUT.milliseconds)
+
+            val hasActiveSignalProvider = hasActiveSignalProvider()
+            val shouldTrackDeadClick =
+                synchronized(stateLock) {
+                    val isCurrentSession = pendingDeadClicks[clickId] === deadClickSession
+                    if (isCurrentSession) {
+                        pendingDeadClicks.remove(clickId)
+                    }
+                    isCurrentSession &&
+                        started &&
+                        lifecycleGeneration == deadClickSession.lifecycleGeneration &&
+                        hasActiveSignalProvider &&
+                        !deadClickSession.uiChanged
+                }
+            if (shouldTrackDeadClick) {
+                trackDeadClick(deadClickSession)
+            }
+        }
+
+    private fun startUiChangeCollection(lifecycleGeneration: Long): Job =
         amplitude.amplitudeScope.launch(
             amplitude.amplitudeDispatcher,
             start = CoroutineStart.UNDISPATCHED,
         ) {
-            stateMutex.withLock {
-                if (!started) {
-                    logger.error("Dead click detection is disabled - call start() to enable.")
-                    return@withLock
+            logger.debug("Starting UI change signal collection for dead click detection")
+            amplitude.signalFlow.collect { signal ->
+                if (signal is InterfaceChangeSignal) {
+                    recordUiChange(signal.timestampMillis, lifecycleGeneration)
                 }
-
-                if (!hasActiveSignalProvider()) {
-                    logger.error("Dead click detection is disabled - no UI change signal provider is active.")
-                    return@withLock
-                }
-
-                pendingDeadClicks[clickId]?.job?.cancel()
-
-                val deadClickSession =
-                    DeadClickSession(
-                        target = target,
-                        activityName = activityName,
-                        clickInfo = clickInfo.copy(timestamp = clickTime),
-                        targetInfo = targetInfo,
-                        lifecycleGeneration = lifecycleGeneration,
-                        uiChanged =
-                            recentUiChangeTimes.any { timestampMillis ->
-                                timestampMillis >= clickTime
-                            },
-                    )
-
-                val job =
-                    amplitude.amplitudeScope.launch(
-                        amplitude.amplitudeDispatcher,
-                        start = CoroutineStart.LAZY,
-                    ) {
-                        delay(DEAD_CLICK_TIMEOUT)
-
-                        val shouldTrackDeadClick =
-                            stateMutex.withLock {
-                                pendingDeadClicks.remove(clickId, deadClickSession) &&
-                                    started &&
-                                    lifecycleGeneration == deadClickSession.lifecycleGeneration &&
-                                    hasActiveSignalProvider() &&
-                                    !deadClickSession.uiChanged
-                            }
-                        if (shouldTrackDeadClick) {
-                            trackDeadClick(deadClickSession)
-                        }
-                    }
-
-                deadClickSession.job = job
-                pendingDeadClicks[clickId] = deadClickSession
-                job.start()
             }
         }
-    }
 
-    private fun startUiChangeCollection() {
-        uiChangeCollectionJob =
-            amplitude.amplitudeScope.launch(
-                amplitude.amplitudeDispatcher,
-                start = CoroutineStart.UNDISPATCHED,
-            ) {
-                logger.debug("Starting UI change signal collection for dead click detection")
-                amplitude.signalFlow.collectLatest { signal ->
-                    if (signal is InterfaceChangeSignal) {
-                        recordUiChange(signal.timestampMillis)
-                    }
-                }
-            }
-    }
-
-    private suspend fun recordUiChange(timestampMillis: Long) {
+    private fun recordUiChange(
+        timestampMillis: Long,
+        collectionLifecycleGeneration: Long,
+    ) {
         val didRecordChange =
-            stateMutex.withLock {
-                if (!started) return@withLock false
+            synchronized(stateLock) {
+                if (!started || lifecycleGeneration != collectionLifecycleGeneration) {
+                    return@synchronized false
+                }
 
                 if (recentUiChangeTimes.size == MAX_RECENT_UI_CHANGES) {
                     recentUiChangeTimes.removeFirst()

--- a/android/src/main/java/com/amplitude/android/FrustrationInteractionsDetector.kt
+++ b/android/src/main/java/com/amplitude/android/FrustrationInteractionsDetector.kt
@@ -17,19 +17,27 @@ import com.amplitude.android.internal.buildElementInteractedProperties
 import com.amplitude.android.signals.UiChangeSignal
 import com.amplitude.common.Logger
 import com.amplitude.core.Amplitude
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.platform.InterfaceChangeSignal
+import com.amplitude.core.platform.InterfaceSignalProvider
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import java.util.ArrayDeque
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Core frustration interactions detector that handles rage click and dead click detection.
  *
- * **Important**: Call `start()` to enable proper dead click detection. Dead clicks require
- * active subscription to UI change signals to function correctly. If `start()` is not called,
- * dead click events will not be tracked and a warning will be logged.
+ * **Important**: Call [start] to enable dead click detection. Dead clicks require an active
+ * [InterfaceSignalProvider]. [UiChangeSignal] remains a compatible signal payload, but its provider
+ * must expose current availability through [InterfaceSignalProvider].
  */
+@OptIn(RestrictedAmplitudeFeature::class)
 public class FrustrationInteractionsDetector(
     private val amplitude: Amplitude,
     private val logger: Logger,
@@ -45,6 +53,7 @@ public class FrustrationInteractionsDetector(
          */
         private const val RAGE_CLICK_DISTANCE_THRESHOLD: Float = 50f
         private const val DEAD_CLICK_TIMEOUT: Long = 3_000L // 3 seconds
+        private const val MAX_RECENT_UI_CHANGES: Int = 32
         private const val RAGE_CLICK_THRESHOLD: Int = 4
         private const val RAGE_CLICK_TIME_WINDOW: Long = 1_000L // 1 second
     }
@@ -52,31 +61,52 @@ public class FrustrationInteractionsDetector(
     // Convert pt to pixels for density-independent behavior
     private val rageClickDistanceThresholdPx: Float = RAGE_CLICK_DISTANCE_THRESHOLD * density
 
+    @Volatile
+    private var started = false
+    private val lifecycleLock = Any()
+    private val lifecycleGeneration = AtomicLong(0L)
     private var uiChangeCollectionJob: Job? = null
 
     // Rage click detection
     private val pendingRageClicks = ConcurrentHashMap<String, RageClickSession>()
 
     // Dead click detection
+    private val deadClickLock = Any()
     private val pendingDeadClicks = ConcurrentHashMap<String, DeadClickSession>()
-    private var lastUiChangeTime = 0L
+    private val recentUiChangeTimes = ArrayDeque<Long>(MAX_RECENT_UI_CHANGES)
 
     /**
      * Starts the detector and begins subscribing to UI change signals.
      * This is required for proper dead click detection.
      */
     public fun start() {
-        startUiChangeCollection()
+        synchronized(lifecycleLock) {
+            if (started) return
+
+            startUiChangeCollection()
+            started = true
+        }
         logger.debug("FrustrationInteractionsDetector started - UI change collection is now active")
     }
 
     public fun stop() {
-        lastUiChangeTime = 0L
-        uiChangeCollectionJob?.cancel()
-        // Cancel all pending dead click jobs to prevent resource leaks
-        pendingDeadClicks.values.forEach { it.job?.cancel() }
-        pendingDeadClicks.clear()
-        pendingRageClicks.clear()
+        val jobsToCancel =
+            synchronized(lifecycleLock) {
+                started = false
+                lifecycleGeneration.incrementAndGet()
+                val jobs =
+                    synchronized(deadClickLock) {
+                        val pendingJobs = pendingDeadClicks.values.mapNotNull { it.job }
+                        pendingDeadClicks.clear()
+                        recentUiChangeTimes.clear()
+                        pendingJobs
+                    }
+                pendingRageClicks.clear()
+                uiChangeCollectionJob?.cancel()
+                uiChangeCollectionJob = null
+                jobs
+            }
+        jobsToCancel.forEach { it.cancel() }
         logger.debug("FrustrationInteractionsDetector stopped - UI change collection is now inactive")
     }
 
@@ -167,16 +197,17 @@ public class FrustrationInteractionsDetector(
         clickTime: Long,
         clickId: String,
     ) {
-        if (uiChangeCollectionJob?.isActive != true) {
+        if (!started) {
             logger.error("Dead click detection is disabled - call start() to enable.")
             return
         }
 
-        // Dead click detection requires an active SignalProvider plugin to emit UI change signals
         if (!hasActiveSignalProvider()) {
-            logger.error("Dead click detection is disabled - no UI change signals observed yet. Ensure SessionReplay plugin is active.")
+            logger.error("Dead click detection is disabled - no UI change signal provider is active.")
             return
         }
+
+        val clickLifecycleGeneration = lifecycleGeneration.get()
 
         // Cancel any existing dead click job for this location to prevent accumulation
         pendingDeadClicks[clickId]?.job?.cancel()
@@ -187,47 +218,84 @@ public class FrustrationInteractionsDetector(
                 activityName = activityName,
                 clickInfo = clickInfo.copy(timestamp = clickTime),
                 targetInfo = targetInfo,
-                preClickUiChangeTime = lastUiChangeTime,
+                lifecycleGeneration = clickLifecycleGeneration,
             )
-
-        pendingDeadClicks[clickId] = deadClickSession
 
         // Schedule dead click detection
         val job =
-            amplitude.amplitudeScope.launch(amplitude.amplitudeDispatcher) {
+            amplitude.amplitudeScope.launch(
+                amplitude.amplitudeDispatcher,
+                start = CoroutineStart.LAZY,
+            ) {
                 delay(DEAD_CLICK_TIMEOUT)
 
-                // Check if UI changed after the click
-                if (lastUiChangeTime <= deadClickSession.preClickUiChangeTime) {
-                    // No UI change detected, this is a dead click
+                val shouldTrackDeadClick =
+                    synchronized(deadClickLock) {
+                        pendingDeadClicks.remove(clickId, deadClickSession) &&
+                            started &&
+                            lifecycleGeneration.get() == deadClickSession.lifecycleGeneration &&
+                            hasActiveSignalProvider() &&
+                            !deadClickSession.uiChanged.get()
+                    }
+                if (shouldTrackDeadClick) {
                     trackDeadClick(deadClickSession)
                 }
-
-                // Clean up when done
-                pendingDeadClicks.remove(clickId)
             }
 
         deadClickSession.job = job
+        synchronized(deadClickLock) {
+            deadClickSession.uiChanged.set(
+                recentUiChangeTimes.any { timestampMillis ->
+                    timestampMillis >= deadClickSession.clickInfo.timestamp
+                },
+            )
+            pendingDeadClicks[clickId] = deadClickSession
+        }
+
+        if (!started || lifecycleGeneration.get() != clickLifecycleGeneration) {
+            pendingDeadClicks.remove(clickId, deadClickSession)
+            job.cancel()
+            return
+        }
+        job.start()
     }
 
     private fun startUiChangeCollection() {
         uiChangeCollectionJob =
-            amplitude.amplitudeScope.launch(amplitude.amplitudeDispatcher) {
+            amplitude.amplitudeScope.launch(
+                amplitude.amplitudeDispatcher,
+                start = CoroutineStart.UNDISPATCHED,
+            ) {
                 logger.debug("Starting UI change signal collection for dead click detection")
                 amplitude.signalFlow.collectLatest { signal ->
-                    if (signal is UiChangeSignal) {
-                        lastUiChangeTime = signal.timestamp.time
-                        logger.debug("UI change detected at $lastUiChangeTime")
+                    if (signal is InterfaceChangeSignal) {
+                        recordUiChange(signal.timestampMillis)
                     }
                 }
             }
     }
 
-    /**
-     * This is used to determine if a SignalProvider-backed plugin is active.
-     * So if we have seen at least one UiChangeSignal, lastUiChangeTime will be > 0.
-     */
-    private fun hasActiveSignalProvider(): Boolean = lastUiChangeTime > 0L
+    private fun recordUiChange(timestampMillis: Long) {
+        synchronized(deadClickLock) {
+            if (!started) return
+
+            if (recentUiChangeTimes.size == MAX_RECENT_UI_CHANGES) {
+                recentUiChangeTimes.removeFirst()
+            }
+            recentUiChangeTimes.addLast(timestampMillis)
+            pendingDeadClicks.values.forEach { session ->
+                if (timestampMillis >= session.clickInfo.timestamp) {
+                    session.uiChanged.set(true)
+                }
+            }
+        }
+        logger.debug("UI change detected at $timestampMillis")
+    }
+
+    private fun hasActiveSignalProvider(): Boolean =
+        amplitude.plugins(InterfaceSignalProvider::class.java).any { provider ->
+            runCatching { provider.isProviding }.getOrDefault(false)
+        }
 
     private fun startNewRageClickSession(
         locationKey: String,
@@ -338,7 +406,8 @@ public class FrustrationInteractionsDetector(
         val activityName: String,
         val clickInfo: ClickInfo,
         val targetInfo: TargetInfo,
-        val preClickUiChangeTime: Long,
+        val lifecycleGeneration: Long,
+        val uiChanged: AtomicBoolean = AtomicBoolean(false),
         var job: Job? = null,
     )
 

--- a/android/src/main/java/com/amplitude/android/FrustrationInteractionsDetector.kt
+++ b/android/src/main/java/com/amplitude/android/FrustrationInteractionsDetector.kt
@@ -25,10 +25,10 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.ArrayDeque
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Core frustration interactions detector that handles rage click and dead click detection.
@@ -63,16 +63,15 @@ public class FrustrationInteractionsDetector(
 
     @Volatile
     private var started = false
-    private val lifecycleLock = Any()
-    private val lifecycleGeneration = AtomicLong(0L)
+    private val stateMutex = Mutex()
+    private var lifecycleGeneration = 0L
     private var uiChangeCollectionJob: Job? = null
 
     // Rage click detection
     private val pendingRageClicks = ConcurrentHashMap<String, RageClickSession>()
 
     // Dead click detection
-    private val deadClickLock = Any()
-    private val pendingDeadClicks = ConcurrentHashMap<String, DeadClickSession>()
+    private val pendingDeadClicks = mutableMapOf<String, DeadClickSession>()
     private val recentUiChangeTimes = ArrayDeque<Long>(MAX_RECENT_UI_CHANGES)
 
     /**
@@ -80,34 +79,44 @@ public class FrustrationInteractionsDetector(
      * This is required for proper dead click detection.
      */
     public fun start() {
-        synchronized(lifecycleLock) {
-            if (started) return
+        amplitude.amplitudeScope.launch(
+            amplitude.amplitudeDispatcher,
+            start = CoroutineStart.UNDISPATCHED,
+        ) {
+            val didStart =
+                stateMutex.withLock {
+                    if (started) return@withLock false
 
-            startUiChangeCollection()
-            started = true
+                    started = true
+                    startUiChangeCollection()
+                    true
+                }
+            if (didStart) {
+                logger.debug("FrustrationInteractionsDetector started - UI change collection is now active")
+            }
         }
-        logger.debug("FrustrationInteractionsDetector started - UI change collection is now active")
     }
 
     public fun stop() {
-        val jobsToCancel =
-            synchronized(lifecycleLock) {
-                started = false
-                lifecycleGeneration.incrementAndGet()
-                val jobs =
-                    synchronized(deadClickLock) {
-                        val pendingJobs = pendingDeadClicks.values.mapNotNull { it.job }
-                        pendingDeadClicks.clear()
-                        recentUiChangeTimes.clear()
-                        pendingJobs
-                    }
-                pendingRageClicks.clear()
-                uiChangeCollectionJob?.cancel()
-                uiChangeCollectionJob = null
-                jobs
-            }
-        jobsToCancel.forEach { it.cancel() }
-        logger.debug("FrustrationInteractionsDetector stopped - UI change collection is now inactive")
+        amplitude.amplitudeScope.launch(
+            amplitude.amplitudeDispatcher,
+            start = CoroutineStart.UNDISPATCHED,
+        ) {
+            val jobsToCancel =
+                stateMutex.withLock {
+                    val pendingJobs = pendingDeadClicks.values.mapNotNull { it.job }
+                    started = false
+                    lifecycleGeneration++
+                    pendingDeadClicks.clear()
+                    recentUiChangeTimes.clear()
+                    pendingRageClicks.clear()
+                    uiChangeCollectionJob?.cancel()
+                    uiChangeCollectionJob = null
+                    pendingJobs
+                }
+            jobsToCancel.forEach { it.cancel() }
+            logger.debug("FrustrationInteractionsDetector stopped - UI change collection is now inactive")
+        }
     }
 
     /**
@@ -202,62 +211,61 @@ public class FrustrationInteractionsDetector(
             return
         }
 
-        if (!hasActiveSignalProvider()) {
-            logger.error("Dead click detection is disabled - no UI change signal provider is active.")
-            return
-        }
-
-        val clickLifecycleGeneration = lifecycleGeneration.get()
-
-        // Cancel any existing dead click job for this location to prevent accumulation
-        pendingDeadClicks[clickId]?.job?.cancel()
-
-        val deadClickSession =
-            DeadClickSession(
-                target = target,
-                activityName = activityName,
-                clickInfo = clickInfo.copy(timestamp = clickTime),
-                targetInfo = targetInfo,
-                lifecycleGeneration = clickLifecycleGeneration,
-            )
-
-        // Schedule dead click detection
-        val job =
-            amplitude.amplitudeScope.launch(
-                amplitude.amplitudeDispatcher,
-                start = CoroutineStart.LAZY,
-            ) {
-                delay(DEAD_CLICK_TIMEOUT)
-
-                val shouldTrackDeadClick =
-                    synchronized(deadClickLock) {
-                        pendingDeadClicks.remove(clickId, deadClickSession) &&
-                            started &&
-                            lifecycleGeneration.get() == deadClickSession.lifecycleGeneration &&
-                            hasActiveSignalProvider() &&
-                            !deadClickSession.uiChanged.get()
-                    }
-                if (shouldTrackDeadClick) {
-                    trackDeadClick(deadClickSession)
+        amplitude.amplitudeScope.launch(
+            amplitude.amplitudeDispatcher,
+            start = CoroutineStart.UNDISPATCHED,
+        ) {
+            stateMutex.withLock {
+                if (!started) {
+                    logger.error("Dead click detection is disabled - call start() to enable.")
+                    return@withLock
                 }
+
+                if (!hasActiveSignalProvider()) {
+                    logger.error("Dead click detection is disabled - no UI change signal provider is active.")
+                    return@withLock
+                }
+
+                pendingDeadClicks[clickId]?.job?.cancel()
+
+                val deadClickSession =
+                    DeadClickSession(
+                        target = target,
+                        activityName = activityName,
+                        clickInfo = clickInfo.copy(timestamp = clickTime),
+                        targetInfo = targetInfo,
+                        lifecycleGeneration = lifecycleGeneration,
+                        uiChanged =
+                            recentUiChangeTimes.any { timestampMillis ->
+                                timestampMillis >= clickTime
+                            },
+                    )
+
+                val job =
+                    amplitude.amplitudeScope.launch(
+                        amplitude.amplitudeDispatcher,
+                        start = CoroutineStart.LAZY,
+                    ) {
+                        delay(DEAD_CLICK_TIMEOUT)
+
+                        val shouldTrackDeadClick =
+                            stateMutex.withLock {
+                                pendingDeadClicks.remove(clickId, deadClickSession) &&
+                                    started &&
+                                    lifecycleGeneration == deadClickSession.lifecycleGeneration &&
+                                    hasActiveSignalProvider() &&
+                                    !deadClickSession.uiChanged
+                            }
+                        if (shouldTrackDeadClick) {
+                            trackDeadClick(deadClickSession)
+                        }
+                    }
+
+                deadClickSession.job = job
+                pendingDeadClicks[clickId] = deadClickSession
+                job.start()
             }
-
-        deadClickSession.job = job
-        synchronized(deadClickLock) {
-            deadClickSession.uiChanged.set(
-                recentUiChangeTimes.any { timestampMillis ->
-                    timestampMillis >= deadClickSession.clickInfo.timestamp
-                },
-            )
-            pendingDeadClicks[clickId] = deadClickSession
         }
-
-        if (!started || lifecycleGeneration.get() != clickLifecycleGeneration) {
-            pendingDeadClicks.remove(clickId, deadClickSession)
-            job.cancel()
-            return
-        }
-        job.start()
     }
 
     private fun startUiChangeCollection() {
@@ -275,21 +283,25 @@ public class FrustrationInteractionsDetector(
             }
     }
 
-    private fun recordUiChange(timestampMillis: Long) {
-        synchronized(deadClickLock) {
-            if (!started) return
+    private suspend fun recordUiChange(timestampMillis: Long) {
+        val didRecordChange =
+            stateMutex.withLock {
+                if (!started) return@withLock false
 
-            if (recentUiChangeTimes.size == MAX_RECENT_UI_CHANGES) {
-                recentUiChangeTimes.removeFirst()
-            }
-            recentUiChangeTimes.addLast(timestampMillis)
-            pendingDeadClicks.values.forEach { session ->
-                if (timestampMillis >= session.clickInfo.timestamp) {
-                    session.uiChanged.set(true)
+                if (recentUiChangeTimes.size == MAX_RECENT_UI_CHANGES) {
+                    recentUiChangeTimes.removeFirst()
                 }
+                recentUiChangeTimes.addLast(timestampMillis)
+                pendingDeadClicks.values.forEach { session ->
+                    if (timestampMillis >= session.clickInfo.timestamp) {
+                        session.uiChanged = true
+                    }
+                }
+                true
             }
+        if (didRecordChange) {
+            logger.debug("UI change detected at $timestampMillis")
         }
-        logger.debug("UI change detected at $timestampMillis")
     }
 
     private fun hasActiveSignalProvider(): Boolean =
@@ -407,7 +419,7 @@ public class FrustrationInteractionsDetector(
         val clickInfo: ClickInfo,
         val targetInfo: TargetInfo,
         val lifecycleGeneration: Long,
-        val uiChanged: AtomicBoolean = AtomicBoolean(false),
+        var uiChanged: Boolean = false,
         var job: Job? = null,
     )
 

--- a/android/src/main/java/com/amplitude/android/signals/UiChangeSignal.kt
+++ b/android/src/main/java/com/amplitude/android/signals/UiChangeSignal.kt
@@ -1,6 +1,7 @@
 package com.amplitude.android.signals
 
-import com.amplitude.core.platform.Signal
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.platform.InterfaceChangeSignal
 import java.util.Date
 
 /**
@@ -9,4 +10,8 @@ import java.util.Date
  *
  * @property timestamp The time when the UI change occurred.
  */
-public data class UiChangeSignal(val timestamp: Date) : Signal
+@OptIn(RestrictedAmplitudeFeature::class)
+public data class UiChangeSignal(val timestamp: Date) : InterfaceChangeSignal {
+    override val timestampMillis: Long
+        get() = timestamp.time
+}

--- a/android/src/test/kotlin/com/amplitude/android/FrustrationInteractionsDetectorTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/FrustrationInteractionsDetectorTest.kt
@@ -25,15 +25,21 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import java.util.Date
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalCoroutinesApi::class, RestrictedAmplitudeFeature::class)
 class FrustrationInteractionsDetectorTest {
@@ -412,6 +418,114 @@ class FrustrationInteractionsDetectorTest {
     }
 
     @Test
+    fun `slow provider availability check does not block stop or register stale click`() {
+        val availabilityCheckStarted = CountDownLatch(1)
+        val continueAvailabilityCheck = CountDownLatch(1)
+        val stopStarted = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+        interfaceSignalProvider.activate()
+        interfaceSignalProvider.availabilityCheckStarted = availabilityCheckStarted
+        interfaceSignalProvider.continueAvailabilityCheck = continueAvailabilityCheck
+        detector.start()
+
+        val clickFuture =
+            executor.submit {
+                detector.processClick(
+                    FrustrationInteractionsDetector.ClickInfo(100f, 100f),
+                    testTargetInfo,
+                    mockViewTarget,
+                    testActivityName,
+                )
+            }
+
+        try {
+            assertTrue(availabilityCheckStarted.await(5, TimeUnit.SECONDS))
+            val stopFuture =
+                executor.submit {
+                    stopStarted.countDown()
+                    detector.stop()
+                }
+
+            assertTrue(stopStarted.await(5, TimeUnit.SECONDS))
+            stopFuture.get(1, TimeUnit.SECONDS)
+
+            continueAvailabilityCheck.countDown()
+            clickFuture.get(5, TimeUnit.SECONDS)
+            testDispatcher.scheduler.advanceTimeBy(4_000L)
+            testDispatcher.scheduler.runCurrent()
+
+            verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
+        } finally {
+            continueAvailabilityCheck.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `reentrant stop during collector startup cleans up collection`() {
+        var shouldStopDuringStartup = true
+        every {
+            mockLogger.debug("Starting UI change signal collection for dead click detection")
+        } answers {
+            if (shouldStopDuringStartup) {
+                shouldStopDuringStartup = false
+                detector.stop()
+            }
+        }
+
+        detector.start()
+        testDispatcher.scheduler.runCurrent()
+
+        assertEquals(0, uiChangeFlow.subscriptionCount.value)
+
+        detector.start()
+        testDispatcher.scheduler.runCurrent()
+
+        assertEquals(1, uiChangeFlow.subscriptionCount.value)
+    }
+
+    @Test
+    fun `signal emitted immediately after start is observed on queued dispatcher`() {
+        val scheduler = TestCoroutineScheduler()
+        val dispatcher = StandardTestDispatcher(scheduler)
+        val signalFlow = MutableSharedFlow<Signal>(extraBufferCapacity = 1)
+        val amplitude = mockk<Amplitude>(relaxed = true)
+        every { amplitude.signalFlow } returns signalFlow
+        every { amplitude.amplitudeScope } returns CoroutineScope(dispatcher)
+        every { amplitude.amplitudeDispatcher } returns dispatcher
+        every { amplitude.plugins(InterfaceSignalProvider::class.java) } returns
+            listOf(interfaceSignalProvider)
+        interfaceSignalProvider.activate()
+        val detector =
+            FrustrationInteractionsDetector(
+                amplitude = amplitude,
+                logger = mockLogger,
+                density = 2f,
+                autocaptureStateProvider = {
+                    AutocaptureState(interactions = listOf(InteractionType.DeadClick))
+                },
+            )
+
+        detector.start()
+        detector.processClick(
+            FrustrationInteractionsDetector.ClickInfo(100f, 100f),
+            testTargetInfo,
+            mockViewTarget,
+            testActivityName,
+        )
+        assertTrue(
+            signalFlow.tryEmit(TestInterfaceChangeSignal(System.currentTimeMillis() + 1L)),
+        )
+
+        scheduler.runCurrent()
+        scheduler.advanceTimeBy(4_000L)
+        scheduler.runCurrent()
+
+        verify(exactly = 0) { amplitude.track(DEAD_CLICK, any()) }
+        detector.stop()
+    }
+
+    @Test
     fun `older signal does not erase post-click interface change`() {
         interfaceSignalProvider.activate()
         detector.start()
@@ -685,9 +799,13 @@ class FrustrationInteractionsDetectorTest {
         override val type: Plugin.Type = Plugin.Type.Utility
         override lateinit var amplitude: Amplitude
         var throwOnAvailabilityCheck: Boolean = false
+        var availabilityCheckStarted: CountDownLatch? = null
+        var continueAvailabilityCheck: CountDownLatch? = null
         override val isProviding: Boolean
             get() {
                 if (throwOnAvailabilityCheck) error("availability failed")
+                availabilityCheckStarted?.countDown()
+                continueAvailabilityCheck?.await(5, TimeUnit.SECONDS)
                 return active
             }
     }

--- a/android/src/test/kotlin/com/amplitude/android/FrustrationInteractionsDetectorTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/FrustrationInteractionsDetectorTest.kt
@@ -11,6 +11,10 @@ import com.amplitude.android.internal.ViewTarget
 import com.amplitude.android.signals.UiChangeSignal
 import com.amplitude.common.Logger
 import com.amplitude.core.Amplitude
+import com.amplitude.core.RestrictedAmplitudeFeature
+import com.amplitude.core.platform.InterfaceChangeSignal
+import com.amplitude.core.platform.InterfaceSignalProvider
+import com.amplitude.core.platform.Plugin
 import com.amplitude.core.platform.Signal
 import io.mockk.clearMocks
 import io.mockk.every
@@ -31,7 +35,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import java.util.Date
 
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, RestrictedAmplitudeFeature::class)
 class FrustrationInteractionsDetectorTest {
     private lateinit var mockAmplitude: Amplitude
     private lateinit var mockLogger: Logger
@@ -39,6 +43,7 @@ class FrustrationInteractionsDetectorTest {
     private val testActivityName = "TestActivity"
     private lateinit var uiChangeFlow: MutableSharedFlow<Signal>
     private lateinit var detector: FrustrationInteractionsDetector
+    private lateinit var interfaceSignalProvider: TestInterfaceSignalProvider
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private val testTargetInfo =
@@ -59,6 +64,7 @@ class FrustrationInteractionsDetectorTest {
         mockLogger = mockk(relaxed = true)
         mockViewTarget = mockk(relaxed = true)
         uiChangeFlow = MutableSharedFlow(extraBufferCapacity = 1)
+        interfaceSignalProvider = TestInterfaceSignalProvider()
 
         // Setup mock ViewTarget properties to match testTargetInfo
         every { mockViewTarget.className } returns testTargetInfo.className
@@ -73,6 +79,8 @@ class FrustrationInteractionsDetectorTest {
         every { mockAmplitude.signalFlow } returns uiChangeFlow
         every { mockAmplitude.amplitudeScope } returns CoroutineScope(testDispatcher)
         every { mockAmplitude.amplitudeDispatcher } returns testDispatcher
+        every { mockAmplitude.plugins(InterfaceSignalProvider::class.java) } returns
+            listOf(interfaceSignalProvider)
 
         detector =
             FrustrationInteractionsDetector(
@@ -196,6 +204,7 @@ class FrustrationInteractionsDetectorTest {
         val mockAmplitudeWithStart = mockk<Amplitude>(relaxed = true)
         every { mockAmplitudeWithStart.amplitudeScope } returns CoroutineScope(testDispatcher)
         every { mockAmplitudeWithStart.amplitudeDispatcher } returns testDispatcher
+        every { mockAmplitudeWithStart.signalFlow } returns MutableSharedFlow()
 
         val detectorWithStart =
             FrustrationInteractionsDetector(
@@ -321,11 +330,8 @@ class FrustrationInteractionsDetectorTest {
 
     @Test
     fun `dead click detection should work after start()`() {
-        // Start the detector and ensure the signal collector is subscribed
+        interfaceSignalProvider.activate()
         detector.start()
-        testDispatcher.scheduler.runCurrent()
-        // Emit a UiChangeSignal to enable dead click detection
-        uiChangeFlow.tryEmit(UiChangeSignal(Date(System.currentTimeMillis())))
         testDispatcher.scheduler.runCurrent()
 
         // Process a click
@@ -346,7 +352,27 @@ class FrustrationInteractionsDetectorTest {
     }
 
     @Test
-    fun `dead click detection should not work after start() until UiChangeSignal is observed`() {
+    fun `Android UI signal after click prevents dead click`() {
+        interfaceSignalProvider.activate()
+        detector.start()
+
+        detector.processClick(
+            FrustrationInteractionsDetector.ClickInfo(100f, 100f),
+            testTargetInfo,
+            mockViewTarget,
+            testActivityName,
+        )
+        uiChangeFlow.tryEmit(UiChangeSignal(Date(System.currentTimeMillis() + 1L)))
+        testDispatcher.scheduler.runCurrent()
+
+        testDispatcher.scheduler.advanceTimeBy(4_000L)
+        testDispatcher.scheduler.runCurrent()
+
+        verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
+    }
+
+    @Test
+    fun `dead click detection should not work without an active signal provider`() {
         detector.start()
 
         val clickInfo = FrustrationInteractionsDetector.ClickInfo(100f, 100f)
@@ -356,40 +382,110 @@ class FrustrationInteractionsDetectorTest {
         testDispatcher.scheduler.advanceTimeBy(4000L)
         testDispatcher.scheduler.runCurrent()
 
-        // Should not track without UiChangeSignal and should log the gating error
+        // Should not track without a provider and should log the gating error
         verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
         verify {
             mockLogger.error(
-                match { it.contains("no UI change signals observed yet") },
+                match { it.contains("no UI change signal provider is active") },
             )
         }
     }
 
     @Test
-    fun `dead click detection should reset after stop()`() {
-        // Enable by emitting a UiChangeSignal after start
+    fun `pending dead click should be cancelled across stop and restart`() {
+        interfaceSignalProvider.activate()
         detector.start()
-        uiChangeFlow.tryEmit(UiChangeSignal(Date(System.currentTimeMillis())))
-        testDispatcher.scheduler.runCurrent()
+        detector.processClick(
+            FrustrationInteractionsDetector.ClickInfo(100f, 100f),
+            testTargetInfo,
+            mockViewTarget,
+            testActivityName,
+        )
 
-        // Stop should reset gating state
         detector.stop()
-
-        // Restart but do NOT emit UiChangeSignal again
         detector.start()
 
-        val clickInfo = FrustrationInteractionsDetector.ClickInfo(100f, 100f)
-        detector.processClick(clickInfo, testTargetInfo, mockViewTarget, testActivityName)
-
-        testDispatcher.scheduler.advanceTimeBy(4000L)
+        testDispatcher.scheduler.advanceTimeBy(4_000L)
         testDispatcher.scheduler.runCurrent()
 
         verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
-        verify {
-            mockLogger.error(
-                match { it.contains("no UI change signals observed yet") },
-            )
-        }
+    }
+
+    @Test
+    fun `older signal does not erase post-click interface change`() {
+        interfaceSignalProvider.activate()
+        detector.start()
+
+        detector.processClick(
+            FrustrationInteractionsDetector.ClickInfo(100f, 100f),
+            testTargetInfo,
+            mockViewTarget,
+            testActivityName,
+        )
+        uiChangeFlow.tryEmit(TestInterfaceChangeSignal(System.currentTimeMillis() + 1L))
+        testDispatcher.scheduler.runCurrent()
+        uiChangeFlow.tryEmit(TestInterfaceChangeSignal(System.currentTimeMillis() - 1_000L))
+        testDispatcher.scheduler.runCurrent()
+
+        testDispatcher.scheduler.advanceTimeBy(4_000L)
+        testDispatcher.scheduler.runCurrent()
+
+        verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
+    }
+
+    @Test
+    fun `delayed pre-click signal does not prevent dead click`() {
+        interfaceSignalProvider.activate()
+        detector.start()
+
+        detector.processClick(
+            FrustrationInteractionsDetector.ClickInfo(100f, 100f),
+            testTargetInfo,
+            mockViewTarget,
+            testActivityName,
+        )
+        uiChangeFlow.tryEmit(TestInterfaceChangeSignal(System.currentTimeMillis() - 1_000L))
+        testDispatcher.scheduler.runCurrent()
+
+        testDispatcher.scheduler.advanceTimeBy(4_000L)
+        testDispatcher.scheduler.runCurrent()
+
+        verify { mockAmplitude.track(DEAD_CLICK, any()) }
+    }
+
+    @Test
+    fun `provider becoming unavailable before timeout skips dead click classification`() {
+        interfaceSignalProvider.activate()
+        detector.start()
+
+        detector.processClick(
+            FrustrationInteractionsDetector.ClickInfo(100f, 100f),
+            testTargetInfo,
+            mockViewTarget,
+            testActivityName,
+        )
+        interfaceSignalProvider.deactivate()
+
+        testDispatcher.scheduler.advanceTimeBy(4_000L)
+        testDispatcher.scheduler.runCurrent()
+
+        verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
+    }
+
+    @Test
+    fun `provider availability failure does not escape click processing`() {
+        interfaceSignalProvider.throwOnAvailabilityCheck = true
+        detector.start()
+
+        detector.processClick(
+            FrustrationInteractionsDetector.ClickInfo(100f, 100f),
+            testTargetInfo,
+            mockViewTarget,
+            testActivityName,
+        )
+
+        verify(exactly = 0) { mockAmplitude.track(DEAD_CLICK, any()) }
+        verify { mockLogger.error(match { it.contains("no UI change signal provider is active") }) }
     }
 
     //endregion
@@ -515,10 +611,7 @@ class FrustrationInteractionsDetectorTest {
             )
         detectorWithOptions.start()
 
-        // Emit initial UI change to indicate signal provider is active
-        testDispatcher.scheduler.advanceUntilIdle()
-        uiChangeFlow.tryEmit(UiChangeSignal(Date()))
-        testDispatcher.scheduler.advanceUntilIdle()
+        interfaceSignalProvider.activate()
 
         // Test dead click
         val deadClickInfo = FrustrationInteractionsDetector.ClickInfo(500f, 500f)
@@ -571,10 +664,7 @@ class FrustrationInteractionsDetectorTest {
             )
         detectorWithDefaultOptions.start()
 
-        // Emit initial UI change
-        testDispatcher.scheduler.advanceUntilIdle()
-        uiChangeFlow.tryEmit(UiChangeSignal(Date(System.currentTimeMillis())))
-        testDispatcher.scheduler.runCurrent()
+        interfaceSignalProvider.activate()
 
         // Test dead click
         val deadClickInfo = FrustrationInteractionsDetector.ClickInfo(500f, 500f)
@@ -589,4 +679,20 @@ class FrustrationInteractionsDetectorTest {
     }
 
     //endregion
+
+    private class TestInterfaceSignalProvider : InterfaceSignalProvider {
+        override var active: Boolean = false
+        override val type: Plugin.Type = Plugin.Type.Utility
+        override lateinit var amplitude: Amplitude
+        var throwOnAvailabilityCheck: Boolean = false
+        override val isProviding: Boolean
+            get() {
+                if (throwOnAvailabilityCheck) error("availability failed")
+                return active
+            }
+    }
+
+    private data class TestInterfaceChangeSignal(
+        override val timestampMillis: Long,
+    ) : InterfaceChangeSignal
 }


### PR DESCRIPTION
### Describe what this PR is addressing
[SDKA-10](https://linear.app/amplitude/issue/SDKA-10/retarget-android-and-session-replay-on-analytics-core): establishes the core `InterfaceChangeSignal` and `InterfaceSignalProvider` contract so Session Replay can emit UI change evidence without linking to `analytics-android`.

**Stack (merge bottom-up):** this PR (#498) then [#500](https://github.com/amplitude/Amplitude-Kotlin/pull/500).

### Describe the solution
* Defines `@RestrictedAmplitudeFeature` contracts `InterfaceChangeSignal` and `InterfaceSignalProvider` in `:analytics-core`.
* Implements `InterfaceChangeSignal` on Android's `UiChangeSignal`, preserving existing binary ABI while exposing `timestampMillis`.
* Updates `FrustrationInteractionsDetector` to consume `InterfaceSignalProvider` readiness and observe `InterfaceChangeSignal` events.
* Hardens frustration detector lifecycle: synchronizes detector state, decouples provider checks from lock acquisition, and prevents stale click registration across start/stop generations.
* Uses bounded timestamp buffering to suppress dead clicks on render updates occurring after click registration.

### Steps to verify the change
* `./gradlew ktlintCheck`
* `./gradlew apiCheck`
* `./gradlew :analytics-core:test`
* `./gradlew :android:testDebugUnitTest`

### Useful links and documentation (optional)
* Stack: https://github.com/amplitude/Amplitude-Kotlin/pull/500
* Linear: https://linear.app/amplitude/issue/SDKA-10/retarget-android-and-session-replay-on-analytics-core

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [ ] Does your PR have a breaking change?