### PR TITLE
feat: emit Element Interacted events for long-press

### DIFF
--- a/android/src/main/java/com/amplitude/android/AutocaptureOptions.kt
+++ b/android/src/main/java/com/amplitude/android/AutocaptureOptions.kt
@@ -26,6 +26,13 @@ public enum class AutocaptureOption {
 
     /**
      * Enable element interaction tracking.
+     *
+     * When enabled, Amplitude emits `[Amplitude] Element Interacted` for:
+     * - **tap** — `[Amplitude] Action` is `"touch"`
+     * - **long-press** — `[Amplitude] Action` is `"long press"`
+     *
+     * Only clickable, visible views (the same targets as taps) are captured.
+     * Scroll, fling, and long-click-only views are not captured.
      */
     ELEMENT_INTERACTIONS,
 

--- a/android/src/main/java/com/amplitude/android/internal/ViewTarget.kt
+++ b/android/src/main/java/com/amplitude/android/internal/ViewTarget.kt
@@ -44,16 +44,28 @@ public data class ViewTarget(
     public enum class Type { Clickable }
 }
 
+internal const val ELEMENT_INTERACTED_ACTION_TOUCH: String = "touch"
+internal const val ELEMENT_INTERACTED_ACTION_LONG_PRESS: String = "long press"
+
 /**
  * Builds the base properties for ELEMENT_INTERACTED events.
  * This is the foundation used by both standard element tracking and frustration analytics.
+ *
+ * `[Amplitude] Action` defaults to `"touch"` (taps and frustration analytics).
  */
 public fun buildElementInteractedProperties(
     target: ViewTarget,
     activityName: String,
 ): Map<String, Any?> =
+    buildElementInteractedProperties(target, activityName, ELEMENT_INTERACTED_ACTION_TOUCH)
+
+internal fun buildElementInteractedProperties(
+    target: ViewTarget,
+    activityName: String,
+    action: String,
+): Map<String, Any?> =
     mapOf(
-        ACTION to "touch",
+        ACTION to action,
         TARGET_CLASS to target.className,
         TARGET_RESOURCE to target.resourceName,
         TARGET_TAG to target.tag,

--- a/android/src/main/java/com/amplitude/android/internal/gestures/AutocaptureGestureListener.kt
+++ b/android/src/main/java/com/amplitude/android/internal/gestures/AutocaptureGestureListener.kt
@@ -7,6 +7,8 @@ import androidx.annotation.VisibleForTesting
 import com.amplitude.android.AutocaptureState
 import com.amplitude.android.Constants.EventTypes.ELEMENT_INTERACTED
 import com.amplitude.android.InteractionType.ElementInteraction
+import com.amplitude.android.internal.ELEMENT_INTERACTED_ACTION_LONG_PRESS
+import com.amplitude.android.internal.ELEMENT_INTERACTED_ACTION_TOUCH
 import com.amplitude.android.internal.TrackFunction
 import com.amplitude.android.internal.ViewHierarchyScanner.findTarget
 import com.amplitude.android.internal.ViewTarget
@@ -40,31 +42,11 @@ public class AutocaptureGestureListener(
     override fun onShowPress(e: MotionEvent) {}
 
     override fun onSingleTapUp(e: MotionEvent): Boolean {
-        // Short-circuit if no interactions are enabled — avoids expensive view hierarchy scan.
-        if (autocaptureState.interactions.isEmpty()) return false
-
-        val decorView = decorViewRef.get() ?: logger.error("DecorView is null in onSingleTapUp()").let { return false }
-
-        val target: ViewTarget =
-            decorView.findTarget(
-                Pair(e.x, e.y),
-                viewTargetLocators,
-                ViewTarget.Type.Clickable,
-                logger,
-            ) ?: logger.warn("Unable to find click target. No event captured.").let {
-                return false
-            }
+        val target = findClickableTarget(e, "onSingleTapUp") ?: return false
 
         // Notify callback with found target (for reuse by frustration interactions)
         onViewTargetFound?.invoke(target)
-
-        // Track element interaction events only if ElementInteraction is enabled
-        if (ElementInteraction in autocaptureState.interactions) {
-            // Build ELEMENT_INTERACTED properties using shared function
-            val properties = buildElementInteractedProperties(target, activityName)
-            track(ELEMENT_INTERACTED, properties)
-        }
-
+        trackElementInteracted(target, ELEMENT_INTERACTED_ACTION_TOUCH)
         return false
     }
 
@@ -77,7 +59,42 @@ public class AutocaptureGestureListener(
         return false
     }
 
-    override fun onLongPress(e: MotionEvent) {}
+    override fun onLongPress(e: MotionEvent) {
+        // Long-press is not a tap: do not cache the target for rage/dead click on ACTION_UP.
+        if (ElementInteraction !in autocaptureState.interactions) return
+        val target = findClickableTarget(e, "onLongPress") ?: return
+        trackElementInteracted(target, ELEMENT_INTERACTED_ACTION_LONG_PRESS)
+    }
+
+    private fun findClickableTarget(
+        event: MotionEvent,
+        caller: String,
+    ): ViewTarget? {
+        // Short-circuit if no interactions are enabled — avoids expensive view hierarchy scan.
+        if (autocaptureState.interactions.isEmpty()) return null
+
+        val decorView =
+            decorViewRef.get() ?: logger.error("DecorView is null in $caller()").let { return null }
+
+        return decorView.findTarget(
+            Pair(event.x, event.y),
+            viewTargetLocators,
+            ViewTarget.Type.Clickable,
+            logger,
+        ) ?: logger.warn("Unable to find click target. No event captured.").let {
+            null
+        }
+    }
+
+    private fun trackElementInteracted(
+        target: ViewTarget,
+        action: String,
+    ) {
+        if (ElementInteraction in autocaptureState.interactions) {
+            val properties = buildElementInteractedProperties(target, activityName, action)
+            track(ELEMENT_INTERACTED, properties)
+        }
+    }
 
     override fun onFling(
         e1: MotionEvent?,

--- a/android/src/test/kotlin/com/amplitude/android/internal/ViewTargetTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/internal/ViewTargetTest.kt
@@ -1,5 +1,6 @@
 package com.amplitude.android.internal
 
+import com.amplitude.android.Constants.EventProperties.ACTION
 import com.amplitude.android.Constants.EventProperties.TARGET_ACCESSIBILITY_LABEL
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -313,5 +314,48 @@ class ViewTargetTest {
 
         assertEquals("Submit form", properties[TARGET_ACCESSIBILITY_LABEL])
         assertEquals("Jetpack Compose", properties["[Amplitude] Target Source"])
+    }
+
+    @Test
+    fun `buildElementInteractedProperties - defaults Action to touch`() {
+        val viewTarget =
+            ViewTarget(
+                _view = null,
+                className = "android.widget.Button",
+                resourceName = "submit_button",
+                tag = null,
+                text = "Submit",
+                accessibilityLabel = null,
+                source = "android_view",
+                hierarchy = "Activity → Button",
+            )
+
+        val properties = buildElementInteractedProperties(viewTarget, "MainActivity")
+
+        assertEquals("touch", properties[ACTION])
+    }
+
+    @Test
+    fun `buildElementInteractedProperties - uses provided Action`() {
+        val viewTarget =
+            ViewTarget(
+                _view = null,
+                className = "android.widget.Button",
+                resourceName = "submit_button",
+                tag = null,
+                text = "Submit",
+                accessibilityLabel = null,
+                source = "android_view",
+                hierarchy = "Activity → Button",
+            )
+
+        val properties =
+            buildElementInteractedProperties(
+                viewTarget,
+                "MainActivity",
+                ELEMENT_INTERACTED_ACTION_LONG_PRESS,
+            )
+
+        assertEquals("long press", properties[ACTION])
     }
 }

--- a/android/src/test/kotlin/com/amplitude/android/internal/gestures/AutocaptureGestureListenerClickTest.kt
+++ b/android/src/test/kotlin/com/amplitude/android/internal/gestures/AutocaptureGestureListenerClickTest.kt
@@ -12,6 +12,7 @@ import com.amplitude.MainDispatcherRule
 import com.amplitude.android.AutocaptureState
 import com.amplitude.android.InteractionType
 import com.amplitude.android.internal.TrackFunction
+import com.amplitude.android.internal.ViewTarget
 import com.amplitude.android.internal.locators.AndroidViewTargetLocator
 import com.amplitude.common.Logger
 import io.mockk.every
@@ -47,6 +48,7 @@ class AutocaptureGestureListenerClickTest {
             isInvalidTargetClickable: Boolean = true,
             attachViewsToRoot: Boolean = true,
             targetOverride: View? = null,
+            onViewTargetFound: ((ViewTarget) -> Unit)? = null,
         ): AutocaptureGestureListener {
             invalidTarget =
                 mockView(
@@ -101,6 +103,7 @@ class AutocaptureGestureListenerClickTest {
                 logger,
                 listOf(AndroidViewTargetLocator()),
                 { AutocaptureState(interactions = listOf(InteractionType.ElementInteraction)) },
+                onViewTargetFound,
             )
         }
     }
@@ -328,6 +331,96 @@ class AutocaptureGestureListenerClickTest {
                         it["[Amplitude] Target Resource"] == "test_button"
                 },
             )
+        }
+    }
+
+    @Test
+    fun `long-press captures an event with Action long press`() {
+        val event = mockk<MotionEvent>(relaxed = true)
+        val sut =
+            fixture.getSut(
+                type = View::class,
+                event = event,
+                isInvalidTargetVisible = false,
+            )
+
+        sut.onLongPress(event)
+
+        verify(exactly = 1) {
+            fixture.track(
+                "[Amplitude] Element Interacted",
+                match {
+                    it["[Amplitude] Action"] == "long press" &&
+                        it["[Amplitude] Target Class"] == "android.view.View" &&
+                        it["[Amplitude] Target Resource"] == "test_button"
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `long-press does not notify view target found callback`() {
+        val event = mockk<MotionEvent>(relaxed = true)
+        val onViewTargetFound = mockk<(ViewTarget) -> Unit>(relaxed = true)
+        val sut =
+            fixture.getSut(
+                type = View::class,
+                event = event,
+                isInvalidTargetVisible = false,
+                onViewTargetFound = onViewTargetFound,
+            )
+
+        sut.onLongPress(event)
+
+        verify(exactly = 0) { onViewTargetFound(any()) }
+        verify(exactly = 1) {
+            fixture.track("[Amplitude] Element Interacted", any())
+        }
+    }
+
+    @Test
+    fun `tap notifies view target found callback`() {
+        val event = mockk<MotionEvent>(relaxed = true)
+        val onViewTargetFound = mockk<(ViewTarget) -> Unit>(relaxed = true)
+        val sut =
+            fixture.getSut(
+                type = View::class,
+                event = event,
+                isInvalidTargetVisible = false,
+                onViewTargetFound = onViewTargetFound,
+            )
+
+        sut.onSingleTapUp(event)
+
+        verify(exactly = 1) { onViewTargetFound(any()) }
+    }
+
+    @Test
+    fun `does not track long-press when element interaction is disabled`() {
+        val event = mockk<MotionEvent>(relaxed = true)
+        val decorView =
+            fixture.window.mockDecorView(type = ViewGroup::class, event = event, clickable = true) {
+                every { it.childCount } returns 0
+            }
+
+        fixture.resources.mockForTarget(decorView, "decor_view")
+        every { fixture.context.resources } returns fixture.resources
+        every { decorView.context } returns fixture.context
+
+        val sut =
+            AutocaptureGestureListener(
+                decorView,
+                fixture.activityName,
+                fixture.track,
+                fixture.logger,
+                listOf(AndroidViewTargetLocator()),
+                { AutocaptureState(interactions = emptyList()) },
+            )
+
+        sut.onLongPress(event)
+
+        verify(exactly = 0) {
+            fixture.track(any(), any())
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Describe what this PR is addressing
Element-interaction autocapture only emitted `[Amplitude] Element Interacted` for taps, with `[Amplitude] Action` hardcoded to `"touch"`. Scroll, long-press, and fling were no-ops, and docs did not say which gestures were supported.

This PR adds long-press capture so Action identifies the gesture, and documents the supported set. Scroll and fling remain out of scope.

### Describe the solution
- `AutocaptureGestureListener.onLongPress` now finds the same clickable, visible target as taps and tracks `[Amplitude] Element Interacted` with Action `"long press"`.
- Taps still use Action `"touch"`. `GestureDetector` does not also fire `onSingleTapUp` after a long-press, so one gesture produces one event.
- Long-press does **not** write `lastFoundViewTarget`. That cache is consumed on `ACTION_UP` for rage/dead click; sharing it would treat a long-press release as a tap.
- `buildElementInteractedProperties` keeps its public 2-arg signature (still `"touch"`). An internal 3-arg overload sets Action for long-press. Frustration analytics are unchanged.
- `AutocaptureOption.ELEMENT_INTERACTIONS` KDoc lists supported gestures (tap, long-press) and explicitly excludes scroll, fling, and long-click-only views.

### Steps to verify the change
- `./gradlew :android:test --tests '*AutocaptureGestureListenerClickTest*' --tests '*ViewTargetTest*'`
- Unit tests assert long-press Action is `"long press"`, tap Action stays `"touch"`, long-press does not invoke the view-target-found callback, and tracking is skipped when element interactions are disabled.

### Useful links and documentation (optional)
Customer request: Android element interaction autocapture should support long-press in addition to taps, with `[Amplitude] Action` identifying the gesture.

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-Kotlin/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* [x] Does your PR have a breaking change?

No breaking change. Existing tap events are unchanged. Public `buildElementInteractedProperties` signature is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fce886e-9e70-4bc1-9995-0927b4d417d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fce886e-9e70-4bc1-9995-0927b4d417d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

